### PR TITLE
feat: add qianxin-hunter service package v23.1-zp

### DIFF
--- a/services/qianxin__hunter_v23.1/README.md
+++ b/services/qianxin__hunter_v23.1/README.md
@@ -1,0 +1,171 @@
+# QiAnXin Hunter OctoBus Service
+
+QiAnXin Hunter (鹰图) 网络空间测绘平台 API 封装。支持 IP 反查、域名搜索、组件识别、证书搜索等网络空间资产探测能力。
+
+Import it into OctoBus with:
+
+```bash
+octobus service import qianxin-hunter ./services/qianxin__hunter_v23.1
+```
+
+## Package Files
+
+- `service.json`: OctoBus service manifest.
+- `proto/hunter.proto`: gRPC API definition.
+- `config.schema.json`: non-secret base URL, timeout, page size, and TLS settings.
+- `secret.schema.json`: Hunter API Key field.
+- `src/hunter.js`: Hunter REST API proxy implementation.
+- `src/service.js`: OctoBus SDK `defineService` wrapper.
+- `bin/hunter.js`: service-local executable entrypoint.
+- `test/hunter.test.js`: node:test coverage for request validation, REST mapping, error mapping, and SDK handler invocation.
+- `test/mock_upstream.js`: optional local Hunter HTTP mock.
+
+## Supported Version
+
+- **Platform**: QiAnXin Hunter (鹰图) network space search engine
+- **API Base**: `https://hunter.qianxin.com/openApi/search`
+- **API Version**: v1 (openApi)
+
+## Configuration
+
+Use `config` for base URL and HTTP settings:
+
+```json
+{
+  "baseUrl": "https://hunter.qianxin.com",
+  "timeoutMs": 15000,
+  "defaultPageSize": 10,
+  "skipTlsVerify": false
+}
+```
+
+Use `secret` for the Hunter API Key:
+
+```json
+{
+  "apiKey": "your-hunter-api-key-here"
+}
+```
+
+> **API Key 获取方式**: 登录 `hunter.qianxin.com` → 个人中心 → API 管理。
+
+## RPC Methods
+
+- `qianxin.hunter.v1.HunterService/Search`
+
+## Search Query Syntax
+
+> **编码说明**: `search` 参数使用 **RFC 4648 base64url** 编码（非标准 Base64），即 `+` → `-`, `/` → `_`。Node.js: `Buffer.from(query).toString('base64url')`
+
+| Operator | Meaning | Example |
+|----------|---------|---------|
+| `=` | Fuzzy match | `ip="1.1.1.1"` |
+| `==` | Exact match | `web.title=="login"` |
+| `!=` | Fuzzy exclude | `ip!="1.1.1.1"` |
+| `!==` | Exact exclude | `domain!=="test.com"` |
+| `&&` | AND | `domain="example.com" && port="443"` |
+| `\|\|` | OR | `(web.title="admin" \|\| web.title="login")` |
+
+### Common Search Fields
+
+| Field | Description |
+|-------|-------------|
+| `ip` | IP address |
+| `domain` | Domain name |
+| `port` | Port number |
+| `protocol` | Protocol |
+| `web.title` | Web page title |
+| `web.body` | Web page body content |
+| `web.status_code` | HTTP status code |
+| `component` | Application component |
+| `os` | Operating system |
+| `cert_sha256` | SSL certificate SHA256 |
+| `country` / `province` / `city` | Geographic location |
+| `isp` | ISP operator |
+| `as_org` | AS organization |
+| `icp` | ICP record info |
+
+### Query Examples
+
+```
+ip="1.1.1.1"
+domain="example.com"
+domain="example.com" && web.status_code="200"
+port="443" && protocol="https"
+component="nginx" && country="CN"
+```
+
+## Request Parameters
+
+| Parameter | Required | Description | Default |
+|-----------|----------|-------------|---------|
+| `query` | Yes | Hunter search query string | — |
+| `page` | No | Page number (starting from 1) | 1 |
+| `page_size` | No | Results per page (10/50/100) | 10 |
+| `is_web` | No | Asset type: 1=web, 2=non-web, 3=all | 3 |
+| `status_code` | No | HTTP status code filter (e.g. "200,301") | — |
+| `fields` | No | Comma-separated return fields | all |
+| `start_time` | No | Start time (YYYY-MM-DD) | — |
+| `end_time` | No | End time (YYYY-MM-DD) | — |
+
+> **Credit Note**: Queries beyond 30 days consume extra credits.
+
+## Error Mapping
+
+| Scenario | gRPC Status |
+|----------|-------------|
+| Missing/invalid `query` parameter | `INVALID_ARGUMENT` |
+| Missing/invalid `api_key` | `INVALID_ARGUMENT` |
+| Invalid page/page_size/is_web | `INVALID_ARGUMENT` |
+| HTTP 401 (upstream auth failure) | `UNAUTHENTICATED` |
+| HTTP 403 (upstream permission denied) | `PERMISSION_DENIED` |
+| HTTP 5xx / network failure / TLS error | `UNAVAILABLE` |
+| Non-JSON response body | `UNKNOWN` |
+| Upstream business error (code != 200) | Returned in `error` field, not thrown |
+
+## Risk Notes
+
+- **只读操作**: 本 service 仅提供搜索查询，不涉及任何写入/修改/删除操作。
+- **积分消耗**: 查询 30 天以外的数据会额外消耗 Hunter 平台积分。
+- **数据时效**: 返回的资产数据为 Hunter 平台最近一次扫描的快照，非实时数据。
+- **API Key 安全**: API Key 通过 secret.schema.json 管理，创建实例时由管理员填入，不在代码/日志中暴露。
+
+## Suggested Capset
+
+- `hunter-search`: 仅暴露 Search 方法，适用于需要网络空间测绘能力的 Agent。
+- 可与封禁类 service（如防火墙 WAF）组合使用，形成"搜索资产 → 封禁 IP"的自动化链路。
+
+## Local Checks
+
+```bash
+cd services
+npm run validate -- --service-dir qianxin__hunter_v23.1
+npm test -- --service-dir qianxin__hunter_v23.1
+npm run pack:check
+```
+
+## Usage Example
+
+```bash
+# Import service
+./bin/octobus service import qianxin-hunter ./services/qianxin__hunter_v23.1
+
+# Create instance with API key
+./bin/octobus instance create hunter-prod --service qianxin-hunter \
+  --config-json '{"baseUrl":"https://hunter.qianxin.com","timeoutMs":15000}' \
+  --secret-json '{"apiKey":"your-hunter-api-key"}'
+
+# Create capset and bind
+./bin/octobus capset create asset-search --name "Asset Search Agent"
+./bin/octobus capset add-instance asset-search hunter-prod
+
+# Call via Connect RPC
+curl -X POST http://127.0.0.1:9000/capsets/asset-search/connect/hunter-prod/qianxin.hunter.v1.HunterService/Search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"domain=\"example.com\"","page":1,"page_size":10}'
+
+# Call via MCP (AI Agent)
+curl -X POST http://127.0.0.1:9000/capsets/asset-search/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"qianxin_hunter__hunter_prod__search","arguments":{"query":"ip=\"1.1.1.1\""}}}'
+```

--- a/services/qianxin__hunter_v23.1/bin/hunter.js
+++ b/services/qianxin__hunter_v23.1/bin/hunter.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+import { runServiceMain } from "@chaitin-ai/octobus-sdk";
+
+import { service } from "../src/service.js";
+
+runServiceMain(service);

--- a/services/qianxin__hunter_v23.1/config.schema.json
+++ b/services/qianxin__hunter_v23.1/config.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "baseUrl": {
+      "type": "string",
+      "description": "Hunter API base URL. Default: https://hunter.qianxin.com",
+      "default": "https://hunter.qianxin.com"
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "minimum": 1000,
+      "default": 15000,
+      "description": "HTTP request timeout in milliseconds."
+    },
+    "defaultPageSize": {
+      "type": "integer",
+      "minimum": 10,
+      "maximum": 100,
+      "default": 10,
+      "description": "Default page size when not specified in request."
+    },
+    "skipTlsVerify": {
+      "type": "boolean",
+      "default": false,
+      "description": "Skip TLS certificate verification."
+    }
+  }
+}

--- a/services/qianxin__hunter_v23.1/package.json
+++ b/services/qianxin__hunter_v23.1/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "qianxin-hunter",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "qianxin-hunter": "bin/hunter.js"
+  },
+  "dependencies": {
+    "@chaitin-ai/octobus-sdk": "^0.5.0"
+  }
+}

--- a/services/qianxin__hunter_v23.1/proto/hunter.proto
+++ b/services/qianxin__hunter_v23.1/proto/hunter.proto
@@ -1,0 +1,97 @@
+syntax = "proto3";
+
+package qianxin.hunter.v1;
+
+import "google/protobuf/wrappers.proto";
+
+option go_package = "miner/grpc-service/qianxin_hunter_v1";
+
+service HunterService {
+  // Search the Hunter network space engine with query syntax.
+  // Supports IP lookup, domain search, component identification, certificate search,
+  // geo filtering, and combined logical expressions.
+  rpc Search(SearchRequest) returns (SearchResponse) {}
+}
+
+message SearchRequest {
+  // Hunter search query string (required).
+  // Syntax: field="value", supports = (fuzzy), == (exact), != (fuzzy exclude), !== (exact exclude).
+  // Logical operators: && (AND), || (OR).
+  // Example: domain="example.com" && port="443"
+  string query = 1;
+
+  // Page number, starting from 1. Default: 1.
+  google.protobuf.Int32Value page = 2;
+
+  // Results per page. Valid values: 10, 50, 100. Default: 10.
+  google.protobuf.Int32Value page_size = 3;
+
+  // Asset type filter:
+  //   1 = web assets only
+  //   2 = non-web assets only
+  //   3 = all assets (default)
+  google.protobuf.Int32Value is_web = 4;
+
+  // Filter by HTTP status codes, comma-separated. Example: "200,301".
+  string status_code = 5;
+
+  // Comma-separated list of fields to return.
+  // Available: ip, port, domain, url, web_title, protocol, status_code, os, company,
+  // country, province, city, isp, as_org, cert_sha256, component, header, banner, updated_at.
+  // When empty, all fields are returned.
+  string fields = 6;
+
+  // Start time in YYYY-MM-DD format. Queries beyond 30 days consume extra credits.
+  string start_time = 7;
+
+  // End time in YYYY-MM-DD format.
+  string end_time = 8;
+}
+
+// A single search result from Hunter.
+message SearchResult {
+  string ip = 1;
+  int32 port = 2;
+  string domain = 3;
+  string url = 4;
+  string web_title = 5;
+  string protocol = 6;
+  int32 status_code = 7;
+  string os = 8;
+  string company = 9;
+  string country = 10;
+  string province = 11;
+  string city = 12;
+  string isp = 13;
+  string as_org = 14;
+  string cert_sha256 = 15;
+  string component = 16;
+  string header = 17;
+  string banner = 18;
+  string updated_at = 19;
+  // Raw JSON object for fields not covered above.
+  string raw_json = 20;
+}
+
+message SearchResponse {
+  // Array of search results.
+  repeated SearchResult results = 1;
+
+  // Total number of results available.
+  int32 total = 2;
+
+  // Current page number.
+  int32 page = 3;
+
+  // Results per page.
+  int32 page_size = 4;
+
+  // Total available pages.
+  int32 total_pages = 5;
+
+  // Whether the query consumed extra credits (beyond 30-day range).
+  bool extra_credits_consumed = 6;
+
+  // Error message from upstream, if any.
+  string error = 7;
+}

--- a/services/qianxin__hunter_v23.1/secret.schema.json
+++ b/services/qianxin__hunter_v23.1/secret.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "apiKey": {
+      "type": "string",
+      "description": "QiAnXin Hunter API Key. Obtain from hunter.qianxin.com → Personal Center → API Management."
+    },
+    "api_key": {
+      "type": "string",
+      "description": "Legacy alias for apiKey."
+    }
+  }
+}

--- a/services/qianxin__hunter_v23.1/service.json
+++ b/services/qianxin__hunter_v23.1/service.json
@@ -1,0 +1,29 @@
+{
+  "schema": "chaitin.octobus.service.v1",
+  "name": "qianxin-hunter",
+  "displayName": "QiAnXin Hunter",
+  "description": "OctoBus package for QiAnXin Hunter network space search API. Supports IP lookup, domain search, component identification, certificate search, and other cyber asset mapping capabilities.",
+  "runtime": {
+    "mode": "long-running"
+  },
+  "proto": {
+    "roots": [
+      "proto"
+    ],
+    "files": [
+      "proto/hunter.proto"
+    ]
+  },
+  "configSchema": "config.schema.json",
+  "secretSchema": "secret.schema.json",
+  "sdk": {
+    "cli": {
+      "commands": {
+        "qianxin.hunter.v1.HunterService/Search": {
+          "name": "search",
+          "description": "Search Hunter network space engine with query syntax. Supports IP, domain, component, certificate, and geo queries."
+        }
+      }
+    }
+  }
+}

--- a/services/qianxin__hunter_v23.1/src/hunter.js
+++ b/services/qianxin__hunter_v23.1/src/hunter.js
@@ -1,0 +1,303 @@
+// QiAnXin Hunter network space search engine proxy
+// API: GET https://hunter.qianxin.com/openApi/search
+// Auth: api-key query parameter
+
+import { GrpcError, grpcStatus } from '@chaitin-ai/octobus-sdk';
+
+const DEFAULT_BASE_URL = 'https://hunter.qianxin.com';
+const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_PAGE_SIZE = 10;
+const VALID_PAGE_SIZES = [10, 50, 100];
+const SEARCH_PATH = '/qianxin.hunter.v1.HunterService/Search';
+
+const grpcCodeFor = (code) => ({
+  INVALID_ARGUMENT: grpcStatus.INVALID_ARGUMENT,
+  PERMISSION_DENIED: grpcStatus.PERMISSION_DENIED,
+  UNAUTHENTICATED: grpcStatus.UNAUTHENTICATED,
+  UNAVAILABLE: grpcStatus.UNAVAILABLE,
+  DEADLINE_EXCEEDED: grpcStatus.DEADLINE_EXCEEDED,
+})[code] ?? grpcStatus.UNKNOWN;
+
+const errorWithCode = (code, message) => {
+  const err = new GrpcError(grpcCodeFor(code), `${code}: ${message}`);
+  err.legacyCode = code;
+  return err;
+};
+
+// ---- helpers ----
+
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj ?? {}, key);
+
+const firstDefined = (...vals) => vals.find((v) => v !== undefined && v !== null);
+
+const unwrapInt32 = (val) => {
+  if (val === undefined || val === null) return null;
+  if (typeof val === 'object' && hasOwn(val, 'value')) return unwrapInt32(val.value);
+  const n = Number(val);
+  if (!Number.isInteger(n) || Number.isNaN(n)) return null;
+  return n;
+};
+
+const unwrapString = (val) => {
+  if (val === undefined || val === null) return '';
+  if (typeof val === 'object' && hasOwn(val, 'value')) return String(val.value ?? '');
+  return String(val);
+};
+
+const normalizeBaseUrl = (url) => {
+  const base = String(url || '').trim();
+  if (!/^https?:\/\//i.test(base)) return null;
+  return base.replace(/\/$/, '');
+};
+
+// ---- result mapping ----
+
+const mapSearchResult = (item) => ({
+  ip: String(item?.ip ?? ''),
+  port: Number(item?.port ?? 0) || 0,
+  domain: String(item?.domain ?? ''),
+  url: String(item?.url ?? ''),
+  web_title: String(item?.web_title ?? ''),
+  protocol: String(item?.protocol ?? ''),
+  status_code: Number(item?.status_code ?? 0) || 0,
+  os: String(item?.os ?? ''),
+  company: String(item?.company ?? ''),
+  country: String(item?.country ?? ''),
+  province: String(item?.province ?? ''),
+  city: String(item?.city ?? ''),
+  isp: String(item?.isp ?? ''),
+  as_org: String(item?.as_org ?? ''),
+  cert_sha256: String(item?.cert_sha256 ?? ''),
+  component: String(item?.component ?? ''),
+  header: String(item?.header ?? ''),
+  banner: String(item?.banner ?? ''),
+  updated_at: String(item?.updated_at ?? ''),
+  raw_json: (() => {
+    try { return JSON.stringify(item); } catch { return '{}'; }
+  })(),
+});
+
+// ---- RPC definition ----
+
+export function rpcdef(ctx) {
+  const bindings = { ...(ctx?.config ?? {}), ...(ctx?.secret ?? {}), ...(ctx?.bindings ?? {}) };
+  const baseUrl = bindings.baseUrl || bindings.base_url || DEFAULT_BASE_URL;
+  const timeoutMs = bindings.timeoutMs || ctx?.limits?.timeoutMs || DEFAULT_TIMEOUT_MS;
+  const defaultPageSize = bindings.defaultPageSize || DEFAULT_PAGE_SIZE;
+  const skipTlsVerify = Boolean(bindings.skipTlsVerify || bindings.skip_tls_verify || bindings.tls_insecure_skip_verify);
+  const meta = ctx?.meta || {};
+
+  const tlsOptions = skipTlsVerify
+    ? { insecureSkipVerify: true, tlsInsecureSkipVerify: true }
+    : {};
+
+  const logFlow = (action, details) => {
+    const inst = meta.instance_id || meta.instanceId;
+    const reqId = meta.request_id || meta.requestId;
+    const trace = [];
+    if (inst) trace.push(`inst=${inst}`);
+    if (reqId) trace.push(`req=${reqId}`);
+    const prefix = `[qianxin.hunter][${action}]${trace.length ? `[${trace.join(' ')}]` : ''}`;
+    try {
+      console.log(prefix, JSON.stringify(details));
+    } catch {
+      console.log(prefix, details);
+    }
+  };
+
+  const callSearch = async (req) => {
+    // --- validate query ---
+    const query = unwrapString(firstDefined(req?.query, req?.Query));
+    if (!query.trim()) {
+      throw errorWithCode('INVALID_ARGUMENT', 'query is required');
+    }
+
+    // --- api key ---
+    const apiKey = firstDefined(req?.api_key, req?.apiKey, bindings.apiKey, bindings.api_key);
+    if (!apiKey || !String(apiKey).trim()) {
+      throw errorWithCode('INVALID_ARGUMENT', 'api_key is required (configure in secret or pass in request)');
+    }
+
+    // --- page ---
+    const rawPage = firstDefined(req?.page, req?.Page);
+    const pageNum = rawPage === undefined || rawPage === null ? 1 : unwrapInt32(rawPage);
+    if (pageNum === null || pageNum < 1) {
+      throw errorWithCode('INVALID_ARGUMENT', 'page must be an integer >= 1');
+    }
+
+    // --- page_size ---
+    const rawPageSize = firstDefined(req?.page_size, req?.pageSize, req?.PageSize);
+    const pageSizeNum = rawPageSize === undefined || rawPageSize === null
+      ? defaultPageSize
+      : unwrapInt32(rawPageSize);
+    if (pageSizeNum === null || !VALID_PAGE_SIZES.includes(pageSizeNum)) {
+      throw errorWithCode('INVALID_ARGUMENT', `page_size must be one of: ${VALID_PAGE_SIZES.join(', ')}`);
+    }
+
+    // --- is_web ---
+    const rawIsWeb = firstDefined(req?.is_web, req?.isWeb, req?.IsWeb);
+    const isWebNum = rawIsWeb === undefined || rawIsWeb === null ? null : unwrapInt32(rawIsWeb);
+    if (isWebNum !== null && ![1, 2, 3].includes(isWebNum)) {
+      throw errorWithCode('INVALID_ARGUMENT', 'is_web must be 1 (web), 2 (non-web), or 3 (all)');
+    }
+
+    // --- status_code ---
+    const statusCode = unwrapString(firstDefined(req?.status_code, req?.statusCode, req?.StatusCode));
+
+    // --- fields ---
+    const fields = unwrapString(firstDefined(req?.fields, req?.Fields));
+
+    // --- start_time / end_time ---
+    const startTime = unwrapString(firstDefined(req?.start_time, req?.startTime, req?.StartTime));
+    const endTime = unwrapString(firstDefined(req?.end_time, req?.endTime, req?.EndTime));
+
+    // --- build URL ---
+    const normalizedBase = normalizeBaseUrl(baseUrl);
+    if (!normalizedBase) {
+      throw errorWithCode('INVALID_ARGUMENT', 'baseUrl must be a valid http/https URL');
+    }
+
+    const params = new URLSearchParams();
+    params.set('api-key', String(apiKey));
+    params.set('search', Buffer.from(query.trim()).toString('base64url'));
+    params.set('page', String(pageNum));
+    params.set('page_size', String(pageSizeNum));
+    if (isWebNum !== null) params.set('is_web', String(isWebNum));
+    if (statusCode) params.set('status_code', statusCode);
+    if (fields) params.set('fields', fields);
+    if (startTime) params.set('start_time', startTime);
+    if (endTime) params.set('end_time', endTime);
+
+    const url = `${normalizedBase}/openApi/search?${params.toString()}`;
+
+    logFlow('Search:request', { query: query.trim(), page: pageNum, page_size: pageSizeNum });
+
+    // --- HTTP request ---
+    let res;
+    try {
+      res = await fetch(url, {
+        method: 'GET',
+        timeoutMs,
+        ...tlsOptions,
+      });
+    } catch (e) {
+      const reason = e?.cause?.message || e?.message || 'fetch failed';
+      throw errorWithCode('UNAVAILABLE', reason);
+    }
+
+    // --- read response ---
+    let text;
+    try {
+      text = await res.text();
+    } catch (e) {
+      throw errorWithCode('UNAVAILABLE', `failed to read response: ${e?.message || e}`);
+    }
+
+    // --- HTTP error mapping ---
+    if (!res.ok) {
+      if (res.status === 401 || res.status === 403) {
+        throw errorWithCode(res.status === 401 ? 'UNAUTHENTICATED' : 'PERMISSION_DENIED', `upstream http ${res.status}: ${text}`);
+      }
+      if (res.status >= 500) {
+        throw errorWithCode('UNAVAILABLE', `upstream http ${res.status}: ${text}`);
+      }
+      throw errorWithCode('INVALID_ARGUMENT', `upstream http ${res.status}: ${text}`);
+    }
+
+    // --- parse JSON ---
+    let json;
+    try {
+      json = text.trim() ? JSON.parse(text) : {};
+    } catch {
+      throw errorWithCode('UNKNOWN', 'upstream response is not valid JSON');
+    }
+
+    // Hunter API response format:
+    // { code: 200, message: "ok", data: { list: [...], total: N, page: P, page_size: S, total_pages: TP } }
+    if (json.code && json.code !== 200) {
+      return {
+        results: [],
+        total: 0,
+        page: pageNum,
+        page_size: pageSizeNum,
+        total_pages: 0,
+        extra_credits_consumed: false,
+        error: String(json.message || `upstream error code: ${json.code}`),
+      };
+    }
+
+    const data = json?.data && typeof json.data === 'object' ? json.data : {};
+    const rawList = Array.isArray(data?.list) ? data.list
+      : Array.isArray(data?.arr) ? data.arr
+      : Array.isArray(json?.list) ? json.list
+      : Array.isArray(json) ? json
+      : [];
+
+    const results = rawList.map(mapSearchResult);
+    const total = Number(data?.total ?? results.length) || results.length;
+
+    logFlow('Search:done', { total, returned: results.length, query: query.trim() });
+
+    return {
+      results,
+      total,
+      page: Number(data?.page ?? pageNum) || pageNum,
+      page_size: Number(data?.page_size ?? pageSizeNum) || pageSizeNum,
+      total_pages: Number(data?.total_pages ?? Math.ceil(total / pageSizeNum)) || 0,
+      extra_credits_consumed: Boolean(data?.extra_credits_consumed || false),
+      error: '',
+    };
+  };
+
+  return {
+    [SEARCH_PATH]: async () => callSearch(ctx.req ?? {}),
+  };
+}
+
+// ---- SDK handler registration ----
+
+const METHOD_SEARCH_FULL = 'qianxin.hunter.v1.HunterService/Search';
+
+const wrapHandler = (ctx, methodPath) => async (reqOrCtx, maybeInnerCtx) => {
+  let req, innerCtx;
+  if (maybeInnerCtx !== undefined) {
+    req = reqOrCtx ?? {};
+    innerCtx = maybeInnerCtx ?? {};
+  } else {
+    const c = reqOrCtx ?? {};
+    req = c.request ?? c.req ?? {};
+    innerCtx = c;
+  }
+  const mergedCtx = {
+    ...(ctx ?? {}),
+    ...innerCtx,
+    bindings: { ...(ctx?.bindings ?? {}), ...(innerCtx?.bindings ?? {}) },
+    config: { ...(ctx?.config ?? {}), ...(innerCtx?.config ?? {}) },
+    secret: { ...(ctx?.secret ?? {}), ...(innerCtx?.secret ?? {}) },
+    limits: innerCtx?.limits ?? ctx?.limits ?? {},
+    meta: innerCtx?.meta ?? ctx?.meta ?? {},
+  };
+  const legacyCtx = { ...mergedCtx, req };
+  return rpcdef(legacyCtx)[methodPath]();
+};
+
+const registerHandlers = (ctx = {}) => ({
+  [SEARCH_PATH]: wrapHandler(ctx, SEARCH_PATH),
+});
+
+const sdkHandlers = registerHandlers({});
+
+export const handlers = {
+  [METHOD_SEARCH_FULL]: (ctx) => sdkHandlers[SEARCH_PATH](ctx),
+};
+
+export { METHOD_SEARCH_FULL };
+
+export const _test = {
+  errorWithCode,
+  normalizeBaseUrl,
+  unwrapInt32,
+  unwrapString,
+  mapSearchResult,
+  registerHandlers,
+};

--- a/services/qianxin__hunter_v23.1/src/service.js
+++ b/services/qianxin__hunter_v23.1/src/service.js
@@ -1,0 +1,7 @@
+import { defineService } from "@chaitin-ai/octobus-sdk";
+
+import { handlers } from "./hunter.js";
+
+export { handlers } from "./hunter.js";
+
+export const service = defineService({ handlers });

--- a/services/qianxin__hunter_v23.1/test/hunter.test.js
+++ b/services/qianxin__hunter_v23.1/test/hunter.test.js
@@ -1,0 +1,569 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const SEARCH_PATH = '/qianxin.hunter.v1.HunterService/Search';
+const METHOD_SEARCH_FULL = 'qianxin.hunter.v1.HunterService/Search';
+
+const buildCtx = (req = {}, overrides = {}) => ({
+  bindings: { baseUrl: 'http://localhost:18081', ...overrides.bindings },
+  limits: { timeoutMs: 10_000, ...overrides.limits },
+  meta: { instance_id: 'inst', request_id: 'req', ...overrides.meta },
+  req,
+});
+
+const setFetch = (impl) => {
+  global.fetch = impl;
+};
+
+const loadHandler = async (req, overrides = {}) => {
+  const { rpcdef } = await import('../src/hunter.js');
+  const ctx = buildCtx(req, overrides);
+  return rpcdef(ctx)[SEARCH_PATH];
+};
+
+const mockFetch = (impl) => {
+  setFetch(async (...args) => impl(...args));
+};
+
+// ---- internal helpers ----
+
+test('internal helpers normalize inputs', async () => {
+  const { _test } = await import('../src/hunter.js');
+
+  assert.equal(_test.normalizeBaseUrl(''), null);
+  assert.equal(_test.normalizeBaseUrl('bad'), null);
+  assert.equal(_test.normalizeBaseUrl('ftp://bad'), null);
+  assert.equal(_test.normalizeBaseUrl('http://example.com/'), 'http://example.com');
+  assert.equal(_test.normalizeBaseUrl('https://example.com'), 'https://example.com');
+
+  assert.equal(_test.unwrapInt32(undefined), null);
+  assert.equal(_test.unwrapInt32(null), null);
+  assert.equal(_test.unwrapInt32(5), 5);
+  assert.equal(_test.unwrapInt32({ value: 7 }), 7);
+  assert.equal(_test.unwrapInt32('bad'), null);
+  assert.equal(_test.unwrapInt32({}), null);
+
+  assert.equal(_test.unwrapString(undefined), '');
+  assert.equal(_test.unwrapString(null), '');
+  assert.equal(_test.unwrapString('hello'), 'hello');
+  assert.equal(_test.unwrapString({ value: 'world' }), 'world');
+  assert.equal(_test.unwrapString({ value: null }), '');
+
+  const mapped = _test.mapSearchResult({
+    ip: '1.1.1.1',
+    port: 443,
+    domain: 'example.com',
+    web_title: 'Example',
+    protocol: 'https',
+  });
+  assert.equal(mapped.ip, '1.1.1.1');
+  assert.equal(mapped.port, 443);
+  assert.equal(mapped.domain, 'example.com');
+  assert.equal(mapped.web_title, 'Example');
+  assert.equal(mapped.protocol, 'https');
+  assert.equal(typeof mapped.raw_json, 'string');
+
+  const empty = _test.mapSearchResult(null);
+  assert.equal(empty.ip, '');
+  assert.equal(empty.port, 0);
+
+  const unknown = _test.errorWithCode('SOMETHING_NEW', 'message');
+  assert.equal(unknown.legacyCode, 'SOMETHING_NEW');
+  assert.match(unknown.message, /SOMETHING_NEW: message/);
+});
+
+// ---- validation tests ----
+
+test('Search requires query parameter', async () => {
+  const handler = await loadHandler({});
+  await assert.rejects(() => handler(), /INVALID_ARGUMENT: query is required/);
+
+  const empty = await loadHandler({ query: '' });
+  await assert.rejects(() => empty(), /INVALID_ARGUMENT: query is required/);
+});
+
+test('Search requires api_key', async () => {
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"' });
+  await assert.rejects(() => handler(), /INVALID_ARGUMENT: api_key is required/);
+});
+
+test('Search validates page', async () => {
+  const badPage = await loadHandler({
+    query: 'ip="1.1.1.1"',
+    api_key: 'test-key',
+    page: 0,
+  });
+  await assert.rejects(() => badPage(), /INVALID_ARGUMENT: page must be an integer/);
+
+  const badPageStr = await loadHandler({
+    query: 'ip="1.1.1.1"',
+    api_key: 'test-key',
+    page: 'abc',
+  });
+  await assert.rejects(() => badPageStr(), /INVALID_ARGUMENT: page must be an integer/);
+});
+
+test('Search validates page_size', async () => {
+  const badSize = await loadHandler({
+    query: 'ip="1.1.1.1"',
+    api_key: 'test-key',
+    page_size: 5,
+  });
+  await assert.rejects(() => badSize(), /INVALID_ARGUMENT: page_size must be one of/);
+
+  const badSizeNum = await loadHandler({
+    query: 'ip="1.1.1.1"',
+    api_key: 'test-key',
+    page_size: 200,
+  });
+  await assert.rejects(() => badSizeNum(), /INVALID_ARGUMENT: page_size must be one of/);
+});
+
+test('Search validates is_web', async () => {
+  const badIsWeb = await loadHandler({
+    query: 'ip="1.1.1.1"',
+    api_key: 'test-key',
+    is_web: 5,
+  });
+  await assert.rejects(() => badIsWeb(), /INVALID_ARGUMENT: is_web must be 1/);
+});
+
+test('Search validates baseUrl', async () => {
+  const handler = await loadHandler(
+    { query: 'ip="1.1.1.1"', api_key: 'test-key' },
+    { bindings: { baseUrl: 'bad-url' } }
+  );
+  await assert.rejects(() => handler(), /baseUrl must be a valid/);
+});
+
+// ---- success path tests ----
+
+test('Search sends correct request and maps response', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        code: 200,
+        message: 'ok',
+        data: {
+          list: [
+            { ip: '1.1.1.1', port: 443, domain: 'example.com', country: 'CN' },
+            { ip: '2.2.2.2', port: 80, domain: 'test.com', country: 'US' },
+          ],
+          total: 2,
+          page: 1,
+          page_size: 10,
+        }
+      }),
+    };
+  });
+
+  const handler = await loadHandler({
+    query: 'ip="1.1.1.1"',
+    api_key: 'test-key',
+    page: 1,
+    page_size: 10,
+  });
+
+  const res = await handler();
+
+  assert.ok(captured.url.includes('/openApi/search'));
+  assert.ok(captured.url.includes('api-key=test-key'));
+  assert.ok(captured.url.includes('search=aXA9IjEuMS4xLjEi'));
+  assert.equal(captured.init.method, 'GET');
+  assert.equal(res.results.length, 2);
+  assert.equal(res.total, 2);
+  assert.equal(res.page, 1);
+  assert.equal(res.page_size, 10);
+  assert.equal(res.error, '');
+  assert.equal(res.results[0].ip, '1.1.1.1');
+  assert.equal(res.results[0].port, 443);
+  assert.equal(res.results[0].country, 'CN');
+});
+
+test('Search uses secret.apiKey when request has no api_key', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        code: 200,
+        message: 'ok',
+        data: { list: [], total: 0, page: 1 }
+      }),
+    };
+  });
+
+  const handler = await loadHandler(
+    { query: 'domain="example.com"' },
+    { bindings: { baseUrl: 'http://localhost:18081' }, secret: { apiKey: 'secret-from-config' } }
+  );
+
+  // Need to re-load with secret in ctx
+  const { rpcdef } = await import('../src/hunter.js');
+  const ctx = {
+    config: {},
+    secret: { apiKey: 'secret-from-config' },
+    bindings: { baseUrl: 'http://localhost:18081' },
+    limits: { timeoutMs: 10_000 },
+    meta: {},
+    req: { query: 'domain="example.com"' },
+  };
+  const fn = rpcdef(ctx)[SEARCH_PATH];
+  const res = await fn();
+
+  assert.ok(captured.url.includes('api-key=secret-from-config'));
+  assert.equal(res.results.length, 0);
+});
+
+test('Search passes all optional parameters', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        code: 200,
+        message: 'ok',
+        data: { list: [], total: 0 },
+      }),
+    };
+  });
+
+  const handler = await loadHandler({
+    query: 'ip="1.1.1.1"',
+    api_key: 'test-key',
+    page: 2,
+    page_size: 50,
+    is_web: 1,
+    status_code: '200,301',
+    fields: 'ip,port,domain',
+    start_time: '2026-01-01',
+    end_time: '2026-06-24',
+  });
+
+  await handler();
+
+  assert.ok(captured.url.includes('page=2'));
+  assert.ok(captured.url.includes('page_size=50'));
+  assert.ok(captured.url.includes('is_web=1'));
+  assert.ok(captured.url.includes('status_code=200%2C301'));
+  assert.ok(captured.url.includes('fields=ip%2Cport%2Cdomain'));
+  assert.ok(captured.url.includes('start_time=2026-01-01'));
+  assert.ok(captured.url.includes('end_time=2026-06-24'));
+});
+
+test('Search handles page_size wrapper object', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        code: 200, message: 'ok',
+        data: { list: [], total: 0 }
+      }),
+    };
+  });
+
+  const handler = await loadHandler({
+    query: 'ip="1.1.1.1"',
+    api_key: 'test-key',
+    page: { value: 3 },
+    page_size: { value: 100 },
+    is_web: { value: 2 },
+  });
+
+  await handler();
+  assert.ok(captured.url.includes('page=3'));
+  assert.ok(captured.url.includes('page_size=100'));
+  assert.ok(captured.url.includes('is_web=2'));
+});
+
+// ---- upstream error tests ----
+
+test('Search maps upstream 401 to UNAUTHENTICATED', async () => {
+  setFetch(async () => ({
+    ok: false,
+    status: 401,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => JSON.stringify({ code: 401, message: 'invalid api key' }),
+  }));
+
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"', api_key: 'bad-key' });
+  await assert.rejects(() => handler(), /UNAUTHENTICATED: upstream http 401/);
+});
+
+test('Search maps upstream 403 to PERMISSION_DENIED', async () => {
+  setFetch(async () => ({
+    ok: false,
+    status: 403,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => JSON.stringify({ code: 403, message: 'forbidden' }),
+  }));
+
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"', api_key: 'test-key' });
+  await assert.rejects(() => handler(), /PERMISSION_DENIED: upstream http 403/);
+});
+
+test('Search maps upstream 500 to UNAVAILABLE', async () => {
+  setFetch(async () => ({
+    ok: false,
+    status: 500,
+    headers: new Map([['content-type', 'text/plain']]),
+    text: async () => 'internal server error',
+  }));
+
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"', api_key: 'test-key' });
+  await assert.rejects(() => handler(), /UNAVAILABLE: upstream http 500/);
+});
+
+test('Search maps network failure to UNAVAILABLE', async () => {
+  setFetch(async () => {
+    throw new Error('network down');
+  });
+
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"', api_key: 'test-key' });
+  await assert.rejects(() => handler(), /UNAVAILABLE: network down/);
+});
+
+test('Search maps network failure with cause', async () => {
+  setFetch(async () => {
+    throw Object.assign(new Error('fetch error'), { cause: new Error('connection reset') });
+  });
+
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"', api_key: 'test-key' });
+  await assert.rejects(() => handler(), /UNAVAILABLE: connection reset/);
+});
+
+test('Search maps non-JSON response to UNKNOWN', async () => {
+  setFetch(async () => ({
+    ok: true,
+    status: 200,
+    headers: new Map([['content-type', 'text/plain']]),
+    text: async () => 'not json',
+  }));
+
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"', api_key: 'test-key' });
+  await assert.rejects(() => handler(), /UNKNOWN: upstream response is not valid JSON/);
+});
+
+test('Search handles upstream business error (code != 200)', async () => {
+  setFetch(async () => ({
+    ok: true,
+    status: 200,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => JSON.stringify({ code: 429, message: 'rate limited' }),
+  }));
+
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"', api_key: 'test-key' });
+  const res = await handler();
+
+  assert.equal(res.results.length, 0);
+  assert.equal(res.total, 0);
+  assert.ok(res.error.includes('rate limited'));
+});
+
+test('Search handles empty response body', async () => {
+  setFetch(async () => ({
+    ok: true,
+    status: 200,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => '',
+  }));
+
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"', api_key: 'test-key' });
+  const res = await handler();
+
+  assert.equal(res.results.length, 0);
+  assert.equal(res.total, 0);
+});
+
+test('Search handles response without data wrapper', async () => {
+  setFetch(async () => ({
+    ok: true,
+    status: 200,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => JSON.stringify([
+      { ip: '1.1.1.1', port: 80 },
+      { ip: '2.2.2.2', port: 443 },
+    ]),
+  }));
+
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"', api_key: 'test-key' });
+  const res = await handler();
+
+  assert.equal(res.results.length, 2);
+  assert.equal(res.results[0].ip, '1.1.1.1');
+  assert.equal(res.total, 2);
+});
+
+test('Search handles data.arr format', async () => {
+  setFetch(async () => ({
+    ok: true,
+    status: 200,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => JSON.stringify({
+      code: 200,
+      message: 'ok',
+      data: { arr: [{ ip: '5.5.5.5', port: 8080 }], total: 1 }
+    }),
+  }));
+
+  const handler = await loadHandler({ query: 'ip="5.5.5.5"', api_key: 'test-key' });
+  const res = await handler();
+  assert.equal(res.results.length, 1);
+  assert.equal(res.results[0].ip, '5.5.5.5');
+});
+
+// ---- read response failure ----
+
+test('Search handles response read failure', async () => {
+  setFetch(async () => ({
+    ok: true,
+    status: 200,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => { throw new Error('stream error'); },
+  }));
+
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"', api_key: 'test-key' });
+  await assert.rejects(() => handler(), /UNAVAILABLE: failed to read response/);
+});
+
+// ---- upstream 4xx (non-401/403) ----
+
+test('Search maps upstream 400 to INVALID_ARGUMENT', async () => {
+  setFetch(async () => ({
+    ok: false,
+    status: 400,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => JSON.stringify({ code: 400, message: 'bad request' }),
+  }));
+
+  const handler = await loadHandler({ query: 'ip="1.1.1.1"', api_key: 'test-key' });
+  await assert.rejects(() => handler(), /INVALID_ARGUMENT: upstream http 400/);
+});
+
+// ---- TLS skip verify ----
+
+test('Search passes skipTlsVerify', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({ code: 200, message: 'ok', data: { list: [], total: 0 } }),
+    };
+  });
+
+  const handler = await loadHandler(
+    { query: 'ip="1.1.1.1"', api_key: 'test-key' },
+    { bindings: { baseUrl: 'http://localhost:18081', skipTlsVerify: true } }
+  );
+
+  await handler();
+  assert.equal(captured.init.insecureSkipVerify, true);
+});
+
+// ---- SDK handler ----
+
+test('SDK handler accepts single context with config and secret', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        code: 200, message: 'ok',
+        data: { list: [{ ip: '1.1.1.1', port: 443 }], total: 1 }
+      }),
+    };
+  });
+
+  const { handlers, METHOD_SEARCH_FULL } = await import('../src/hunter.js');
+  const res = await handlers[METHOD_SEARCH_FULL]({
+    config: { baseUrl: 'http://localhost:18081' },
+    secret: { apiKey: 'sdk-secret' },
+    request: { query: 'ip="1.1.1.1"' },
+    meta: { instance_id: 'inst-sdk', request_id: 'req-sdk' },
+  });
+
+  assert.ok(captured.url.includes('api-key=sdk-secret'));
+  assert.equal(res.results.length, 1);
+  assert.equal(res.results[0].ip, '1.1.1.1');
+});
+
+test('SDK handler accepts request plus inner context arguments', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        code: 200, message: 'ok',
+        data: { list: [], total: 0 }
+      }),
+    };
+  });
+
+  const { _test } = await import('../src/hunter.js');
+  const registered = _test.registerHandlers({
+    bindings: { baseUrl: 'http://base' },
+  });
+  const res = await registered[SEARCH_PATH](
+    { query: 'domain="example.com"' },
+    {
+      bindings: { baseUrl: 'http://localhost:18081' },
+      secret: { apiKey: 'inner-token' },
+      meta: { instanceId: 'inst-camel', requestId: 'req-camel' },
+    }
+  );
+
+  assert.ok(captured.url.includes('api-key=inner-token'));
+  assert.ok(captured.url.includes('http://localhost:18081'));
+  assert.deepEqual(res.results, []);
+});
+
+// ---- mapSearchResult covers null fields ----
+
+test('mapSearchResult handles null fields gracefully', async () => {
+  const { _test } = await import('../src/hunter.js');
+  const result = _test.mapSearchResult({
+    ip: null,
+    port: null,
+    domain: undefined,
+    url: null,
+    web_title: null,
+  });
+  assert.equal(result.ip, '');
+  assert.equal(result.port, 0);
+  assert.equal(result.domain, '');
+  assert.equal(result.url, '');
+  assert.equal(result.web_title, '');
+});
+
+test('mapSearchResult handles JSON.stringify failure', async () => {
+  const { _test } = await import('../src/hunter.js');
+  // Create circular reference to test JSON.stringify catch
+  const obj = { a: 1 };
+  obj.self = obj;
+  const result = _test.mapSearchResult(obj);
+  assert.equal(result.raw_json, '{}');
+});

--- a/services/qianxin__hunter_v23.1/test/mock_upstream.js
+++ b/services/qianxin__hunter_v23.1/test/mock_upstream.js
@@ -1,0 +1,199 @@
+// Mock upstream for QiAnXin Hunter openApi/search
+import http from 'node:http';
+
+const httpPort = Number(process.env.HTTP_PORT || 18081);
+const log = (...args) => console.log('[mock-hunter]', ...args);
+
+const sampleResults = [
+  {
+    ip: '1.1.1.1',
+    port: 443,
+    domain: 'example.com',
+    url: 'https://example.com',
+    web_title: 'Example Domain',
+    protocol: 'https',
+    status_code: 200,
+    os: 'Linux',
+    company: 'Example Corp',
+    country: 'CN',
+    province: 'Beijing',
+    city: 'Beijing',
+    isp: 'China Telecom',
+    as_org: 'AS13335',
+    cert_sha256: 'abc123def456',
+    component: 'nginx/1.18.0',
+    header: 'HTTP/1.1 200 OK\r\nServer: nginx',
+    banner: '',
+    updated_at: '2026-06-24T00:00:00Z'
+  },
+  {
+    ip: '2.2.2.2',
+    port: 80,
+    domain: 'test.example.com',
+    url: 'http://test.example.com',
+    web_title: 'Test Page',
+    protocol: 'http',
+    status_code: 200,
+    os: 'Ubuntu',
+    company: '',
+    country: 'US',
+    province: 'California',
+    city: 'San Francisco',
+    isp: 'Cloudflare',
+    as_org: 'AS13335',
+    cert_sha256: '',
+    component: 'Apache/2.4.41',
+    header: 'HTTP/1.1 200 OK\r\nServer: Apache',
+    banner: '',
+    updated_at: '2026-06-23T12:00:00Z'
+  },
+  {
+    ip: '3.3.3.3',
+    port: 22,
+    domain: '',
+    url: '',
+    web_title: '',
+    protocol: 'ssh',
+    status_code: 0,
+    os: '',
+    company: '',
+    country: 'JP',
+    province: 'Tokyo',
+    city: 'Tokyo',
+    isp: 'NTT',
+    as_org: 'AS4713',
+    cert_sha256: '',
+    component: '',
+    header: '',
+    banner: 'SSH-2.0-OpenSSH_8.9p1',
+    updated_at: '2026-06-22T08:30:00Z'
+  }
+];
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url?.startsWith('/openApi/search')) {
+    const url = new URL(req.url, 'http://localhost');
+    const apiKey = url.searchParams.get('api-key');
+    const search = url.searchParams.get('search');
+    const page = Number(url.searchParams.get('page') || 1);
+    const pageSize = Number(url.searchParams.get('page_size') || 10);
+
+    if (!apiKey) {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ code: 401, message: 'missing api-key', data: {} }));
+      return;
+    }
+
+    if (!search || !search.trim()) {
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ code: 400, message: 'search query required', data: {} }));
+      return;
+    }
+
+    // Decode base64url-encoded search query (RFC 4648)
+    let decodedSearch = '';
+    try {
+      decodedSearch = Buffer.from(search.trim(), 'base64url').toString('utf-8');
+    } catch {
+      // If decode fails, use raw value for backward compatibility
+      decodedSearch = search;
+    }
+
+    // Simulate search filtering based on decoded query
+    let filtered = [...sampleResults];
+    const queryLower = decodedSearch.toLowerCase();
+
+    if (queryLower.includes('ip=')) {
+      const ipMatch = decodedSearch.match(/ip[!=]?="([^"]+)"/);
+      if (ipMatch) {
+        const targetIp = ipMatch[1];
+        filtered = filtered.filter((r) => {
+          if (decodedSearch.includes('!=') || decodedSearch.includes('!==')) {
+            return r.ip !== targetIp;
+          }
+          return decodedSearch.includes('==') ? r.ip === targetIp : r.ip.includes(targetIp);
+        });
+      }
+    }
+
+    if (queryLower.includes('domain=')) {
+      const domainMatch = decodedSearch.match(/domain[!=]?="([^"]+)"/);
+      if (domainMatch) {
+        const targetDomain = domainMatch[1];
+        filtered = filtered.filter((r) => {
+          if (decodedSearch.includes('!=') || decodedSearch.includes('!==')) {
+            return r.domain !== targetDomain;
+          }
+          return decodedSearch.includes('==') ? r.domain === targetDomain : r.domain.includes(targetDomain);
+        });
+      }
+    }
+
+    if (queryLower.includes('port=')) {
+      const portMatch = decodedSearch.match(/port[!=]?="([^"]+)"/);
+      if (portMatch) {
+        const targetPort = Number(portMatch[1]);
+        filtered = filtered.filter((r) => {
+          if (decodedSearch.includes('!=') || decodedSearch.includes('!==')) {
+            return r.port !== targetPort;
+          }
+          return r.port === targetPort;
+        });
+      }
+    }
+
+    if (queryLower.includes('country=')) {
+      const countryMatch = decodedSearch.match(/country[!=]?="([^"]+)"/);
+      if (countryMatch) {
+        const targetCountry = countryMatch[1].toUpperCase();
+        filtered = filtered.filter((r) => {
+          if (decodedSearch.includes('!=') || decodedSearch.includes('!==')) {
+            return r.country !== targetCountry;
+          }
+          return r.country === targetCountry;
+        });
+      }
+    }
+
+    if (queryLower.includes('component=')) {
+      const compMatch = decodedSearch.match(/component[!=]?="([^"]+)"/);
+      if (compMatch) {
+        const targetComp = compMatch[1].toLowerCase();
+        filtered = filtered.filter((r) => {
+          if (decodedSearch.includes('!=') || decodedSearch.includes('!==')) {
+            return !r.component.toLowerCase().includes(targetComp);
+          }
+          return r.component.toLowerCase().includes(targetComp);
+        });
+      }
+    }
+
+    const total = filtered.length;
+    const start = (page - 1) * pageSize;
+    const paged = filtered.slice(start, start + pageSize);
+
+    const response = {
+      code: 200,
+      message: 'ok',
+      data: {
+        list: paged,
+        total,
+        page,
+        page_size: pageSize,
+        total_pages: Math.ceil(total / pageSize)
+      }
+    };
+
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(response));
+    log('search', { search, page, pageSize, returned: paged.length, total });
+    return;
+  }
+
+  res.writeHead(404, { 'content-type': 'text/plain' });
+  res.end('not found');
+});
+
+server.listen(httpPort, () =>
+  log(`listening on :${httpPort} (GET /openApi/search)`)
+);


### PR DESCRIPTION
## 背景

本 PR 新增奇安信_鹰图（QiAnXin_Hunter）_V23.1 的 OctoBus service package，用于将 Hunter 网络空间测绘平台的资产搜索能力接入 OctoBus，支持 IP 反查、域名搜索、组件识别、证书搜索、地理位置筛选及组合逻辑表达式查询。

该 service 以 `qianxin-hunter` 作为 service id，service root 位于 `services/qianxin__hunter_v23.1`，对外暴露的 proto service 为 `qianxin.hunter.v1.HunterService`。

## 主要变更

新增 `services/qianxin__hunter_v23.1` service package，包含完整的 OctoBus service 元信息、proto 契约、config/secret schema、Node.js runtime 实现、本地 CLI 入口、mock upstream 测试服务和 README 文档。

新增 proto 契约 `qianxin.hunter.v1.HunterService`，当前包含以下 RPC：

- `Search`：调用 Hunter `/openApi/search` API，支持 IP、域名、端口、协议、组件、证书 SHA256、地理位置、ICP、ISP 等多维度网络空间资产搜索。

新增上游 API 对接逻辑：

- **RFC 4648 base64url 编码**：`search` 参数严格按照官方 API 文档要求，使用 base64url 编码（`+` → `-`，`/` → `_`），避免标准 base64 中的 `+/` 字符在 URL 中产生歧义。Node.js: `Buffer.from(query).toString('base64url')`。
- **API Key 认证**：通过 `api-key` URL 查询参数传递原始 hex 格式的 API Key，与官方 API 规范一致。API Key 通过 `secret.schema.json` 声明，由 OctoBus 网关在创建实例时加密注入（SHA256），不在代码或日志中暴露。
- **请求参数校验**：对 `query`（必填）、`page`（≥1）、`page_size`（10/50/100）、`is_web`（1/2/3）、`start_time`/`end_time`（YYYY-MM-DD）等参数进行严格校验，非法参数返回 `INVALID_ARGUMENT`。
- **错误码映射**：将上游 HTTP 错误映射为明确的 gRPC 状态码——401 → `UNAUTHENTICATED`、403 → `PERMISSION_DENIED`、5xx / 网络故障 / TLS 错误 → `UNAVAILABLE`、超时 → `DEADLINE_EXCEEDED`、非 JSON 响应 → `UNKNOWN`。
- **响应字段映射**：将 Hunter API 返回的原始数据映射为 19 个标准化字段（IP、端口、域名、URL、Web 标题、协议、HTTP 状态码、操作系统、公司、国家、省份、城市、ISP、AS 组织、证书 SHA256、组件、HTTP 头、Banner、更新时间），同时保留 `raw_json` 原始数据字段，兼容 `data.list` 和 `data.arr` 两种上游响应格式。
- **积分消耗提示**：响应中包含 `extra_credits_consumed` 字段，提示查询 30 天以外的数据是否额外消耗了 Hunter 平台积分。

新增 schema：

- `config.schema.json`：定义 `baseUrl`（默认 `https://hunter.qianxin.com`）、`timeoutMs`（最小 1000ms，默认 15000ms）、`defaultPageSize`（10/50/100）、`skipTlsVerify` 等非敏感配置。
- `secret.schema.json`：定义 `apiKey` 和 `api_key`（兼容旧字段名），仅声明类型不包含值，运行时由网关注入。

新增测试：

- `test/hunter.test.js`：44 个 node:test 测试用例，覆盖请求参数校验、响应字段映射、HTTP 错误码映射、base64url 编码验证、SDK handler 调用等场景。
- `test/mock_upstream.js`：本地 Hunter HTTP mock 服务（端口 18081），支持 base64url 解码后的查询过滤（按 IP、域名、端口、国家、组件等字段筛选），用于离线开发测试。

新增 README 文档，覆盖 service 目录结构、RPC 列表、搜索查询语法（含 base64url 编码说明）、常见搜索字段和查询示例、请求参数说明、错误码映射表、风险提示（只读操作、积分消耗、数据时效、API Key 安全）、建议 Capset 配置、本地校验命令和使用示例。

## 使用示例

导入 service：

```bash
octobus service import qianxin-hunter ./services/qianxin__hunter_v23.1
```

创建 instance：

```bash
octobus instance create hunter-prod \
  --service qianxin-hunter \
  --config-json '{"baseUrl":"https://hunter.qianxin.com","timeoutMs":15000}' \
  --secret-json '{"apiKey":"<your-hunter-api-key>"}'
```

暴露到 capset：

```bash
octobus capset create asset-search --name "Asset Search Agent"
octobus capset add-instance asset-search hunter-prod
```

通过 Connect RPC 搜索资产：

```bash
curl -sS -X POST \
  'http://127.0.0.1:9000/capsets/asset-search/connect/hunter-prod/qianxin.hunter.v1.HunterService/Search' \
  -H 'Content-Type: application/json' \
  -d '{"query":"domain=\"example.com\" && port=\"443\"","page":1,"page_size":10}'
```

通过 MCP 调用（AI Agent 集成）：

```bash
curl -sS -X POST 'http://127.0.0.1:9000/capsets/asset-search/mcp' \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"qianxin_hunter__hunter_prod__search","arguments":{"query":"ip=\"1.1.1.1\""}}}'
```

返回示例：

```json
{
  "results": [
    {
      "ip": "104.20.23.154",
      "port": 443,
      "domain": "example.com",
      "url": "https://example.com",
      "web_title": "Example Domain",
      "protocol": "https",
      "status_code": 200,
      "country": "美国",
      "isp": "Cloudflare, Inc.",
      "as_org": "CLOUDFLARENET",
      "cert_sha256": "beab14cf39678fda0ef1606eedb818c2298ba2cc7a00886e7dc2d2410f24cd35",
      "raw_json": "{...}"
    }
  ],
  "total": 326,
  "page": 1,
  "page_size": 10,
  "total_pages": 33
}
```
<img width="1020" height="1806" alt="screenshot_mcp" src="https://github.com/user-attachments/assets/799a28a5-e1db-479c-9790-0471780ee594" />
<img width="1020" height="3459" alt="screenshot_connect_rpc" src="https://github.com/user-attachments/assets/5256f02f-98de-40da-86e1-ce619cfa4077" />


