### PR TITLE
chore: missing libprotobuf-dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
 		nodejs \
 		npm \
 		protobuf-compiler \
+		libprotobuf-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY go.mod go.sum ./
@@ -45,6 +46,7 @@ RUN apt-get update \
 		nodejs \
 		npm \
 		protobuf-compiler \
+		libprotobuf-dev \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& groupadd --system octobus \
 	&& useradd --system --gid octobus --home-dir /var/lib/octobus --create-home --shell /usr/sbin/nologin octobus


### PR DESCRIPTION
Fix issue importing third-party protos like Google：

```bash
compile proto descriptor: exit status 1: google/protobuf/struct.proto: File not found.
test.proto:5:1: Import "google/protobuf/struct.proto" was not found or had errors.
```