### PR TITLE
Add security and compliance contact information

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,3 +488,9 @@ go test ./tests/e2e -count=1
 End-to-end tests build the real `octobus` binary, start a real daemon, call the admin API through the CLI, and then verify the gRPC, Connect RPC, MCP, OpenAPI, and reflection endpoints.
 
 The default GitHub Actions CI is a lightweight validation: it checks public traces, Go formatting and vet, runs `go test ./cmd/... ./internal/...`, builds the binary, checks the OctoBus npm binary packages, and runs npm test/build/pack dry-run under `sdk`. Full `task test` and e2e remain local gates. OctoBus binary package publishing is triggered only by `v<version>` tag push builds, and the tag version must match `npm/octobus/package.json.version`. SDK publishing is triggered only by `sdk-v<version>` tag push builds, and the tag version must match `sdk/package.json.version`. Both npm publishing paths require the repository secret `NPM_TOKEN`.
+
+## Security And Compliance
+
+If you believe this repository contains a security vulnerability, infringing content, or another compliance risk, please report it privately to `octobus-opensource@chaitin.com`.
+
+For the full reporting process and required details, see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+If you discover a security vulnerability, suspected infringement, or another compliance concern in this repository, please report it privately to `octobus-opensource@chaitin.com`.
+
+Please include the following details where possible:
+
+- Repository URL and relevant branch, tag, commit, or pull request
+- Affected files, components, or features
+- A clear description of the issue
+- Reproduction steps, logs, screenshots, or supporting evidence
+- Any proposed mitigation or urgency assessment
+
+We typically respond to new reports within 3 business days and will review them as quickly as possible.
+
+Please do not disclose unpatched vulnerabilities or sensitive compliance concerns publicly before we have had a chance to investigate and respond.
+
+If you are unsure whether an issue should be reported here, contact `octobus-opensource@chaitin.com` first and we will route it internally.


### PR DESCRIPTION
## Summary

- add a security and compliance contact section to `README.md`
- add `SECURITY.md` with the reporting process and contact email
- document `octobus-opensource@chaitin.com` as the contact address

## Notes

- this change only appends a new contact section to the existing `README.md`
- existing repository content is left unchanged
- `SECURITY.md` uses a response expectation of typically within 3 business days
- this PR only adds the feedback channel and does not change the repository's existing license boundaries