### PR TITLE
docs: add GOPROXY configuration note for restricted networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ To run the daemon locally and perform normal service import/start workflows, ins
 - `protoc`: compiles proto descriptors during service import
 - `git`: fetches and archives packages imported from HTTPS Git sources
 
+If `go build` or `task build` fails with timeouts when downloading Go modules (e.g. `dial tcp ... i/o timeout` from `proxy.golang.org`), you may need to configure a Go module proxy:
+
+```bash
+go env -w GOPROXY=https://goproxy.cn,direct
+```
+
 ## Basic Workflow
 
 The following example uses the built-in calculator service to run through a complete workflow. Before starting, build the binary, start the daemon as described above, and verify that the CLI can connect:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,6 +105,12 @@ export OCTOBUS_ADDR="127.0.0.1:9000"
 - `protoc`：导入 service 时编译 proto descriptor
 - `git`：从 HTTPS Git source 导入 service 时拉取和归档 package
 
+如果 `go build` 或 `task build` 在下载 Go 模块时超时（例如 `proxy.golang.org` 报 `dial tcp ... i/o timeout`），可以配置 Go 模块代理：
+
+```bash
+go env -w GOPROXY=https://goproxy.cn,direct
+```
+
 ## 基本使用流程
 
 下面用仓库内置的 calculator 示例跑通一次完整流程。开始前先按上一节构建 binary、启动 daemon，并确认 CLI 能连上：


### PR DESCRIPTION
Addresses #11 — adds a note in the Dependencies section (both English and Chinese README) about configuring GOPROXY when proxy.golang.org is unreachable, with the recommended workaround: go env -w GOPROXY=https://goproxy.cn,direct