### PR TITLE
build: make ldd static check locale-stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,11 +87,11 @@ jobs:
       - name: Build octobus
         run: |
           bash ./scripts/build-octobus.sh bin/octobus
-          if ldd bin/octobus 2>&1 | grep -q "not a dynamic executable"; then
+          if LC_ALL=C ldd bin/octobus 2>&1 | grep -q "not a dynamic executable"; then
             exit 0
           fi
           echo "::error::bin/octobus is dynamically linked; expected a static binary"
-          ldd bin/octobus
+          LC_ALL=C ldd bin/octobus
           exit 1
 
       - name: Check OctoBus npm packages

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,11 +47,11 @@ tasks:
       - bash ./scripts/build-octobus.sh bin/octobus
       - |
         if command -v ldd >/dev/null 2>&1; then
-          if ldd bin/octobus 2>&1 | grep -q "not a dynamic executable"; then
+          if LC_ALL=C ldd bin/octobus 2>&1 | grep -q "not a dynamic executable"; then
             exit 0
           fi
           echo "bin/octobus is dynamically linked; expected a static binary" >&2
-          ldd bin/octobus >&2
+          LC_ALL=C ldd bin/octobus >&2
           exit 1
         fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,11 +23,11 @@ ARG OCTOBUS_VERSION
 ARG OCTOBUS_COMMIT
 ARG OCTOBUS_BUILD_DATE
 RUN bash ./scripts/build-octobus.sh /out/octobus \
-	&& if ldd /out/octobus 2>&1 | grep -q "not a dynamic executable"; then \
+	&& if LC_ALL=C ldd /out/octobus 2>&1 | grep -q "not a dynamic executable"; then \
 		true; \
 	else \
 		echo "/out/octobus is dynamically linked; expected a static binary" >&2; \
-		ldd /out/octobus >&2; \
+		LC_ALL=C ldd /out/octobus >&2; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
## Summary

  Make the static binary verification locale-stable by running `ldd` with `LC_ALL=C` in local Task builds, Docker builds, and GitHub Actions.

  ## Why

  The build checks whether `ldd` reports `not a dynamic executable` to confirm `bin/octobus` is statically linked. On localized Linux systems, `ldd` may print the same result in another language, for example Chinese `不是动态可执行文件`, which makes the current English `grep` fail even though
  the binary is static.

  This keeps the existing static binary requirement intact and only makes the check deterministic across locales.

  ## Tests

  - `task build`