### PR TITLE
Add YXLink WAF service adapter

### DIFF
--- a/services/bin/octobus-tentacles.js
+++ b/services/bin/octobus-tentacles.js
@@ -157,6 +157,10 @@ const services = {
     entryFile: "../wd__k01/bin/wd-k01.js",
     serviceModule: "../wd__k01/src/service.js",
   },
+  "yxlink-waf": {
+    entryFile: "../yxlink__waf/bin/yxlink-waf.js",
+    serviceModule: "../yxlink__waf/src/service.js",
+  },
 };
 
 const serviceNames = Object.keys(services);

--- a/services/bin/yxlink-waf.js
+++ b/services/bin/yxlink-waf.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import { runServiceMain } from "@chaitin-ai/octobus-sdk";
+
+import { service } from "../yxlink__waf/src/service.js";
+
+runServiceMain(service, {
+  entryFile: fileURLToPath(new URL("../yxlink__waf/bin/yxlink-waf.js", import.meta.url)),
+});

--- a/services/package.json
+++ b/services/package.json
@@ -42,7 +42,8 @@
     "topsec-fw-2u": "bin/topsec-fw-2u.js",
     "venus-ads-v3-6": "bin/venus-ads-v3-6.js",
     "wangsu-label-ip": "bin/wangsu-label-ip.js",
-    "wd-k01": "bin/wd-k01.js"
+    "wd-k01": "bin/wd-k01.js",
+    "yxlink-waf": "bin/yxlink-waf.js"
   },
   "files": [
     "bin/das-gateway-v3.js",
@@ -83,6 +84,7 @@
     "bin/venus-ads-v3-6.js",
     "bin/wd-k01.js",
     "bin/wangsu-label-ip.js",
+    "bin/yxlink-waf.js",
     "das__gateway_v3",
     "das__tgfw_v6",
     "dingtalk__group-robot",
@@ -121,6 +123,7 @@
     "venus__ads_v3-6",
     "wd__k01",
     "wangsu__label-ip",
+    "yxlink__waf",
     "scripts",
     "bin/octobus-tentacles.js"
   ],

--- a/services/yxlink__waf/README.md
+++ b/services/yxlink__waf/README.md
@@ -1,0 +1,92 @@
+# YXLink WAF
+
+OctoBus service package for YXLink WAF external API v2.1/v2.2 style interfaces. It covers Web tamper resistance management and intrusion log query/delete/count workflows from the provided YXLink WAF API document.
+
+## Supported Version
+
+- Product: YXLink Web Application Firewall
+- API document: `YXLink WAF 对外 API 接口文档 v2.1`, with document history mentioning v2.2 updates for daily intrusion count.
+- Auth: signed `Authorization` HTTP header built from `appId`, random `nonceStr`, Unix `timestamp`, and SHA1 signature with `appSecret`.
+
+## Configuration
+
+Instance config example:
+
+```json
+{
+  "host": "https://waf.example.com",
+  "timeoutMs": 5000,
+  "skipTlsVerify": false
+}
+```
+
+Aliases `baseUrl` and `restBaseUrl` are accepted for `host`.
+
+Instance secret example:
+
+```json
+{
+  "appId": "your-app-id",
+  "appSecret": "your-app-secret"
+}
+```
+
+Aliases `app_id` and `app_secret` are accepted.
+
+## Methods
+
+| Method | Upstream API | Notes |
+| --- | --- | --- |
+| `ListTamperSites` | `POST /api/tamperresistance/tamperresistanceforweb/paginate` | Lists Web tamper resistance records with `start` and `limit`. |
+| `CreateTamperSite` | `POST /api/tamperresistance/tamperresistanceforweb/create` | Creates one monitored site. |
+| `UpdateTamperSite` | `POST /api/tamperresistance/tamperresistanceforweb/update` | Updates one monitored site by `id`. |
+| `DeleteTamperSites` | `POST /api/tamperresistance/tamperresistanceforweb/remove` | Deletes one or more tamper records by comma-joined IDs. |
+| `EnableTamperSites` | `POST /api/tamperresistance/tamperresistanceforweb/enable` | Starts monitoring for one or more records. |
+| `DisableTamperSites` | `POST /api/tamperresistance/tamperresistanceforweb/disable` | Stops monitoring for one or more records. |
+| `RebuildTamperBackups` | `POST /api/tamperresistance/tamperresistanceforweb/rebuildBackup` | Rebuilds backups for one or more records. |
+| `ListIntrusionLogs` | `POST /api/intrusionprevention/intrusionlog/paginate` | Lists intrusion logs in `normal` or `summary` view. |
+| `DeleteIntrusionLogs` | `POST /api/intrusionprevention/intrusionlog/remove` | Deletes intrusion logs; normal view uses `id_date`, summary view can use `id_list`. |
+| `CountIntrusionLogs` | `POST /api/intrusionprevention/intrusionlog/count?date=...` | Returns intrusion log count for a date. |
+
+## Risk Notes
+
+- `CreateTamperSite`, `UpdateTamperSite`, `DeleteTamperSites`, `EnableTamperSites`, `DisableTamperSites`, and `RebuildTamperBackups` change device state.
+- `DeleteIntrusionLogs` deletes audit/security event records. Use a test object or backup/export logs before invoking it.
+- Deletion APIs are not reversible through this adapter.
+- The adapter does not log request bodies or secrets; avoid putting real credentials or production addresses in tests, README snippets, or PR screenshots.
+
+## Write Operation Semantics
+
+- `CreateTamperSite` defaults to `start=false`, `schedule=1`, `filecharset=gbk`, `connect=1`, `folder=/`, and `parallel=5` when those fields are omitted. `port`, `quickdiff`, and `maxsize` are required to avoid silently creating an unsafe monitor.
+- The upstream API document does not describe idempotency keys. Treat create/delete/update/enable/disable/rebuild calls as non-idempotent device operations and retry only after checking the current device state.
+- Rollback must be performed with the corresponding device operation, such as disabling a monitor, restoring an exported log backup, or recreating a deleted record from a saved copy.
+- Preserve OctoBus request metadata and device-side operation logs when using write methods in production; this adapter does not emit additional audit records by itself.
+
+## Suggested Capsets
+
+- Read-only SOC capset: `ListTamperSites`, `ListIntrusionLogs`, `CountIntrusionLogs`
+- WAF operations capset: add `EnableTamperSites`, `DisableTamperSites`, `RebuildTamperBackups`
+- Break-glass admin capset: add create/update/delete methods and require stricter token controls
+
+## Local Validation
+
+From the repository root:
+
+```bash
+cd services
+npm run validate -- --service-dir yxlink__waf
+npm test -- --service-dir yxlink__waf
+npm run pack:check
+```
+
+## Example
+
+```bash
+./bin/octobus service import yxlink-waf ./services/yxlink__waf
+./bin/octobus instance create yxlink-waf-test \
+  --service yxlink-waf \
+  --config-json '{"host":"https://waf.example.com","timeoutMs":5000}' \
+  --secret-json '{"appId":"demo-app","appSecret":"demo-secret"}'
+./bin/octobus capset create waf-ops --name WafOps
+./bin/octobus capset add-instance waf-ops yxlink-waf-test
+```

--- a/services/yxlink__waf/bin/yxlink-waf.js
+++ b/services/yxlink__waf/bin/yxlink-waf.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import { runServiceMain } from '@chaitin-ai/octobus-sdk';
+
+import { service } from '../src/service.js';
+
+runServiceMain(service);

--- a/services/yxlink__waf/config.schema.json
+++ b/services/yxlink__waf/config.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "host": {
+      "type": "string",
+      "description": "YXLink WAF base URL, for example https://waf.example.com."
+    },
+    "baseUrl": {
+      "type": "string",
+      "description": "Alias for host."
+    },
+    "restBaseUrl": {
+      "type": "string",
+      "description": "Alias for host."
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 5000,
+      "description": "HTTP request timeout in milliseconds."
+    },
+    "skipTlsVerify": {
+      "type": "boolean",
+      "default": false,
+      "description": "Skip TLS certificate verification for private deployments."
+    },
+    "tlsInsecureSkipVerify": {
+      "type": "boolean",
+      "default": false,
+      "description": "Alias for skipTlsVerify."
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Optional extra HTTP headers."
+    }
+  }
+}

--- a/services/yxlink__waf/package.json
+++ b/services/yxlink__waf/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "yxlink-waf",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "yxlink-waf": "bin/yxlink-waf.js"
+  },
+  "dependencies": {
+    "@chaitin-ai/octobus-sdk": "^0.5.0"
+  }
+}

--- a/services/yxlink__waf/proto/yxlink_waf.proto
+++ b/services/yxlink__waf/proto/yxlink_waf.proto
@@ -1,0 +1,194 @@
+syntax = "proto3";
+
+package YXLink_WAF;
+
+import "google/protobuf/struct.proto";
+
+option go_package = "miner/grpc-service/YXLink_WAF";
+
+service YXLinkWafService {
+  // 获取网页防篡改列表
+  rpc ListTamperSites(ListTamperSitesRequest) returns (ListTamperSitesResponse) {}
+
+  // 新增网页防篡改记录
+  rpc CreateTamperSite(TamperSiteMutationRequest) returns (CreateTamperSiteResponse) {}
+
+  // 修改网页防篡改记录
+  rpc UpdateTamperSite(UpdateTamperSiteRequest) returns (UpdateTamperSiteResponse) {}
+
+  // 删除网页防篡改记录
+  rpc DeleteTamperSites(IdsRequest) returns (ActionResponse) {}
+
+  // 启动监控
+  rpc EnableTamperSites(IdsRequest) returns (ActionResponse) {}
+
+  // 停止监控
+  rpc DisableTamperSites(IdsRequest) returns (ActionResponse) {}
+
+  // 重建备份
+  rpc RebuildTamperBackups(IdsRequest) returns (ActionResponse) {}
+
+  // 获取入侵记录列表
+  rpc ListIntrusionLogs(ListIntrusionLogsRequest) returns (ListIntrusionLogsResponse) {}
+
+  // 删除入侵记录
+  rpc DeleteIntrusionLogs(DeleteIntrusionLogsRequest) returns (ActionResponse) {}
+
+  // 获取某日入侵记录数量
+  rpc CountIntrusionLogs(CountIntrusionLogsRequest) returns (CountIntrusionLogsResponse) {}
+}
+
+message ListTamperSitesRequest {
+  int64 start = 1; // 起始位置，默认 0
+  int64 limit = 2; // 长度，默认 30
+}
+
+message ListTamperSitesResponse {
+  bool success = 1;
+  string msg = 2;
+  string code = 3;
+  int64 total_amount = 4;
+  repeated TamperSite sites = 5;
+  google.protobuf.Struct raw = 6;
+}
+
+message TamperSiteMutationRequest {
+  string website = 1; // 网站名称，必填
+  string description = 2; // 网站说明
+  bool start = 3; // 是否启用
+  int64 schedule = 4; // 计划任务：1 全天 / 2 工作时间 / 3 下班时间
+  string address = 5; // 网站 IP 地址，必填
+  string filecharset = 6; // 默认编码：gbk/utf8/gb18030
+  string username = 7; // 连接用户，必填
+  string password = 8; // 连接密码
+  int64 connect = 9; // 连接类型：1 FTP / 2 SFTP
+  int64 port = 10; // 端口
+  string folder = 11; // 网站相对路径
+  int64 parallel = 12; // 并发连接数
+  int64 quickdiff = 13; // 监控检查间隔/秒
+  int64 maxsize = 14; // 监控文件大小限制/B
+  string exclude = 15; // 忽略文件列表，多个以换行分割
+}
+
+message UpdateTamperSiteRequest {
+  string id = 1; // 记录 ID，必填
+  TamperSiteMutationRequest site = 2; // 更新后的记录内容
+}
+
+message CreateTamperSiteResponse {
+  bool success = 1;
+  string msg = 2;
+  string code = 3;
+  string inserted_id = 4;
+  google.protobuf.Struct raw = 5;
+}
+
+message UpdateTamperSiteResponse {
+  bool success = 1;
+  string msg = 2;
+  string code = 3;
+  string id = 4;
+  string inserted_id = 5;
+  google.protobuf.Struct raw = 6;
+}
+
+message IdsRequest {
+  repeated string ids = 1; // 记录 ID 列表，提交给设备时用英文逗号拼接
+}
+
+message ActionResponse {
+  bool success = 1;
+  string msg = 2;
+  string code = 3;
+  google.protobuf.Struct raw = 4;
+}
+
+message ListIntrusionLogsRequest {
+  string view_mode = 1; // normal / summary，默认 normal
+  string timestamp = 2; // 攻击日期，格式 yyyy-MM-dd
+  string src_ip = 3;
+  int64 src_port = 4;
+  string dst_ip = 5;
+  int64 dst_port = 6;
+  int64 sid_start = 7;
+  int64 sid_end = 8;
+  string action_type = 9; // B/D/C/P
+  int64 length_type = 10; // 2/1/3
+  int64 data_len = 11;
+  string http_protocol = 12; // GET/POST/Response
+  string get_data = 13;
+  int64 start = 14; // 起始位置，默认 0
+  int64 limit = 15; // 长度，默认 30
+}
+
+message ListIntrusionLogsResponse {
+  bool success = 1;
+  string msg = 2;
+  string code = 3;
+  int64 total_amount = 4;
+  repeated IntrusionLog logs = 5;
+  google.protobuf.Struct raw = 6;
+}
+
+message DeleteIntrusionLogsRequest {
+  repeated string ids = 1; // normal 视图为 id_date；summary 视图可使用 hack_id_list
+  string id_list = 2; // summary 视图中的 hack_id_list
+  string view_mode = 3; // normal / summary
+  string timestamp = 4; // 攻击日期，必填
+}
+
+message CountIntrusionLogsRequest {
+  string date = 1; // 日期，格式 yyyy-MM-dd
+}
+
+message CountIntrusionLogsResponse {
+  bool success = 1;
+  string msg = 2;
+  string code = 3;
+  int64 count = 4;
+  google.protobuf.Struct raw = 5;
+}
+
+message TamperSite {
+  string id = 1;
+  string website = 2;
+  string description = 3;
+  bool start = 4;
+  string address = 5;
+  int64 port = 6;
+  int64 connect = 7;
+  string folder = 8;
+  string username = 9;
+  int64 quickdiff = 10;
+  int64 maxsize = 11;
+  string exclude = 12;
+  string filecharset = 13;
+  int64 parallel = 14;
+  int64 schedule = 15;
+  string status = 16;
+  google.protobuf.Struct raw = 17;
+}
+
+message IntrusionLog {
+  string hack_id = 1;
+  string hack_time = 2;
+  string src_ip = 3;
+  string src_ip_addr = 4;
+  string dst_ip = 5;
+  string src_mac = 6;
+  string dst_mac = 7;
+  int64 data_len = 8;
+  int64 src_port = 9;
+  int64 dst_port = 10;
+  int64 block_reason = 11;
+  string action_type = 12;
+  string http_protocol = 13;
+  string get_data = 14;
+  string raw_data = 15;
+  string rule_name = 16;
+  string rule_type = 17;
+  int64 ranking = 18;
+  string description = 19;
+  string solution = 20;
+  google.protobuf.Struct raw = 21;
+}

--- a/services/yxlink__waf/secret.schema.json
+++ b/services/yxlink__waf/secret.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "appId": {
+      "type": "string",
+      "description": "YXLink WAF API AppID."
+    },
+    "app_id": {
+      "type": "string",
+      "description": "Alias for appId."
+    },
+    "appSecret": {
+      "type": "string",
+      "description": "YXLink WAF API AppSecret."
+    },
+    "app_secret": {
+      "type": "string",
+      "description": "Alias for appSecret."
+    }
+  }
+}

--- a/services/yxlink__waf/service.json
+++ b/services/yxlink__waf/service.json
@@ -1,0 +1,65 @@
+{
+  "schema": "chaitin.octobus.service.v1",
+  "name": "yxlink-waf",
+  "displayName": "YXLink WAF",
+  "description": "OctoBus package for YXLink WAF tamper resistance and intrusion log APIs.",
+  "runtime": {
+    "mode": "long-running"
+  },
+  "proto": {
+    "roots": [
+      "proto"
+    ],
+    "files": [
+      "proto/yxlink_waf.proto"
+    ]
+  },
+  "configSchema": "config.schema.json",
+  "secretSchema": "secret.schema.json",
+  "sdk": {
+    "cli": {
+      "commands": {
+        "YXLink_WAF.YXLinkWafService/ListTamperSites": {
+          "name": "list-tamper-sites",
+          "description": "List YXLink WAF tamper resistance sites."
+        },
+        "YXLink_WAF.YXLinkWafService/CreateTamperSite": {
+          "name": "create-tamper-site",
+          "description": "Create a YXLink WAF tamper resistance site."
+        },
+        "YXLink_WAF.YXLinkWafService/UpdateTamperSite": {
+          "name": "update-tamper-site",
+          "description": "Update a YXLink WAF tamper resistance site."
+        },
+        "YXLink_WAF.YXLinkWafService/DeleteTamperSites": {
+          "name": "delete-tamper-sites",
+          "description": "Delete YXLink WAF tamper resistance sites."
+        },
+        "YXLink_WAF.YXLinkWafService/EnableTamperSites": {
+          "name": "enable-tamper-sites",
+          "description": "Enable tamper monitoring."
+        },
+        "YXLink_WAF.YXLinkWafService/DisableTamperSites": {
+          "name": "disable-tamper-sites",
+          "description": "Disable tamper monitoring."
+        },
+        "YXLink_WAF.YXLinkWafService/RebuildTamperBackups": {
+          "name": "rebuild-tamper-backups",
+          "description": "Rebuild tamper resistance backups."
+        },
+        "YXLink_WAF.YXLinkWafService/ListIntrusionLogs": {
+          "name": "list-intrusion-logs",
+          "description": "List YXLink WAF intrusion logs."
+        },
+        "YXLink_WAF.YXLinkWafService/DeleteIntrusionLogs": {
+          "name": "delete-intrusion-logs",
+          "description": "Delete YXLink WAF intrusion logs."
+        },
+        "YXLink_WAF.YXLinkWafService/CountIntrusionLogs": {
+          "name": "count-intrusion-logs",
+          "description": "Count intrusion logs for a date."
+        }
+      }
+    }
+  }
+}

--- a/services/yxlink__waf/src/service.js
+++ b/services/yxlink__waf/src/service.js
@@ -1,0 +1,7 @@
+import { defineService } from '@chaitin-ai/octobus-sdk';
+
+import { handlers } from './yxlink-waf.js';
+
+export { handlers } from './yxlink-waf.js';
+
+export const service = defineService({ handlers });

--- a/services/yxlink__waf/src/yxlink-waf.js
+++ b/services/yxlink__waf/src/yxlink-waf.js
@@ -1,0 +1,507 @@
+import crypto from 'node:crypto';
+
+import { GrpcError, grpcStatus } from '@chaitin-ai/octobus-sdk';
+
+export const METHOD_LIST_TAMPER_SITES = 'YXLink_WAF.YXLinkWafService/ListTamperSites';
+export const METHOD_CREATE_TAMPER_SITE = 'YXLink_WAF.YXLinkWafService/CreateTamperSite';
+export const METHOD_UPDATE_TAMPER_SITE = 'YXLink_WAF.YXLinkWafService/UpdateTamperSite';
+export const METHOD_DELETE_TAMPER_SITES = 'YXLink_WAF.YXLinkWafService/DeleteTamperSites';
+export const METHOD_ENABLE_TAMPER_SITES = 'YXLink_WAF.YXLinkWafService/EnableTamperSites';
+export const METHOD_DISABLE_TAMPER_SITES = 'YXLink_WAF.YXLinkWafService/DisableTamperSites';
+export const METHOD_REBUILD_TAMPER_BACKUPS = 'YXLink_WAF.YXLinkWafService/RebuildTamperBackups';
+export const METHOD_LIST_INTRUSION_LOGS = 'YXLink_WAF.YXLinkWafService/ListIntrusionLogs';
+export const METHOD_DELETE_INTRUSION_LOGS = 'YXLink_WAF.YXLinkWafService/DeleteIntrusionLogs';
+export const METHOD_COUNT_INTRUSION_LOGS = 'YXLink_WAF.YXLinkWafService/CountIntrusionLogs';
+
+export const PATH_LIST_TAMPER_SITES = '/api/tamperresistance/tamperresistanceforweb/paginate';
+export const PATH_CREATE_TAMPER_SITE = '/api/tamperresistance/tamperresistanceforweb/create';
+export const PATH_UPDATE_TAMPER_SITE = '/api/tamperresistance/tamperresistanceforweb/update';
+export const PATH_DELETE_TAMPER_SITES = '/api/tamperresistance/tamperresistanceforweb/remove';
+export const PATH_ENABLE_TAMPER_SITES = '/api/tamperresistance/tamperresistanceforweb/enable';
+export const PATH_DISABLE_TAMPER_SITES = '/api/tamperresistance/tamperresistanceforweb/disable';
+export const PATH_REBUILD_TAMPER_BACKUPS = '/api/tamperresistance/tamperresistanceforweb/rebuildBackup';
+export const PATH_LIST_INTRUSION_LOGS = '/api/intrusionprevention/intrusionlog/paginate';
+export const PATH_DELETE_INTRUSION_LOGS = '/api/intrusionprevention/intrusionlog/remove';
+export const PATH_COUNT_INTRUSION_LOGS = '/api/intrusionprevention/intrusionlog/count';
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_LIMIT = 30;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const grpcCodeFor = (code) => ({
+  FAILED_PRECONDITION: grpcStatus.FAILED_PRECONDITION,
+  INVALID_ARGUMENT: grpcStatus.INVALID_ARGUMENT,
+  PERMISSION_DENIED: grpcStatus.PERMISSION_DENIED,
+  UNAUTHENTICATED: grpcStatus.UNAUTHENTICATED,
+  UNAVAILABLE: grpcStatus.UNAVAILABLE,
+  DEADLINE_EXCEEDED: grpcStatus.DEADLINE_EXCEEDED,
+  UNKNOWN: grpcStatus.UNKNOWN,
+})[code] ?? grpcStatus.UNKNOWN;
+
+const errorWithCode = (code, message) => {
+  const err = new GrpcError(grpcCodeFor(code), `${code}: ${message}`);
+  err.legacyCode = code;
+  return err;
+};
+
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj ?? {}, key);
+
+const firstDefined = (...values) => values.find((value) => value !== undefined && value !== null);
+
+const unwrap = (value) => {
+  if (value && typeof value === 'object' && hasOwn(value, 'value')) return unwrap(value.value);
+  return value;
+};
+
+const asString = (value) => {
+  const raw = unwrap(value);
+  if (raw === undefined || raw === null) return '';
+  return String(raw).trim();
+};
+
+const asOptionalString = (value) => {
+  const normalized = asString(value);
+  return normalized === '' ? undefined : normalized;
+};
+
+const asInt = (value, field, { min, max, optional = false } = {}) => {
+  const raw = unwrap(value);
+  if (raw === undefined || raw === null || raw === '') {
+    if (optional) return undefined;
+    throw errorWithCode('INVALID_ARGUMENT', `${field} is required`);
+  }
+  const num = Number(raw);
+  if (!Number.isInteger(num) || Number.isNaN(num)) {
+    throw errorWithCode('INVALID_ARGUMENT', `${field} must be an integer`);
+  }
+  if (min !== undefined && num < min) throw errorWithCode('INVALID_ARGUMENT', `${field} must be >= ${min}`);
+  if (max !== undefined && num > max) throw errorWithCode('INVALID_ARGUMENT', `${field} must be <= ${max}`);
+  return num;
+};
+
+const asBool = (value) => {
+  const raw = unwrap(value);
+  if (typeof raw === 'boolean') return raw;
+  if (typeof raw === 'number') return raw !== 0;
+  if (typeof raw === 'string') {
+    const lower = raw.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(lower)) return true;
+    if (['0', 'false', 'no', 'off', ''].includes(lower)) return false;
+  }
+  return Boolean(raw);
+};
+
+const pick = (source, keys) => {
+  for (const key of keys) {
+    if (hasOwn(source, key)) return source[key];
+  }
+  return undefined;
+};
+
+const mergedBindings = (ctx = {}) => ({
+  ...(ctx.config ?? {}),
+  ...(ctx.secret ?? {}),
+  ...(ctx.bindings ?? {}),
+});
+
+const normalizeBaseUrl = (value) => {
+  const url = asString(value).replace(/\/+$/, '');
+  if (!/^https?:\/\//i.test(url)) return '';
+  return url;
+};
+
+const parseHeaders = (value) => {
+  if (value === undefined || value === null || value === '') return {};
+  if (typeof value === 'object' && !Array.isArray(value)) return value;
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+    } catch {
+      return {};
+    }
+  }
+  return {};
+};
+
+const buildTlsOptions = (skipTlsVerify) => (skipTlsVerify
+  ? { skipTlsVerify: true, tlsInsecureSkipVerify: true, insecureSkipVerify: true }
+  : {});
+
+const resolveTimeoutMs = (ctx = {}) => firstDefined(
+  asInt(ctx.req?.timeoutMs, 'timeoutMs', { min: 1, optional: true }),
+  asInt(ctx.req?.timeout_ms, 'timeout_ms', { min: 1, optional: true }),
+  asInt(ctx.bindings?.timeoutMs, 'timeoutMs', { min: 1, optional: true }),
+  asInt(ctx.bindings?.timeout_ms, 'timeout_ms', { min: 1, optional: true }),
+  asInt(ctx.limits?.timeoutMs, 'limits.timeoutMs', { min: 1, optional: true }),
+  DEFAULT_TIMEOUT_MS,
+);
+
+const toPlain = (value) => {
+  if (value === undefined) return null;
+  if (value === null) return null;
+  if (Array.isArray(value)) return value.map((item) => toPlain(item));
+  if (typeof value === 'object') {
+    const out = {};
+    for (const [key, item] of Object.entries(value)) out[key] = toPlain(item);
+    return out;
+  }
+  return value;
+};
+
+const jsonStruct = (value) => toPlain(value);
+
+const sign = (appId, appSecret, nonceStr, timestamp) => {
+  const parts = {
+    appId: String(appId),
+    nonceStr: String(nonceStr),
+    timestamp: String(timestamp),
+    token: String(appSecret),
+  };
+  const canonical = Object.keys(parts)
+    .sort()
+    .map((key) => `${key}=${parts[key]}`)
+    .join('&');
+  return crypto.createHash('sha1').update(canonical).digest('hex');
+};
+
+const buildAuthorization = (appId, appSecret, nonceStr = crypto.randomBytes(8).toString('hex'), timestamp = Math.floor(Date.now() / 1000)) => {
+  const payload = {
+    appId: String(appId),
+    nonceStr: String(nonceStr),
+    timestamp: String(timestamp),
+    signature: sign(appId, appSecret, nonceStr, timestamp),
+  };
+  return Buffer.from(JSON.stringify(payload)).toString('base64');
+};
+
+const resolveCallContext = (ctx = {}, req = {}) => {
+  const bindings = mergedBindings(ctx);
+  const baseUrl = normalizeBaseUrl(firstDefined(bindings.host, bindings.baseUrl, bindings.restBaseUrl));
+  if (!baseUrl) throw errorWithCode('INVALID_ARGUMENT', 'host/baseUrl is required and must include http/https');
+  const appId = asOptionalString(firstDefined(bindings.appId, bindings.app_id));
+  const appSecret = asOptionalString(firstDefined(bindings.appSecret, bindings.app_secret));
+  if (!appId) throw errorWithCode('INVALID_ARGUMENT', 'appId is required in secret');
+  if (!appSecret) throw errorWithCode('INVALID_ARGUMENT', 'appSecret is required in secret');
+  return {
+    req,
+    baseUrl,
+    appId,
+    appSecret,
+    timeoutMs: resolveTimeoutMs({ ...ctx, req }),
+    headers: parseHeaders(bindings.headers),
+    skipTlsVerify: asBool(firstDefined(bindings.skipTlsVerify, bindings.tlsInsecureSkipVerify, bindings.insecureSkipVerify)),
+  };
+};
+
+const formBody = (fields) => {
+  const body = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === undefined || value === null) continue;
+    body.set(key, String(value));
+  }
+  return body;
+};
+
+const requestJSON = async (call, path, fields = {}, { query = {} } = {}) => {
+  const url = new URL(`${call.baseUrl}${path}`);
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null && value !== '') url.searchParams.set(key, String(value));
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), call.timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...call.headers,
+        Authorization: buildAuthorization(call.appId, call.appSecret),
+      },
+      body: formBody(fields),
+      signal: controller.signal,
+      ...buildTlsOptions(call.skipTlsVerify),
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      if (response.status === 401) throw errorWithCode('UNAUTHENTICATED', `upstream http ${response.status}: ${text}`);
+      if (response.status === 403) throw errorWithCode('PERMISSION_DENIED', `upstream http ${response.status}: ${text}`);
+      throw errorWithCode('UNAVAILABLE', `upstream http ${response.status}: ${text}`);
+    }
+    if (text.trim() === '') return {};
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw errorWithCode('UNKNOWN', 'response is not valid JSON');
+    }
+  } catch (error) {
+    if (error.legacyCode) throw error;
+    if (error.name === 'AbortError') throw errorWithCode('DEADLINE_EXCEEDED', `upstream timeout after ${call.timeoutMs}ms`);
+    throw errorWithCode('UNAVAILABLE', error.message);
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const assertBusinessSuccess = (json) => {
+  if (json?.success === false) {
+    const msg = asString(json.msg || json.message || json.code || 'request failed');
+    if (msg === 'auth_failed' || json.code === 'auth_failed') throw errorWithCode('UNAUTHENTICATED', msg);
+    throw errorWithCode('FAILED_PRECONDITION', msg);
+  }
+};
+
+const idsToCSV = (ids, field = 'ids') => {
+  if (!Array.isArray(ids) || ids.length === 0) throw errorWithCode('INVALID_ARGUMENT', `${field} must be a non-empty array`);
+  return ids.map((id) => asString(id)).filter(Boolean).join(',');
+};
+
+const listPagination = (req = {}) => ({
+  start: asInt(firstDefined(req.start, 0), 'start', { min: 0 }),
+  limit: asInt(firstDefined(req.limit, DEFAULT_LIMIT), 'limit', { min: 1 }),
+});
+
+const siteMutationFields = (site = {}, { includeId = false, id } = {}) => {
+  const source = site || {};
+  const fields = {
+    website: asString(source.website),
+    description: asString(source.description),
+    start: asBool(source.start) ? 1 : 0,
+    schedule: asInt(firstDefined(source.schedule, 1), 'schedule', { min: 1, max: 3 }),
+    address: asString(source.address),
+    filecharset: asString(firstDefined(source.filecharset, 'gbk')),
+    username: asString(source.username),
+    password: asString(source.password),
+    connect: asInt(firstDefined(source.connect, 1), 'connect', { min: 1, max: 2 }),
+    port: asInt(source.port, 'port', { min: 1, max: 65535 }),
+    folder: asString(firstDefined(source.folder, '/')),
+    parallel: asInt(firstDefined(source.parallel, 5), 'parallel', { min: 1 }),
+    quickdiff: asInt(source.quickdiff, 'quickdiff', { min: 1 }),
+    maxsize: asInt(source.maxsize, 'maxsize', { min: 1 }),
+    exclude: asString(source.exclude),
+  };
+  for (const required of ['website', 'address', 'username']) {
+    if (!fields[required]) throw errorWithCode('INVALID_ARGUMENT', `${required} is required`);
+  }
+  if (!['gbk', 'utf8', 'gb18030'].includes(fields.filecharset.toLowerCase())) {
+    throw errorWithCode('INVALID_ARGUMENT', 'filecharset must be one of gbk, utf8, gb18030');
+  }
+  if (includeId) fields.id = asString(id);
+  if (includeId && !fields.id) throw errorWithCode('INVALID_ARGUMENT', 'id is required');
+  return fields;
+};
+
+const toInt64 = (value) => {
+  const raw = unwrap(value);
+  if (raw === undefined || raw === null || raw === '') return 0;
+  const n = Number(raw);
+  return Number.isFinite(n) && !Number.isNaN(n) ? Math.trunc(n) : 0;
+};
+
+const mapTamperSite = (item = {}) => ({
+  id: asString(item.id),
+  website: asString(item.website),
+  description: asString(item.description),
+  start: asBool(item.start),
+  address: asString(item.address),
+  port: toInt64(item.port),
+  connect: toInt64(item.connect),
+  folder: asString(item.folder),
+  username: asString(item.username),
+  quickdiff: toInt64(item.quickdiff),
+  maxsize: toInt64(item.maxsize),
+  exclude: asString(item.exclude),
+  filecharset: asString(item.filecharset),
+  parallel: toInt64(item.parallel),
+  schedule: toInt64(item.schedule),
+  status: asString(item.status),
+  raw: jsonStruct(item),
+});
+
+const mapIntrusionLog = (item = {}) => ({
+  hack_id: asString(firstDefined(item.HackId, item.hack_id, item.hackId)),
+  hack_time: asString(firstDefined(item.HackTime, item.hack_time, item.hackTime)),
+  src_ip: asString(firstDefined(item.SrcIp, item.src_ip, item.srcIp)),
+  src_ip_addr: asString(firstDefined(item.SrcIpAddr, item.src_ip_addr, item.srcIpAddr)),
+  dst_ip: asString(firstDefined(item.DstIp, item.dst_ip, item.dstIp)),
+  src_mac: asString(firstDefined(item.SrcMac, item.src_mac, item.srcMac)),
+  dst_mac: asString(firstDefined(item.DstMac, item.dst_mac, item.dstMac)),
+  data_len: toInt64(firstDefined(item.DataLen, item.data_len, item.dataLen)),
+  src_port: toInt64(firstDefined(item.SrcPort, item.src_port, item.srcPort)),
+  dst_port: toInt64(firstDefined(item.DstPort, item.dst_port, item.dstPort)),
+  block_reason: toInt64(firstDefined(item.BlockReason, item.block_reason, item.blockReason)),
+  action_type: asString(firstDefined(item.ActionType, item.action_type, item.actionType)),
+  http_protocol: asString(firstDefined(item.HttpProtocol, item.http_protocol, item.httpProtocol)),
+  get_data: asString(firstDefined(item.GETData, item.get_data, item.getData)),
+  raw_data: asString(firstDefined(item.RawData, item.raw_data, item.rawData)),
+  rule_name: asString(firstDefined(item.RuleName, item.rule_name, item.ruleName)),
+  rule_type: asString(firstDefined(item.rule_type, item.RuleType, item.ruleType)),
+  ranking: toInt64(firstDefined(item.Ranking, item.ranking)),
+  description: asString(firstDefined(item.Description, item.description)),
+  solution: asString(firstDefined(item.Solution, item.solution)),
+  raw: jsonStruct(item),
+});
+
+const actionResponse = (json) => {
+  assertBusinessSuccess(json);
+  return {
+    success: json.success !== false,
+    msg: asString(json.msg),
+    code: asString(json.code),
+    raw: jsonStruct(json),
+  };
+};
+
+const listTamperSites = async (req, ctx) => {
+  const call = resolveCallContext(ctx, req);
+  const json = await requestJSON(call, PATH_LIST_TAMPER_SITES, listPagination(req));
+  assertBusinessSuccess(json);
+  const data = Array.isArray(json.data) ? json.data : [];
+  return {
+    success: json.success !== false,
+    msg: asString(json.msg),
+    code: asString(json.code),
+    total_amount: toInt64(json.totalAmount),
+    sites: data.map(mapTamperSite),
+    raw: jsonStruct(json),
+  };
+};
+
+const createTamperSite = async (req, ctx) => {
+  const call = resolveCallContext(ctx, req);
+  const json = await requestJSON(call, PATH_CREATE_TAMPER_SITE, siteMutationFields(req));
+  assertBusinessSuccess(json);
+  return {
+    success: json.success !== false,
+    msg: asString(json.msg),
+    code: asString(json.code),
+    inserted_id: asString(firstDefined(json.insertedId, json.id)),
+    raw: jsonStruct(json),
+  };
+};
+
+const updateTamperSite = async (req, ctx) => {
+  const call = resolveCallContext(ctx, req);
+  const site = req.site || {};
+  const json = await requestJSON(call, PATH_UPDATE_TAMPER_SITE, siteMutationFields(site, { includeId: true, id: req.id }));
+  assertBusinessSuccess(json);
+  return {
+    success: json.success !== false,
+    msg: asString(json.msg),
+    code: asString(json.code),
+    id: asString(json.id),
+    inserted_id: asString(json.insertedId),
+    raw: jsonStruct(json),
+  };
+};
+
+const tamperAction = (path) => async (req, ctx) => {
+  const call = resolveCallContext(ctx, req);
+  const json = await requestJSON(call, path, { ids: idsToCSV(req.ids) });
+  return actionResponse(json);
+};
+
+const intrusionFilterFields = (req = {}) => {
+  const fields = {};
+  const mapping = {
+    view_mode: 'view_mode',
+    timestamp: 'timestamp',
+    src_ip: 'SrcIp',
+    src_port: 'SrcPort',
+    dst_ip: 'DstIp',
+    dst_port: 'DstPort',
+    sid_start: 'sid_start',
+    sid_end: 'sid_end',
+    action_type: 'ActionType',
+    length_type: 'length_type',
+    data_len: 'DataLen',
+    http_protocol: 'HttpProtocol',
+    get_data: 'GETData',
+  };
+  for (const [from, to] of Object.entries(mapping)) {
+    const value = pick(req, [from, to]);
+    if (value === undefined || value === null || value === '') continue;
+    fields[to] = unwrap(value);
+  }
+  fields.start = asInt(firstDefined(req.start, 0), 'start', { min: 0 });
+  fields.limit = asInt(firstDefined(req.limit, DEFAULT_LIMIT), 'limit', { min: 1 });
+  return fields;
+};
+
+const listIntrusionLogs = async (req, ctx) => {
+  const call = resolveCallContext(ctx, req);
+  const json = await requestJSON(call, PATH_LIST_INTRUSION_LOGS, intrusionFilterFields(req));
+  assertBusinessSuccess(json);
+  const data = Array.isArray(json.data) ? json.data : [];
+  return {
+    success: json.success !== false,
+    msg: asString(json.msg),
+    code: asString(json.code),
+    total_amount: toInt64(json.totalAmount),
+    logs: data.map(mapIntrusionLog),
+    raw: jsonStruct(json),
+  };
+};
+
+const deleteIntrusionLogs = async (req, ctx) => {
+  const call = resolveCallContext(ctx, req);
+  const timestamp = asString(req.timestamp);
+  if (!timestamp) throw errorWithCode('INVALID_ARGUMENT', 'timestamp is required');
+  const fields = {
+    view_mode: asString(req.view_mode),
+    timestamp,
+  };
+  const ids = Array.isArray(req.ids) && req.ids.length > 0 ? idsToCSV(req.ids) : '';
+  const idList = asString(req.id_list);
+  if (!ids && !idList) throw errorWithCode('INVALID_ARGUMENT', 'ids or id_list is required');
+  if (ids) fields.ids = ids;
+  if (idList) fields.id_list = idList;
+  const json = await requestJSON(call, PATH_DELETE_INTRUSION_LOGS, fields);
+  return actionResponse(json);
+};
+
+const countIntrusionLogs = async (req, ctx) => {
+  const call = resolveCallContext(ctx, req);
+  const date = asString(req.date);
+  if (!DATE_RE.test(date)) throw errorWithCode('INVALID_ARGUMENT', 'date must be yyyy-MM-dd');
+  const json = await requestJSON(call, PATH_COUNT_INTRUSION_LOGS, { date }, { query: { date } });
+  assertBusinessSuccess(json);
+  return {
+    success: json.success !== false,
+    msg: asString(json.msg),
+    code: asString(json.code),
+    count: toInt64(json.count),
+    raw: jsonStruct(json),
+  };
+};
+
+export const handlers = {
+  [METHOD_LIST_TAMPER_SITES]: listTamperSites,
+  [METHOD_CREATE_TAMPER_SITE]: createTamperSite,
+  [METHOD_UPDATE_TAMPER_SITE]: updateTamperSite,
+  [METHOD_DELETE_TAMPER_SITES]: tamperAction(PATH_DELETE_TAMPER_SITES),
+  [METHOD_ENABLE_TAMPER_SITES]: tamperAction(PATH_ENABLE_TAMPER_SITES),
+  [METHOD_DISABLE_TAMPER_SITES]: tamperAction(PATH_DISABLE_TAMPER_SITES),
+  [METHOD_REBUILD_TAMPER_BACKUPS]: tamperAction(PATH_REBUILD_TAMPER_BACKUPS),
+  [METHOD_LIST_INTRUSION_LOGS]: listIntrusionLogs,
+  [METHOD_DELETE_INTRUSION_LOGS]: deleteIntrusionLogs,
+  [METHOD_COUNT_INTRUSION_LOGS]: countIntrusionLogs,
+};
+
+export const _test = {
+  actionResponse,
+  asInt,
+  buildTlsOptions,
+  buildAuthorization,
+  formBody,
+  handlers,
+  intrusionFilterFields,
+  listPagination,
+  mapIntrusionLog,
+  mapTamperSite,
+  mergedBindings,
+  normalizeBaseUrl,
+  parseHeaders,
+  resolveCallContext,
+  sign,
+  siteMutationFields,
+};

--- a/services/yxlink__waf/test/mock_upstream.js
+++ b/services/yxlink__waf/test/mock_upstream.js
@@ -1,0 +1,43 @@
+import http from 'node:http';
+
+const json = (res, status, body) => {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+};
+
+export const startMockUpstream = () => {
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf8');
+      requests.push({ method: req.method, url: req.url, headers: req.headers, body });
+      if (!req.headers.authorization) {
+        json(res, 401, { success: false, msg: 'auth_failed', code: 'e8000' });
+        return;
+      }
+      if (req.url?.startsWith('/api/tamperresistance/tamperresistanceforweb/paginate')) {
+        json(res, 200, { success: true, totalAmount: 0, data: [] });
+        return;
+      }
+      if (req.url?.startsWith('/api/intrusionprevention/intrusionlog/count')) {
+        json(res, 200, { success: true, msg: 'success', count: 0 });
+        return;
+      }
+      json(res, 200, { success: true, msg: 'success' });
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve({
+        url: `http://127.0.0.1:${address.port}`,
+        requests,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+};

--- a/services/yxlink__waf/test/yxlink-waf.test.js
+++ b/services/yxlink__waf/test/yxlink-waf.test.js
@@ -1,0 +1,291 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  METHOD_COUNT_INTRUSION_LOGS,
+  METHOD_CREATE_TAMPER_SITE,
+  METHOD_DELETE_INTRUSION_LOGS,
+  METHOD_ENABLE_TAMPER_SITES,
+  METHOD_LIST_INTRUSION_LOGS,
+  METHOD_LIST_TAMPER_SITES,
+  METHOD_UPDATE_TAMPER_SITE,
+  PATH_COUNT_INTRUSION_LOGS,
+  PATH_CREATE_TAMPER_SITE,
+  PATH_DELETE_INTRUSION_LOGS,
+  PATH_ENABLE_TAMPER_SITES,
+  PATH_LIST_INTRUSION_LOGS,
+  PATH_LIST_TAMPER_SITES,
+  PATH_UPDATE_TAMPER_SITE,
+  _test,
+  handlers,
+} from '../src/yxlink-waf.js';
+
+const buildCtx = (overrides = {}) => ({
+  config: { host: 'https://waf.example.com', ...overrides.config },
+  secret: { appId: 'app-1', appSecret: 'secret-1', ...overrides.secret },
+  bindings: overrides.bindings ?? {},
+  limits: { timeoutMs: 10_000, ...overrides.limits },
+  meta: { instance_id: 'inst-1', request_id: 'req-1', ...overrides.meta },
+});
+
+const decodeAuth = (headers) => JSON.parse(Buffer.from(headers.Authorization, 'base64').toString('utf8'));
+
+const bodyEntries = (body) => Object.fromEntries([...body.entries()].map(([key, value]) => [key, String(value)]));
+
+const mockJSON = (impl) => {
+  global.fetch = async (url, init) => {
+    const json = await impl(url, init);
+    return {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(json),
+    };
+  };
+};
+
+test('sign builds deterministic SHA1 signature and Authorization payload', () => {
+  assert.equal(
+    _test.sign('app', 'secret', 'nonce', 1700000000),
+    '73ebc31e4af02a9ae9936209f3e724e79e2629fb',
+  );
+  const auth = _test.buildAuthorization('app', 'secret', 'nonce', 1700000000);
+  assert.deepEqual(JSON.parse(Buffer.from(auth, 'base64').toString('utf8')), {
+    appId: 'app',
+    nonceStr: 'nonce',
+    timestamp: '1700000000',
+    signature: '73ebc31e4af02a9ae9936209f3e724e79e2629fb',
+  });
+});
+
+test('ListTamperSites posts signed form data and maps records', async () => {
+  let captured;
+  mockJSON((url, init) => {
+    captured = { url, init, body: bodyEntries(init.body), auth: decodeAuth(init.headers) };
+    return {
+      success: true,
+      totalAmount: 1,
+      data: [{
+        id: '7',
+        website: 'portal',
+        start: '1',
+        address: '10.0.0.1',
+        port: '21',
+        connect: '1',
+        quickdiff: '120',
+        maxsize: '1024',
+      }],
+    };
+  });
+
+  const res = await handlers[METHOD_LIST_TAMPER_SITES]({ start: 5, limit: 10 }, buildCtx());
+
+  assert.equal(new URL(captured.url).pathname, PATH_LIST_TAMPER_SITES);
+  assert.deepEqual(captured.body, { start: '5', limit: '10' });
+  assert.equal(captured.auth.appId, 'app-1');
+  assert.equal(res.total_amount, 1);
+  assert.equal(res.sites[0].id, '7');
+  assert.equal(res.sites[0].start, true);
+  assert.equal(res.sites[0].port, 21);
+});
+
+test('CreateTamperSite and UpdateTamperSite validate and map mutation fields', async () => {
+  let createBody;
+  mockJSON((url, init) => {
+    createBody = bodyEntries(init.body);
+    assert.equal(new URL(url).pathname, PATH_CREATE_TAMPER_SITE);
+    return { success: true, insertedId: 34 };
+  });
+
+  const create = await handlers[METHOD_CREATE_TAMPER_SITE]({
+    website: 'portal',
+    description: 'main site',
+    start: true,
+    schedule: 1,
+    address: '127.0.0.1',
+    filecharset: 'gbk',
+    username: 'anonymous',
+    password: 'password',
+    connect: 1,
+    port: 21,
+    folder: '/',
+    parallel: 5,
+    quickdiff: 120,
+    maxsize: 10240000,
+    exclude: '*.tmp',
+  }, buildCtx());
+
+  assert.equal(create.inserted_id, '34');
+  assert.equal(createBody.website, 'portal');
+  assert.equal(createBody.start, '1');
+  assert.equal(createBody.port, '21');
+
+  let updateBody;
+  mockJSON((url, init) => {
+    updateBody = bodyEntries(init.body);
+    assert.equal(new URL(url).pathname, PATH_UPDATE_TAMPER_SITE);
+    return { success: true, insertedId: 7 };
+  });
+
+  const update = await handlers[METHOD_UPDATE_TAMPER_SITE]({
+    id: '7',
+    site: {
+      website: 'portal',
+      start: false,
+      address: '127.0.0.1',
+      filecharset: 'utf8',
+      username: 'admin',
+      connect: 2,
+      port: 22,
+      quickdiff: 60,
+      maxsize: 2048,
+    },
+  }, buildCtx());
+
+  assert.equal(update.inserted_id, '7');
+  assert.equal(updateBody.id, '7');
+  assert.equal(updateBody.start, '0');
+  assert.equal(updateBody.filecharset, 'utf8');
+
+  await assert.rejects(
+    () => handlers[METHOD_CREATE_TAMPER_SITE]({ website: 'bad' }, buildCtx()),
+    /port is required/,
+  );
+});
+
+test('Tamper action methods send comma-joined ids and map business failure', async () => {
+  let captured;
+  mockJSON((url, init) => {
+    captured = { url, body: bodyEntries(init.body) };
+    return { success: true, msg: 'success' };
+  });
+
+  const res = await handlers[METHOD_ENABLE_TAMPER_SITES]({ ids: ['2', '3'] }, buildCtx());
+  assert.equal(new URL(captured.url).pathname, PATH_ENABLE_TAMPER_SITES);
+  assert.deepEqual(captured.body, { ids: '2,3' });
+  assert.equal(res.success, true);
+
+  mockJSON(() => ({ success: false, msg: 'auth_failed', code: 'e8000' }));
+  await assert.rejects(
+    () => handlers[METHOD_ENABLE_TAMPER_SITES]({ ids: ['2'] }, buildCtx()),
+    /UNAUTHENTICATED: auth_failed/,
+  );
+});
+
+test('ListIntrusionLogs maps filters and response records', async () => {
+  let captured;
+  mockJSON((url, init) => {
+    captured = { url, body: bodyEntries(init.body) };
+    return {
+      success: true,
+      totalAmount: 1,
+      data: [{
+        HackId: '18',
+        HackTime: '2020-03-13 14:41:43',
+        SrcIp: '192.168.88.200',
+        DstIp: '192.168.98.51',
+        DataLen: '497',
+        SrcPort: '36885',
+        DstPort: '80',
+        BlockReason: 7000001,
+        ActionType: 'D',
+        HttpProtocol: 'GET',
+        GETData: 'http%3A%2F%2Fexample.com',
+      }],
+    };
+  });
+
+  const res = await handlers[METHOD_LIST_INTRUSION_LOGS]({
+    view_mode: 'normal',
+    timestamp: '2020-03-13',
+    src_ip: '192.168.88.200',
+    action_type: 'D',
+    start: 0,
+    limit: 30,
+  }, buildCtx());
+
+  assert.equal(new URL(captured.url).pathname, PATH_LIST_INTRUSION_LOGS);
+  assert.equal(captured.body.SrcIp, '192.168.88.200');
+  assert.equal(captured.body.ActionType, 'D');
+  assert.equal(res.total_amount, 1);
+  assert.equal(res.logs[0].hack_id, '18');
+  assert.equal(res.logs[0].data_len, 497);
+});
+
+test('DeleteIntrusionLogs and CountIntrusionLogs validate required fields', async () => {
+  let deleteBody;
+  mockJSON((url, init) => {
+    deleteBody = bodyEntries(init.body);
+    assert.equal(new URL(url).pathname, PATH_DELETE_INTRUSION_LOGS);
+    return { success: true, msg: 'success' };
+  });
+
+  await handlers[METHOD_DELETE_INTRUSION_LOGS]({
+    ids: ['16_2020-03-13', '13_2020-03-13'],
+    view_mode: 'normal',
+    timestamp: '2020-03-13',
+  }, buildCtx());
+  assert.equal(deleteBody.ids, '16_2020-03-13,13_2020-03-13');
+  assert.equal(deleteBody.timestamp, '2020-03-13');
+
+  let countUrl;
+  mockJSON((url, init) => {
+    countUrl = new URL(url);
+    assert.equal(countUrl.pathname, PATH_COUNT_INTRUSION_LOGS);
+    assert.equal(bodyEntries(init.body).date, '2024-08-29');
+    return { success: true, msg: 'success', count: 21368 };
+  });
+
+  const count = await handlers[METHOD_COUNT_INTRUSION_LOGS]({ date: '2024-08-29' }, buildCtx());
+  assert.equal(countUrl.searchParams.get('date'), '2024-08-29');
+  assert.equal(count.count, 21368);
+
+  await assert.rejects(
+    () => handlers[METHOD_COUNT_INTRUSION_LOGS]({ date: '20240829' }, buildCtx()),
+    /date must be yyyy-MM-dd/,
+  );
+  await assert.rejects(
+    () => handlers[METHOD_DELETE_INTRUSION_LOGS]({ timestamp: '2020-03-13' }, buildCtx()),
+    /ids or id_list is required/,
+  );
+});
+
+test('HTTP failures and config validation map to gRPC style errors', async () => {
+  await assert.rejects(
+    () => handlers[METHOD_LIST_TAMPER_SITES]({}, buildCtx({ config: { host: 'ftp://bad' } })),
+    /host\/baseUrl is required/,
+  );
+
+  global.fetch = async () => ({
+    ok: false,
+    status: 500,
+    text: async () => 'boom',
+  });
+  await assert.rejects(
+    () => handlers[METHOD_LIST_TAMPER_SITES]({}, buildCtx()),
+    /UNAVAILABLE: upstream http 500: boom/,
+  );
+
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    text: async () => 'not-json',
+  });
+  await assert.rejects(
+    () => handlers[METHOD_LIST_TAMPER_SITES]({}, buildCtx()),
+    /UNKNOWN: response is not valid JSON/,
+  );
+});
+
+test('skipTlsVerify sets compatible fetch TLS flags', async () => {
+  let captured;
+  mockJSON((url, init) => {
+    captured = init;
+    return { success: true, totalAmount: 0, data: [] };
+  });
+
+  await handlers[METHOD_LIST_TAMPER_SITES]({}, buildCtx({ config: { skipTlsVerify: true } }));
+  assert.equal(captured.skipTlsVerify, true);
+  assert.equal(captured.tlsInsecureSkipVerify, true);
+  assert.equal(captured.insecureSkipVerify, true);
+  assert.deepEqual(_test.buildTlsOptions(false), {});
+});


### PR DESCRIPTION
## Summary
- add a new `yxlink-waf` OctoBus service package for YXLink WAF external API v2.1/v2.2 style interfaces
- implement signed Authorization header auth, Web tamper resistance management, and intrusion log list/delete/count methods
- wire the service into the root tentacles dispatcher/package metadata and add mock-based tests plus README risk/capset notes

## Methods
- `ListTamperSites`, `CreateTamperSite`, `UpdateTamperSite`, `DeleteTamperSites`
- `EnableTamperSites`, `DisableTamperSites`, `RebuildTamperBackups`
- `ListIntrusionLogs`, `DeleteIntrusionLogs`, `CountIntrusionLogs`

## Tests
- `cd services && npm run validate -- --service-dir yxlink__waf`
- `cd services && npm test -- --service-dir yxlink__waf`
- `cd services && npm run import:check`
- `cd services && npm run pack:check`

## Notes
- API mapping was implemented from the provided YXLink WAF API document.
- No production address, token, cookie, or real credential is included.
- Real-device verification was not performed in this local environment; tests use a mock upstream.

Closes #216