### PR TITLE
feat(services): add Alibaba Cloud Container Security (alibaba__sas) service package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "tencentcloud-sdk-nodejs-bh": "^4.1.247"
+  }
+}

--- a/services/alibaba__sas/README.md
+++ b/services/alibaba__sas/README.md
@@ -1,0 +1,160 @@
+# Alibaba Cloud Security Center (Container Security) Service Package
+
+OctoBus service package for [Alibaba Cloud Security Center](https://www.aliyun.com/product/security-center) (云安全中心) container security features.
+
+## Supported Version
+
+Alibaba Cloud SAS API version `2018-12-03`.
+
+## Authentication
+
+Uses [Alibaba Cloud RPC HMAC-SHA1](https://help.aliyun.com/zh/security-center/developer-reference/api-1/) signing with `AccessKeyId` and `AccessKeySecret`.
+
+- **access_key_id** / **accessKeyId**: Alibaba Cloud AccessKey ID.
+- **access_key_secret** / **accessKeySecret**: Alibaba Cloud AccessKey Secret.
+
+Obtain credentials from [Alibaba Cloud RAM](https://ram.console.aliyun.com/manage/accesskey).
+
+## Package Structure
+
+```
+services/alibaba__sas/
+  service.json              — OctoBus service manifest
+  proto/alibaba_sas.proto   — gRPC API definitions
+  config.schema.json        — non-secret configuration schema
+  secret.schema.json        — secret credentials schema
+  src/service.js            — OctoBus SDK defineService wrapper
+  src/alibaba-sas.js        — RPC HMAC-SHA1 signed API implementation
+  bin/alibaba-sas.js        — service-local executable entry point
+  test/alibaba-sas.test.js  — node:test coverage
+  README.md                 — this file
+```
+
+## Configuration
+
+### Config (non-secret fields)
+
+```json
+{
+  "region": "cn-hangzhou",
+  "endpoint": "sas.aliyuncs.com",
+  "timeoutMs": 10000,
+  "skipTlsVerify": false
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `region` | `cn-hangzhou` | Alibaba Cloud region |
+| `endpoint` | `sas.aliyuncs.com` | API endpoint hostname |
+| `timeoutMs` | `10000` | HTTP request timeout (ms) |
+| `skipTlsVerify` | `false` | Skip TLS verification |
+
+### Secret (sensitive fields)
+
+```json
+{
+  "access_key_id": "your-access-key-id",
+  "access_key_secret": "your-access-key-secret"
+}
+```
+
+Both `snake_case` and `camelCase` field names are accepted.
+
+## Import
+
+```bash
+octobus service import --id alibaba-sas ./services//alibaba__sas
+```
+
+## RPC Methods
+
+| gRPC Method | CLI Command | Description |
+|-------------|-------------|-------------|
+| `Alibaba_SAS.Alibaba_SAS/ListContainerInstances` | `list-container-instances` | List container instances |
+| `Alibaba_SAS.Alibaba_SAS/ListImageInstances` | `list-image-instances` | List container image instances |
+| `Alibaba_SAS.Alibaba_SAS/ListImageVulnerabilities` | `list-image-vulnerabilities` | List container image vulnerabilities |
+| `Alibaba_SAS.Alibaba_SAS/GetClusterSuspEventStatistics` | `get-cluster-susp-event-statistics` | Get cluster security event statistics |
+| `Alibaba_SAS.Alibaba_SAS/ListClusterInterceptionConfig` | `list-cluster-interception-config` | List cluster interception rules |
+
+### Container Instance Management
+
+**ListContainerInstances** — Query container instances with search criteria:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `current_page` | int64 | Page number (1-based) |
+| `page_size` | int64 | Page size (default 20, max 200) |
+| `criteria` | string | Search criteria (e.g., `cluster:k8s-prod`, `namespace:default`) |
+| `logical_exp` | string | Logical operator: `AND` or `OR` |
+
+### Image Management
+
+**ListImageInstances** — Query container image instances:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `current_page` | int64 | Page number |
+| `page_size` | int64 | Page size |
+| `criteria` | string | Search criteria |
+| `logical_exp` | string | Logical operator |
+
+### Vulnerability Management
+
+**ListImageVulnerabilities** — Query image vulnerabilities:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `image_uuid` | string | Yes | Image UUID to query |
+| `current_page` | int64 | No | Page number |
+| `page_size` | int64 | No | Page size |
+| `name` | string | No | Filter by vulnerability name |
+| `level` | string | No | Filter by level: `high`, `medium`, `low` |
+| `vul_type` | string | No | Filter by type: `sca`, `cve` |
+
+### Security Event Statistics
+
+**GetClusterSuspEventStatistics** — Get cluster security event statistics (no parameters).
+
+### Interception Configuration
+
+**ListClusterInterceptionConfig** — List cluster interception rules:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `cluster_id` | string | Filter by cluster ID |
+| `current_page` | int64 | Page number |
+| `page_size` | int64 | Page size |
+
+## Behavior Notes
+
+- All API calls use **POST** to `sas.aliyuncs.com` with HMAC-SHA1 RPC signing.
+- HTTP 401 maps to `UNAUTHENTICATED`; HTTP 403 maps to `PERMISSION_DENIED`.
+- Other HTTP 4xx maps to `FAILED_PRECONDITION`.
+- HTTP 5xx and network errors map to `UNAVAILABLE`.
+- Alibaba Cloud API `InvalidAccessKeyId` / `SignatureDoesNotMatch` map to `UNAUTHENTICATED`.
+- Non-JSON responses map to `UNKNOWN`.
+- Missing credentials map to `FAILED_PRECONDITION`.
+- Missing required request parameters (e.g., `image_uuid`) map to `INVALID_ARGUMENT`.
+
+## Risk & Recommended Capset
+
+**Risk**: All operations are read-only queries. No write operations are implemented.
+
+**Recommended `capset`**: `["recon"]`
+
+## Validation
+
+```bash
+cd services
+npm run validate -- --service-dir alibaba__sas
+npm test -- --service-dir alibaba__sas --coverage
+npm run pack:check
+```
+
+## Known Limitations
+
+1. Pagination results may require multiple calls for large datasets.
+2. The `criteria` search syntax depends on the Alibaba Cloud SAS API implementation.
+3. Write operations (e.g., vulnerability fix, container block) are not yet implemented.
+4. Response field names may vary between Alibaba Cloud SAS API versions.

--- a/services/alibaba__sas/bin/alibaba-sas.js
+++ b/services/alibaba__sas/bin/alibaba-sas.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+import { runServiceMain } from '@chaitin-ai/octobus-sdk';
+
+import { service } from '../src/service.js';
+
+runServiceMain(service);

--- a/services/alibaba__sas/config.schema.json
+++ b/services/alibaba__sas/config.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "region": {
+      "type": "string",
+      "default": "cn-hangzhou",
+      "description": "Alibaba Cloud region, e.g. cn-hangzhou, cn-beijing, ap-southeast-1."
+    },
+    "endpoint": {
+      "type": "string",
+      "default": "sas.aliyuncs.com",
+      "description": "Alibaba Cloud Security Center API endpoint hostname."
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 10000,
+      "description": "HTTP request timeout in milliseconds."
+    },
+    "skipTlsVerify": {
+      "type": "boolean",
+      "default": false,
+      "description": "Skip TLS certificate verification."
+    }
+  }
+}

--- a/services/alibaba__sas/package.json
+++ b/services/alibaba__sas/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "alibaba-sas",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@chaitin-ai/octobus-sdk": "^0.5.0"
+  }
+}

--- a/services/alibaba__sas/proto/alibaba_sas.proto
+++ b/services/alibaba__sas/proto/alibaba_sas.proto
@@ -1,0 +1,178 @@
+syntax = "proto3";
+
+package Alibaba_SAS;
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+option go_package = "miner/grpc-service/Alibaba_SAS";
+
+service Alibaba_SAS {
+  // 查询容器实例列表
+  rpc ListContainerInstances(ListContainerInstancesRequest) returns (ListContainerInstancesResponse) {}
+  // 查询镜像实例列表
+  rpc ListImageInstances(ListImageInstancesRequest) returns (ListImageInstancesResponse) {}
+  // 查询镜像漏洞列表
+  rpc ListImageVulnerabilities(ListImageVulnerabilitiesRequest) returns (ListImageVulnerabilitiesResponse) {}
+  // 查询集群安全事件统计
+  rpc GetClusterSuspEventStatistics(GetClusterSuspEventStatisticsRequest) returns (GetClusterSuspEventStatisticsResponse) {}
+  // 查询集群拦截规则列表
+  rpc ListClusterInterceptionConfig(ListClusterInterceptionConfigRequest) returns (ListClusterInterceptionConfigResponse) {}
+}
+
+// ── 容器实例 ─────────────────────────────────────────────
+
+message ListContainerInstancesRequest {
+  // 当前页码，从 1 开始
+  google.protobuf.Int64Value current_page = 1;
+  // 每页数量，默认 20，最大 200
+  google.protobuf.Int64Value page_size = 2;
+  // 搜索条件（容器 ID、名称、IP、集群等）
+  string criteria = 3;
+  // 搜索条件的逻辑操作符：AND / OR
+  string logical_exp = 4;
+}
+
+message ListContainerInstancesResponse {
+  repeated ContainerInstanceRecord items = 1;
+  int64 total_count = 2;
+}
+
+message ContainerInstanceRecord {
+  // 容器实例 ID
+  string instance_id = 1;
+  // 容器名称
+  string container_name = 2;
+  // 容器状态
+  string status = 3;
+  // 镜像名称
+  string image_name = 4;
+  // 集群名称
+  string cluster_name = 5;
+  // 集群 ID
+  string cluster_id = 6;
+  // Pod 名称
+  string pod_name = 7;
+  // 命名空间
+  string namespace = 8;
+  // 节点 IP
+  string node_ip = 9;
+  // Pod IP
+  string pod_ip = 10;
+  // 风险等级
+  string risk_level = 11;
+}
+
+// ── 镜像实例 ─────────────────────────────────────────────
+
+message ListImageInstancesRequest {
+  google.protobuf.Int64Value current_page = 1;
+  google.protobuf.Int64Value page_size = 2;
+  // 搜索条件（镜像 ID、标签、仓库等）
+  string criteria = 3;
+  // 搜索条件的逻辑操作符
+  string logical_exp = 4;
+}
+
+message ListImageInstancesResponse {
+  repeated ImageInstanceRecord items = 1;
+  int64 total_count = 2;
+}
+
+message ImageInstanceRecord {
+  // 镜像 UUID
+  string image_uuid = 1;
+  // 镜像标签
+  string image_tag = 2;
+  // 镜像 Digest
+  string digest = 3;
+  // 镜像仓库名称
+  string repo_name = 4;
+  // 镜像仓库命名空间
+  string repo_namespace = 5;
+  // 镜像地域
+  string region = 6;
+  // 镜像大小（字节）
+  int64 image_size = 7;
+  // 漏洞数量
+  int64 vul_count = 8;
+  // 告警数量
+  int64 alarm_count = 9;
+  // 风险等级：high / medium / low
+  string risk_level = 10;
+}
+
+// ── 镜像漏洞 ─────────────────────────────────────────────
+
+message ListImageVulnerabilitiesRequest {
+  // 镜像 UUID（必填）
+  string image_uuid = 1;
+  google.protobuf.Int64Value current_page = 2;
+  google.protobuf.Int64Value page_size = 3;
+  // 漏洞名称模糊搜索
+  string name = 4;
+  // 漏洞等级：high / medium / low
+  string level = 5;
+  // 漏洞类型：sca / cve
+  string vul_type = 6;
+}
+
+message ListImageVulnerabilitiesResponse {
+  repeated ImageVulnerabilityRecord items = 1;
+  int64 total_count = 2;
+}
+
+message ImageVulnerabilityRecord {
+  // 漏洞名称
+  string name = 1;
+  // 漏洞别名
+  string alias_name = 2;
+  // CVE ID
+  string cve_id = 3;
+  // 漏洞等级
+  string level = 4;
+  // 漏洞类型
+  string type = 5;
+  // 修复版本
+  string fix_version = 6;
+  // 是否已修复
+  bool is_fixed = 7;
+  // 首次发现时间
+  string first_found_time = 8;
+}
+
+// ── 集群安全事件统计 ─────────────────────────────────────
+
+message GetClusterSuspEventStatisticsRequest {
+}
+
+message GetClusterSuspEventStatisticsResponse {
+  google.protobuf.Struct statistics = 1;
+}
+
+// ── 集群拦截规则 ─────────────────────────────────────────
+
+message ListClusterInterceptionConfigRequest {
+  // 集群 ID
+  string cluster_id = 1;
+  google.protobuf.Int64Value current_page = 2;
+  google.protobuf.Int64Value page_size = 3;
+}
+
+message ListClusterInterceptionConfigResponse {
+  repeated ClusterInterceptionConfigRecord items = 1;
+  int64 total_count = 2;
+}
+
+message ClusterInterceptionConfigRecord {
+  // 集群名称
+  string cluster_name = 1;
+  // 集群 ID
+  string cluster_id = 2;
+  // 拦截类型
+  string intercept_type = 3;
+  // 规则数量
+  int64 rule_count = 4;
+  // 拦截状态：0 关闭，1 开启
+  int32 state = 5;
+}

--- a/services/alibaba__sas/secret.schema.json
+++ b/services/alibaba__sas/secret.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "access_key_id": {
+      "type": "string",
+      "description": "Alibaba Cloud AccessKey ID."
+    },
+    "accessKeyId": {
+      "type": "string",
+      "description": "Alias for access_key_id."
+    },
+    "access_key_secret": {
+      "type": "string",
+      "description": "Alibaba Cloud AccessKey Secret."
+    },
+    "accessKeySecret": {
+      "type": "string",
+      "description": "Alias for access_key_secret."
+    }
+  }
+}

--- a/services/alibaba__sas/service.json
+++ b/services/alibaba__sas/service.json
@@ -1,0 +1,45 @@
+{
+  "schema": "chaitin.octobus.service.v1",
+  "name": "alibaba-sas",
+  "displayName": "Alibaba Cloud Security Center (Container Security)",
+  "description": "OctoBus package for Alibaba Cloud Security Center container security APIs: container/image instance query, vulnerability listing, cluster security event statistics.",
+  "runtime": {
+    "mode": "long-running"
+  },
+  "proto": {
+    "roots": [
+      "proto"
+    ],
+    "files": [
+      "proto/alibaba_sas.proto"
+    ]
+  },
+  "configSchema": "config.schema.json",
+  "secretSchema": "secret.schema.json",
+  "sdk": {
+    "cli": {
+      "commands": {
+        "Alibaba_SAS.Alibaba_SAS/ListContainerInstances": {
+          "name": "list-container-instances",
+          "description": "List Alibaba Cloud container instances."
+        },
+        "Alibaba_SAS.Alibaba_SAS/ListImageInstances": {
+          "name": "list-image-instances",
+          "description": "List container image instances."
+        },
+        "Alibaba_SAS.Alibaba_SAS/ListImageVulnerabilities": {
+          "name": "list-image-vulnerabilities",
+          "description": "List container image vulnerabilities."
+        },
+        "Alibaba_SAS.Alibaba_SAS/GetClusterSuspEventStatistics": {
+          "name": "get-cluster-susp-event-statistics",
+          "description": "Get cluster security event statistics."
+        },
+        "Alibaba_SAS.Alibaba_SAS/ListClusterInterceptionConfig": {
+          "name": "list-cluster-interception-config",
+          "description": "List cluster interception rules."
+        }
+      }
+    }
+  }
+}

--- a/services/alibaba__sas/src/alibaba-sas.js
+++ b/services/alibaba__sas/src/alibaba-sas.js
@@ -1,0 +1,497 @@
+// Alibaba Cloud Security Center (SAS) Container Security API implementation
+// Uses Alibaba Cloud RPC HMAC-SHA1 signing.
+//
+// API version: 2018-12-03
+// Endpoint: sas.aliyuncs.com
+
+import crypto from 'node:crypto';
+import { GrpcError, grpcStatus } from '@chaitin-ai/octobus-sdk';
+
+// ── Constants ──────────────────────────────────────────────
+
+const SERVICE_NAME = 'Alibaba_SAS';
+const API_VERSION = '2018-12-03';
+const DEFAULT_REGION = 'cn-hangzhou';
+const DEFAULT_ENDPOINT = 'sas.aliyuncs.com';
+const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 200;
+
+// ── Method paths ───────────────────────────────────────────
+
+export const LIST_CONTAINER_INSTANCES_PATH = '/Alibaba_SAS.Alibaba_SAS/ListContainerInstances';
+export const LIST_IMAGE_INSTANCES_PATH = '/Alibaba_SAS.Alibaba_SAS/ListImageInstances';
+export const LIST_IMAGE_VULNS_PATH = '/Alibaba_SAS.Alibaba_SAS/ListImageVulnerabilities';
+export const GET_CLUSTER_SUSP_EVENT_STATS_PATH = '/Alibaba_SAS.Alibaba_SAS/GetClusterSuspEventStatistics';
+export const LIST_CLUSTER_INTERCEPTION_CONFIG_PATH = '/Alibaba_SAS.Alibaba_SAS/ListClusterInterceptionConfig';
+
+export const LIST_CONTAINER_INSTANCES_FULL = 'Alibaba_SAS.Alibaba_SAS/ListContainerInstances';
+export const LIST_IMAGE_INSTANCES_FULL = 'Alibaba_SAS.Alibaba_SAS/ListImageInstances';
+export const LIST_IMAGE_VULNS_FULL = 'Alibaba_SAS.Alibaba_SAS/ListImageVulnerabilities';
+export const GET_CLUSTER_SUSP_EVENT_STATS_FULL = 'Alibaba_SAS.Alibaba_SAS/GetClusterSuspEventStatistics';
+export const LIST_CLUSTER_INTERCEPTION_CONFIG_FULL = 'Alibaba_SAS.Alibaba_SAS/ListClusterInterceptionConfig';
+
+// ── Error helpers ──────────────────────────────────────────
+
+const grpcCodeFor = (code) => ({
+  INVALID_ARGUMENT: grpcStatus.INVALID_ARGUMENT,
+  FAILED_PRECONDITION: grpcStatus.FAILED_PRECONDITION,
+  PERMISSION_DENIED: grpcStatus.PERMISSION_DENIED,
+  UNAUTHENTICATED: grpcStatus.UNAUTHENTICATED,
+  UNAVAILABLE: grpcStatus.UNAVAILABLE,
+  UNKNOWN: grpcStatus.UNKNOWN,
+})[code] ?? grpcStatus.UNKNOWN;
+
+const errorWithCode = (code, message) => {
+  const err = new GrpcError(grpcCodeFor(code), `${code}: ${message}`);
+  err.legacyCode = code;
+  return err;
+};
+
+// ── Internal helpers ───────────────────────────────────────
+
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj ?? {}, key);
+
+const firstDefined = (...values) => values.find((v) => v !== undefined && v !== null);
+
+const toTrimmedString = (value) => {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'object' && value !== null && hasOwn(value, 'value')) return toTrimmedString(value.value);
+  return String(value).trim();
+};
+
+const toInt64 = (value) => {
+  if (value === undefined || value === null) return null;
+  const raw = typeof value === 'object' && value !== null && hasOwn(value, 'value') ? value.value : value;
+  if (raw === undefined || raw === null || raw === '') return null;
+  const num = Number(raw);
+  if (!Number.isInteger(num) || Number.isNaN(num)) return null;
+  return num;
+};
+
+const toBoolean = (value) => {
+  if (value === undefined || value === null) return false;
+  const raw = typeof value === 'object' && value !== null && hasOwn(value, 'value') ? value.value : value;
+  if (typeof raw === 'boolean') return raw;
+  if (typeof raw === 'number') return raw !== 0;
+  if (typeof raw === 'string') {
+    const text = raw.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(text)) return true;
+    if (['0', 'false', 'no', 'n', 'off', ''].includes(text)) return false;
+  }
+  return Boolean(raw);
+};
+
+const toValue = (value) => {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') return { stringValue: value };
+  if (typeof value === 'number') return { numberValue: value };
+  if (typeof value === 'boolean') return { boolValue: value };
+  if (Array.isArray(value)) {
+    return { listValue: { values: value.map(toValue).filter((v) => v !== undefined) } };
+  }
+  if (typeof value === 'object') {
+    const fields = {};
+    for (const [key, v] of Object.entries(value)) {
+      fields[key] = toValue(v) ?? { nullValue: 'NULL_VALUE' };
+    }
+    return { structValue: { fields } };
+  }
+  return { stringValue: String(value) };
+};
+
+// ── Alibaba Cloud RPC Signing ──────────────────────────────
+
+const percentEncode = (str) => {
+  return encodeURIComponent(String(str))
+    .replace(/[!*()']/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase())
+    .replace(/%7E/g, '~')
+    .replace(/\+/g, '%20')
+    .replace(/%20/g, '%20'); // already handled above
+};
+
+const signRpc = (params, accessKeySecret) => {
+  const sortedKeys = Object.keys(params).sort();
+  const canonicalizedQueryString = sortedKeys
+    .map((key) => percentEncode(key) + '=' + percentEncode(params[key]))
+    .join('&');
+
+  const stringToSign = 'POST&' + percentEncode('/') + '&' + percentEncode(canonicalizedQueryString);
+
+  const key = accessKeySecret + '&';
+  const signature = crypto.createHmac('sha1', key).update(stringToSign, 'utf8').digest('base64');
+
+  return percentEncode(signature);
+};
+
+const buildCommonParams = (accessKeyId, action) => {
+  const timestamp = new Date().toISOString().replace(/\.\d{3}/, '');
+  return {
+    Format: 'JSON',
+    Version: API_VERSION,
+    AccessKeyId: accessKeyId,
+    SignatureMethod: 'HMAC-SHA1',
+    Timestamp: timestamp,
+    SignatureVersion: '1.0',
+    SignatureNonce: String(Date.now()) + Math.random().toString(36).substring(2, 8),
+    Action: action,
+  };
+};
+
+// ── Binding and context resolution ─────────────────────────
+
+const mergedBindings = (ctx = {}) => ({
+  ...(ctx.config ?? {}),
+  ...(ctx.secret ?? {}),
+  ...(ctx.bindings ?? {}),
+});
+
+const resolveCallContext = (ctx = {}) => ({
+  ...ctx,
+  bindings: mergedBindings(ctx),
+  limits: ctx.limits ?? {},
+  meta: ctx.meta ?? {},
+  req: ctx.req ?? ctx.request ?? {},
+});
+
+const resolveTimeoutMs = (bindings = {}, limits = {}) => {
+  const fromBinding = toInt64(bindings.timeoutMs);
+  if (fromBinding !== null) return fromBinding;
+  const fromLimits = toInt64(limits.timeoutMs);
+  if (fromLimits !== null) return fromLimits;
+  return DEFAULT_TIMEOUT_MS;
+};
+
+const buildLogPrefix = (meta = {}, action) => {
+  const parts = [];
+  if (meta.instance_id || meta.instanceId) parts.push('inst=' + (meta.instance_id || meta.instanceId));
+  if (meta.request_id || meta.requestId) parts.push('req=' + (meta.request_id || meta.requestId));
+  return '[' + SERVICE_NAME + '][' + action + ']' + (parts.length ? '[' + parts.join(' ') + ']' : '');
+};
+
+const logFlow = (meta, action, details) => {
+  const prefix = buildLogPrefix(meta, action);
+  const safe = { ...details };
+  try {
+    console.log(prefix, JSON.stringify(safe));
+  } catch {
+    console.log(prefix, safe);
+  }
+};
+
+// ── Credential extraction ──────────────────────────────────
+
+const resolveCredentials = (bindings = {}) => {
+  const accessKeyId = toTrimmedString(firstDefined(bindings.access_key_id, bindings.accessKeyId));
+  const accessKeySecret = toTrimmedString(firstDefined(bindings.access_key_secret, bindings.accessKeySecret));
+  if (!accessKeyId) throw errorWithCode('FAILED_PRECONDITION', 'binding "access_key_id" or "accessKeyId" is required but not configured');
+  if (!accessKeySecret) throw errorWithCode('FAILED_PRECONDITION', 'binding "access_key_secret" or "accessKeySecret" is required but not configured');
+  return { accessKeyId, accessKeySecret };
+};
+
+const resolveRegion = (bindings = {}) => toTrimmedString(bindings.region) || DEFAULT_REGION;
+
+const resolveEndpoint = (bindings = {}) => toTrimmedString(bindings.endpoint) || DEFAULT_ENDPOINT;
+
+// ── API call ────────────────────────────────────────────────
+
+const callAction = async (ctx, action, apiParams) => {
+  const bindings = mergedBindings(ctx);
+  const credentials = resolveCredentials(bindings);
+  const endpoint = resolveEndpoint(bindings);
+  const timeoutMs = resolveTimeoutMs(bindings, ctx.limits);
+  const meta = ctx.meta || {};
+
+  const commonParams = buildCommonParams(credentials.accessKeyId, action);
+  const allParams = { ...commonParams, ...apiParams };
+  const signature = signRpc(allParams, credentials.accessKeySecret);
+  allParams.Signature = signature;
+
+  // Build POST body
+  const body = Object.entries(allParams)
+    .map(([k, v]) => k + '=' + v)
+    .join('&');
+
+  const url = 'https://' + endpoint + '/';
+
+  logFlow(meta, action + ':start', { endpoint, action });
+
+  let res;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'x-engine-instance': meta.instance_id || meta.instanceId || 'unknown',
+        'x-request-id': meta.request_id || meta.requestId || 'unknown',
+      },
+      body,
+      timeoutMs,
+      ...(toBoolean(bindings.skipTlsVerify) || toBoolean(bindings.tlsInsecureSkipVerify)
+        ? { insecureSkipVerify: true, tlsInsecureSkipVerify: true }
+        : {}),
+    });
+  } catch (err) {
+    const reason = err?.cause?.message || err?.message || 'fetch failed';
+    logFlow(meta, action + ':error', { error: reason });
+    throw errorWithCode('UNAVAILABLE', 'upstream error: ' + reason);
+  }
+
+  const text = await res.text();
+
+  if (res.status === 401) {
+    logFlow(meta, action + ':unauthenticated', { status: res.status });
+    throw errorWithCode('UNAUTHENTICATED', 'upstream http ' + res.status + ': ' + text);
+  }
+
+  if (res.status === 403) {
+    logFlow(meta, action + ':auth-error', { status: res.status });
+    throw errorWithCode('PERMISSION_DENIED', 'upstream http ' + res.status + ': ' + text);
+  }
+
+  if (res.status >= 400 && res.status < 500) {
+    logFlow(meta, action + ':client-error', { status: res.status, response: text });
+    throw errorWithCode('FAILED_PRECONDITION', 'upstream http ' + res.status + ': ' + text);
+  }
+
+  if (res.status >= 500) {
+    logFlow(meta, action + ':server-error', { status: res.status });
+    throw errorWithCode('UNAVAILABLE', 'upstream http ' + res.status + ': ' + text);
+  }
+
+  if (!text.trim()) {
+    throw errorWithCode('UNKNOWN', 'empty response from upstream');
+  }
+
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw errorWithCode('UNKNOWN', 'response is not valid JSON');
+  }
+
+  // Alibaba Cloud API error
+  if (json.Code && json.Code !== '200') {
+    const code = String(json.Code);
+    const msg = String(json.Message || json.message || '');
+    logFlow(meta, action + ':api-error', { code, message: msg });
+
+    if (code === 'InvalidAccessKeyId.NotFound' || code === 'SignatureDoesNotMatch' || code === 'InvalidAccessKeySecret') {
+      throw errorWithCode('UNAUTHENTICATED', 'Alibaba API error: ' + code + ' - ' + msg);
+    }
+    throw errorWithCode('FAILED_PRECONDITION', 'Alibaba API error: ' + code + ' - ' + msg);
+  }
+
+  logFlow(meta, action + ':done', {});
+  return json;
+};
+
+// ── Response mappers ───────────────────────────────────────
+
+const mapContainerInstance = (item) => ({
+  instance_id: String(item?.InstanceId ?? item?.instanceId ?? item?.ContainerId ?? ''),
+  container_name: String(item?.ContainerName ?? item?.containerName ?? ''),
+  status: String(item?.Status ?? item?.status ?? ''),
+  image_name: String(item?.Image ?? item?.image ?? item?.ImageName ?? ''),
+  cluster_name: String(item?.ClusterName ?? item?.clusterName ?? ''),
+  cluster_id: String(item?.ClusterId ?? item?.clusterId ?? ''),
+  pod_name: String(item?.Pod ?? item?.pod ?? item?.PodName ?? ''),
+  namespace: String(item?.Namespace ?? item?.namespace ?? ''),
+  node_ip: String(item?.NodeIp ?? item?.nodeIp ?? item?.NodeIP ?? ''),
+  pod_ip: String(item?.PodIp ?? item?.podIp ?? item?.PodIP ?? ''),
+  risk_level: String(item?.RiskLevel ?? item?.riskLevel ?? ''),
+});
+
+const mapImageInstance = (item) => ({
+  image_uuid: String(item?.ImageUuid ?? item?.imageUuid ?? item?.Uuid ?? ''),
+  image_tag: String(item?.ImageTag ?? item?.imageTag ?? item?.Tag ?? ''),
+  digest: String(item?.Digest ?? item?.digest ?? ''),
+  repo_name: String(item?.RepoName ?? item?.repoName ?? item?.Repository ?? ''),
+  repo_namespace: String(item?.RepoNamespace ?? item?.repoNamespace ?? ''),
+  region: String(item?.Region ?? item?.region ?? item?.RegionId ?? ''),
+  image_size: toInt64(item?.ImageSize ?? item?.imageSize) ?? 0,
+  vul_count: toInt64(item?.VulCount ?? item?.vulCount) ?? 0,
+  alarm_count: toInt64(item?.AlarmCount ?? item?.alarmCount) ?? 0,
+  risk_level: String(item?.RiskLevel ?? item?.riskLevel ?? ''),
+});
+
+const mapImageVulnerability = (item) => ({
+  name: String(item?.Name ?? item?.name ?? ''),
+  alias_name: String(item?.AliasName ?? item?.aliasName ?? ''),
+  cve_id: String(item?.CveId ?? item?.cveId ?? item?.CveID ?? ''),
+  level: String(item?.Level ?? item?.level ?? item?.RiskLevel ?? ''),
+  type: String(item?.Type ?? item?.type ?? ''),
+  fix_version: String(item?.FixVersion ?? item?.fixVersion ?? item?.Fix ?? ''),
+  is_fixed: toBoolean(item?.IsFixed ?? item?.isFixed ?? item?.IsFix ?? false),
+  first_found_time: String(item?.FirstFoundTime ?? item?.firstFoundTime ?? item?.FirstFound ?? ''),
+});
+
+const mapClusterInterceptionConfig = (item) => ({
+  cluster_name: String(item?.ClusterName ?? item?.clusterName ?? ''),
+  cluster_id: String(item?.ClusterId ?? item?.clusterId ?? ''),
+  intercept_type: String(item?.InterceptType ?? item?.interceptType ?? ''),
+  rule_count: toInt64(item?.RuleCount ?? item?.ruleCount) ?? 0,
+  state: toInt64(item?.State ?? item?.state) ?? 0,
+});
+
+// ── Pagination helpers ─────────────────────────────────────
+
+const buildPagination = (req = {}) => {
+  const pageSize = toInt64(firstDefined(req.page_size, req.pageSize, req.PageSize));
+  const currentPage = toInt64(firstDefined(req.current_page, req.currentPage, req.CurrentPage));
+  const result = {};
+  if (currentPage !== null && currentPage > 0) result.CurrentPage = String(currentPage);
+  if (pageSize !== null && pageSize > 0 && pageSize <= MAX_PAGE_SIZE) {
+    result.PageSize = String(pageSize);
+  } else {
+    result.PageSize = String(DEFAULT_PAGE_SIZE);
+  }
+  return result;
+};
+
+const extractList = (json, key) => {
+  const list = json?.[key];
+  if (Array.isArray(list)) return list;
+  return [];
+};
+
+const extractTotal = (json) => {
+  const total = json?.TotalCount ?? json?.totalCount ?? json?.Count;
+  return toInt64(total) ?? 0;
+};
+
+// ── API method implementations ─────────────────────────────
+
+const listContainerInstances = async (req = {}, ctx = {}) => {
+  const apiParams = {
+    ...buildPagination(req),
+  };
+  const criteria = toTrimmedString(firstDefined(req.criteria, req.Criteria));
+  if (criteria) apiParams.Criteria = criteria;
+  const logicalExp = toTrimmedString(firstDefined(req.logical_exp, req.logicalExp, req.LogicalExp));
+  if (logicalExp) apiParams.LogicalExp = logicalExp;
+
+  const response = await callAction(ctx, 'DescribeContainerInstances', apiParams);
+  return {
+    items: extractList(response, 'ContainerInstanceList').map(mapContainerInstance),
+    total_count: extractTotal(response),
+  };
+};
+
+const listImageInstances = async (req = {}, ctx = {}) => {
+  const apiParams = {
+    ...buildPagination(req),
+  };
+  const criteria = toTrimmedString(firstDefined(req.criteria, req.Criteria));
+  if (criteria) apiParams.Criteria = criteria;
+  const logicalExp = toTrimmedString(firstDefined(req.logical_exp, req.logicalExp, req.LogicalExp));
+  if (logicalExp) apiParams.LogicalExp = logicalExp;
+
+  const response = await callAction(ctx, 'DescribeImageInstances', apiParams);
+  return {
+    items: extractList(response, 'ImageInstanceList').map(mapImageInstance),
+    total_count: extractTotal(response),
+  };
+};
+
+const listImageVulnerabilities = async (req = {}, ctx = {}) => {
+  const imageUuid = toTrimmedString(firstDefined(req.image_uuid, req.imageUuid, req.ImageUuid));
+  if (!imageUuid) {
+    throw errorWithCode('INVALID_ARGUMENT', 'image_uuid is required');
+  }
+  const apiParams = {
+    ImageUuid: imageUuid,
+    ...buildPagination(req),
+  };
+  const name = toTrimmedString(firstDefined(req.name, req.Name));
+  if (name) apiParams.Name = name;
+  const level = toTrimmedString(firstDefined(req.level, req.Level));
+  if (level) apiParams.Level = level;
+  const vulType = toTrimmedString(firstDefined(req.vul_type, req.vulType, req.VulType));
+  if (vulType) apiParams.VulType = vulType;
+
+  const response = await callAction(ctx, 'DescribeImageVulList', apiParams);
+  return {
+    items: extractList(response, 'VulRecordList').map(mapImageVulnerability),
+    total_count: extractTotal(response),
+  };
+};
+
+const getClusterSuspEventStatistics = async (req = {}, ctx = {}) => {
+  const response = await callAction(ctx, 'GetClusterSuspEventStatistics', {});
+  return {
+    statistics: toValue(response?.ClusterSuspEventStatistics ?? response?.data ?? response),
+  };
+};
+
+const listClusterInterceptionConfig = async (req = {}, ctx = {}) => {
+  const apiParams = {
+    ...buildPagination(req),
+  };
+  const clusterId = toTrimmedString(firstDefined(req.cluster_id, req.clusterId, req.ClusterId));
+  if (clusterId) apiParams.ClusterId = clusterId;
+
+  const response = await callAction(ctx, 'ListClusterInterceptionConfig', apiParams);
+  return {
+    items: extractList(response, 'ClusterConfigList').map(mapClusterInterceptionConfig),
+    total_count: extractTotal(response),
+  };
+};
+
+// ── rpcdef (filter-style handler) ──────────────────────────
+
+export function rpcdef(ctx = {}) {
+  const callCtx = resolveCallContext(ctx);
+  return {
+    [LIST_CONTAINER_INSTANCES_PATH]: async (req) => listContainerInstances(req ?? callCtx.req, callCtx),
+    [LIST_IMAGE_INSTANCES_PATH]: async (req) => listImageInstances(req ?? callCtx.req, callCtx),
+    [LIST_IMAGE_VULNS_PATH]: async (req) => listImageVulnerabilities(req ?? callCtx.req, callCtx),
+    [GET_CLUSTER_SUSP_EVENT_STATS_PATH]: async (req) => getClusterSuspEventStatistics(req ?? callCtx.req, callCtx),
+    [LIST_CLUSTER_INTERCEPTION_CONFIG_PATH]: async (req) => listClusterInterceptionConfig(req ?? callCtx.req, callCtx),
+  };
+}
+
+// ── SDK handlers (two-arg style) ───────────────────────────
+
+export const handlers = {
+  [LIST_CONTAINER_INSTANCES_FULL]: (req, ctx = {}) => listContainerInstances(req, ctx),
+  [LIST_IMAGE_INSTANCES_FULL]: (req, ctx = {}) => listImageInstances(req, ctx),
+  [LIST_IMAGE_VULNS_FULL]: (req, ctx = {}) => listImageVulnerabilities(req, ctx),
+  [GET_CLUSTER_SUSP_EVENT_STATS_FULL]: (req, ctx = {}) => getClusterSuspEventStatistics(req, ctx),
+  [LIST_CLUSTER_INTERCEPTION_CONFIG_FULL]: (req, ctx = {}) => listClusterInterceptionConfig(req, ctx),
+};
+
+// ── Test exports ───────────────────────────────────────────
+
+export const _test = {
+  percentEncode,
+  signRpc,
+  buildCommonParams,
+  callAction,
+  errorWithCode,
+  firstDefined,
+  hasOwn,
+  logFlow,
+  mergedBindings,
+  resolveCallContext,
+  resolveCredentials,
+  resolveRegion,
+  resolveEndpoint,
+  resolveTimeoutMs,
+  toBoolean,
+  toInt64,
+  toTrimmedString,
+  toValue,
+  buildPagination,
+  extractList,
+  extractTotal,
+  mapContainerInstance,
+  mapImageInstance,
+  mapImageVulnerability,
+  mapClusterInterceptionConfig,
+  listContainerInstances,
+  listImageInstances,
+  listImageVulnerabilities,
+  getClusterSuspEventStatistics,
+  listClusterInterceptionConfig,
+};

--- a/services/alibaba__sas/src/service.js
+++ b/services/alibaba__sas/src/service.js
@@ -1,0 +1,7 @@
+import { defineService } from '@chaitin-ai/octobus-sdk';
+
+import { handlers } from './alibaba-sas.js';
+
+export { handlers } from './alibaba-sas.js';
+
+export const service = defineService({ handlers });

--- a/services/alibaba__sas/test/alibaba-sas.test.js
+++ b/services/alibaba__sas/test/alibaba-sas.test.js
@@ -1,0 +1,375 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const listContainersPath = '/Alibaba_SAS.Alibaba_SAS/ListContainerInstances';
+const listImagesPath = '/Alibaba_SAS.Alibaba_SAS/ListImageInstances';
+const listImageVulnsPath = '/Alibaba_SAS.Alibaba_SAS/ListImageVulnerabilities';
+const getClusterStatsPath = '/Alibaba_SAS.Alibaba_SAS/GetClusterSuspEventStatistics';
+const listInterceptionPath = '/Alibaba_SAS.Alibaba_SAS/ListClusterInterceptionConfig';
+
+const buildCtx = (req = {}, overrides = {}) => ({
+  bindings: {
+    access_key_id: 'test-key-id',
+    access_key_secret: 'test-key-secret',
+    region: 'cn-hangzhou',
+    ...overrides.bindings,
+  },
+  limits: { timeoutMs: 10000, ...overrides.limits },
+  meta: { instance_id: 'inst', request_id: 'req', ...overrides.meta },
+  req,
+});
+
+const loadHandler = async (req, path, overrides = {}) => {
+  const { rpcdef } = await import('../src/alibaba-sas.js');
+  const ctx = buildCtx(req, overrides);
+  return rpcdef(ctx)[path];
+};
+
+const setFetch = (impl) => { global.fetch = impl; };
+const mockUpstream = (responseBody, status = 200) => {
+  setFetch(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => JSON.stringify(responseBody),
+  }));
+};
+
+// ── Internal helpers ──────────────────────────────────────
+
+test('internal helpers work correctly', async () => {
+  const { _test } = await import('../src/alibaba-sas.js');
+
+  assert.equal(_test.toTrimmedString(undefined), '');
+  assert.equal(_test.toTrimmedString(' hello '), 'hello');
+  assert.equal(_test.toTrimmedString({ value: ' world ' }), 'world');
+
+  assert.equal(_test.toInt64(null), null);
+  assert.equal(_test.toInt64({ value: 42 }), 42);
+  assert.equal(_test.toInt64('abc'), null);
+
+  assert.equal(_test.firstDefined(undefined, null, 'a'), 'a');
+
+  assert.equal(_test.toBoolean(true), true);
+  assert.equal(_test.toBoolean('true'), true);
+  assert.equal(_test.toBoolean(0), false);
+
+  assert.deepEqual(_test.toValue('hello'), { stringValue: 'hello' });
+  assert.equal(_test.toValue(null), undefined);
+});
+
+// ── Alibaba Cloud RPC Signing ────────────────────────────
+
+test('percentEncode handles special characters', async () => {
+  const { _test } = await import('../src/alibaba-sas.js');
+  assert.equal(_test.percentEncode('abc'), 'abc');
+  assert.equal(_test.percentEncode('a b'), 'a%20b');
+  assert.equal(_test.percentEncode('a+b'), 'a%2Bb');
+  assert.equal(_test.percentEncode('a~b'), 'a~b');
+  assert.equal(_test.percentEncode('a*b'), 'a%2Ab');
+  assert.equal(_test.percentEncode('中文'), '%E4%B8%AD%E6%96%87');
+});
+
+test('signRpc produces correct format signature', async () => {
+  const { _test } = await import('../src/alibaba-sas.js');
+  const params = {
+    Format: 'JSON',
+    Version: '2018-12-03',
+    AccessKeyId: 'test-id',
+    Action: 'DescribeContainerInstances',
+    Timestamp: '2026-06-25T10:00:00Z',
+    SignatureMethod: 'HMAC-SHA1',
+    SignatureVersion: '1.0',
+    SignatureNonce: 'test-nonce',
+  };
+  const signature = _test.signRpc(params, 'test-secret');
+  assert.ok(typeof signature === 'string');
+  assert.ok(signature.length > 0);
+});
+
+test('buildCommonParams includes all required fields', async () => {
+  const { _test } = await import('../src/alibaba-sas.js');
+  const params = _test.buildCommonParams('test-id', 'DescribeContainerInstances');
+  assert.equal(params.Format, 'JSON');
+  assert.equal(params.Version, '2018-12-03');
+  assert.equal(params.Action, 'DescribeContainerInstances');
+  assert.equal(params.SignatureMethod, 'HMAC-SHA1');
+  assert.equal(params.SignatureVersion, '1.0');
+  assert.ok(params.AccessKeyId, 'test-id');
+  assert.ok(params.Timestamp);
+  assert.ok(params.SignatureNonce);
+});
+
+// ── Credential resolution ─────────────────────────────────
+
+test('resolveCredentials validates required fields', async () => {
+  const { _test } = await import('../src/alibaba-sas.js');
+  const creds = _test.resolveCredentials({ access_key_id: 'id', access_key_secret: 'secret' });
+  assert.equal(creds.accessKeyId, 'id');
+  assert.equal(creds.accessKeySecret, 'secret');
+
+  const camelCase = _test.resolveCredentials({ accessKeyId: 'id2', accessKeySecret: 'secret2' });
+  assert.equal(camelCase.accessKeyId, 'id2');
+
+  assert.throws(() => _test.resolveCredentials({}), /access_key_id.*is required/);
+  assert.throws(() => _test.resolveCredentials({ access_key_id: 'id' }), /access_key_secret.*is required/);
+});
+
+test('resolveRegion and resolveEndpoint use defaults', async () => {
+  const { _test } = await import('../src/alibaba-sas.js');
+  assert.equal(_test.resolveRegion({}), 'cn-hangzhou');
+  assert.equal(_test.resolveRegion({ region: 'cn-beijing' }), 'cn-beijing');
+  assert.equal(_test.resolveEndpoint({}), 'sas.aliyuncs.com');
+  assert.equal(_test.resolveEndpoint({ endpoint: 'custom.sas.com' }), 'custom.sas.com');
+});
+
+// ── Pagination ────────────────────────────────────────────
+
+test('buildPagination handles defaults and limits', async () => {
+  const { _test } = await import('../src/alibaba-sas.js');
+  const defaultP = _test.buildPagination({});
+  assert.equal(defaultP.PageSize, '20');
+  assert.ok(!defaultP.CurrentPage);
+
+  const withP = _test.buildPagination({ page_size: 50, current_page: 1 });
+  assert.equal(withP.PageSize, '50');
+  assert.equal(withP.CurrentPage, '1');
+
+  const maxed = _test.buildPagination({ page_size: 500 });
+  assert.equal(maxed.PageSize, '20');
+
+  const wrappers = _test.buildPagination({ page_size: { value: 10 }, current_page: { value: 2 } });
+  assert.equal(wrappers.PageSize, '10');
+  assert.equal(wrappers.CurrentPage, '2');
+});
+
+// ── ListContainerInstances ────────────────────────────────
+
+test('ListContainerInstances sends request and maps response', async () => {
+  let capturedUrl, capturedBody;
+  setFetch(async (url, init) => {
+    capturedUrl = url;
+    capturedBody = init.body;
+    return {
+      ok: true, status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        ContainerInstanceList: [
+          { InstanceId: 'ci-1', ContainerName: 'nginx', Status: 'Running', ClusterName: 'k8s-prod' },
+        ],
+        TotalCount: 1,
+      }),
+    };
+  });
+
+  const handler = await loadHandler({ page_size: 10 }, listContainersPath);
+  const res = await handler();
+
+  assert.ok(capturedBody.includes('Action=DescribeContainerInstances'));
+  assert.ok(capturedBody.includes('PageSize=10'));
+  assert.equal(res.items.length, 1);
+  assert.equal(res.items[0].container_name, 'nginx');
+  assert.equal(res.total_count, 1);
+});
+
+test('ListContainerInstances handles empty response', async () => {
+  mockUpstream({ ContainerInstanceList: [], TotalCount: 0 });
+  const handler = await loadHandler({}, listContainersPath);
+  const res = await handler();
+  assert.deepEqual(res.items, []);
+  assert.equal(res.total_count, 0);
+});
+
+test('ListContainerInstances with criteria', async () => {
+  let capturedBody;
+  setFetch(async (url, init) => {
+    capturedBody = init.body;
+    return {
+      ok: true, status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({ ContainerInstanceList: [], TotalCount: 0 }),
+    };
+  });
+
+  const handler = await loadHandler({ criteria: 'cluster:k8s-prod', logical_exp: 'AND' }, listContainersPath);
+  await handler();
+  assert.ok(capturedBody.includes('Criteria='));
+  assert.ok(capturedBody.includes('LogicalExp=AND'));
+});
+
+// ── ListImageInstances ────────────────────────────────────
+
+test('ListImageInstances sends request and maps response', async () => {
+  let capturedBody;
+  setFetch(async (url, init) => {
+    capturedBody = init.body;
+    return {
+      ok: true, status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        ImageInstanceList: [
+          { ImageUuid: 'img-1', ImageTag: 'v1.0', RepoName: 'nginx', VulCount: 5, RiskLevel: 'medium' },
+        ],
+        TotalCount: 1,
+      }),
+    };
+  });
+
+  const handler = await loadHandler({}, listImagesPath);
+  const res = await handler();
+  assert.ok(capturedBody.includes('Action=DescribeImageInstances'));
+  assert.equal(res.items[0].image_uuid, 'img-1');
+  assert.equal(res.items[0].vul_count, 5);
+});
+
+// ── ListImageVulnerabilities ──────────────────────────────
+
+test('ListImageVulnerabilities requires image_uuid', async () => {
+  const handler = await loadHandler({}, listImageVulnsPath);
+  await assert.rejects(() => handler(), /INVALID_ARGUMENT: image_uuid is required/);
+});
+
+test('ListImageVulnerabilities sends request and maps response', async () => {
+  let capturedBody;
+  setFetch(async (url, init) => {
+    capturedBody = init.body;
+    return {
+      ok: true, status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        VulRecordList: [
+          { Name: 'CVE-2024-0001', AliasName: 'Test Vuln', CveId: 'CVE-2024-0001', Level: 'high', Type: 'cve', FixVersion: '1.2.3', IsFixed: false },
+        ],
+        TotalCount: 1,
+      }),
+    };
+  });
+
+  const handler = await loadHandler({ image_uuid: 'img-1', level: 'high' }, listImageVulnsPath);
+  const res = await handler();
+  assert.ok(capturedBody.includes('Action=DescribeImageVulList'));
+  assert.equal(res.items[0].cve_id, 'CVE-2024-0001');
+  assert.equal(res.items[0].is_fixed, false);
+  assert.equal(res.total_count, 1);
+});
+
+// ── GetClusterSuspEventStatistics ────────────────────────
+
+test('GetClusterSuspEventStatistics returns statistics', async () => {
+  mockUpstream({ ClusterSuspEventStatistics: { Serious: 3, Suspicious: 5, Remind: 2 } });
+  const handler = await loadHandler({}, getClusterStatsPath);
+  const res = await handler();
+  assert.ok(res.statistics);
+});
+
+// ── ListClusterInterceptionConfig ─────────────────────────
+
+test('ListClusterInterceptionConfig sends request and maps response', async () => {
+  let capturedBody;
+  setFetch(async (url, init) => {
+    capturedBody = init.body;
+    return {
+      ok: true, status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        ClusterConfigList: [
+          { ClusterName: 'k8s-prod', ClusterId: 'c-1', InterceptType: 'container', RuleCount: 5, State: 1 },
+        ],
+        TotalCount: 1,
+      }),
+    };
+  });
+
+  const handler = await loadHandler({ cluster_id: 'c-1' }, listInterceptionPath);
+  const res = await handler();
+  assert.ok(capturedBody.includes('Action=ListClusterInterceptionConfig'));
+  assert.equal(res.items[0].cluster_name, 'k8s-prod');
+  assert.equal(res.items[0].rule_count, 5);
+});
+
+// ── Error mapping ─────────────────────────────────────────
+
+test('HTTP error codes are mapped correctly', async () => {
+  setFetch(async () => ({ ok: false, status: 401, headers: new Map(), text: async () => 'Unauthorized' }));
+  const h401 = await loadHandler({}, listContainersPath);
+  await assert.rejects(() => h401(), /UNAUTHENTICATED/);
+
+  setFetch(async () => ({ ok: false, status: 403, headers: new Map(), text: async () => 'Forbidden' }));
+  const h403 = await loadHandler({}, listContainersPath);
+  await assert.rejects(() => h403(), /PERMISSION_DENIED/);
+
+  setFetch(async () => ({ ok: false, status: 422, headers: new Map(), text: async () => 'Invalid' }));
+  const h422 = await loadHandler({}, listContainersPath);
+  await assert.rejects(() => h422(), /FAILED_PRECONDITION/);
+
+  setFetch(async () => ({ ok: false, status: 503, headers: new Map(), text: async () => 'Down' }));
+  const h503 = await loadHandler({}, listContainersPath);
+  await assert.rejects(() => h503(), /UNAVAILABLE/);
+
+  setFetch(async () => { throw new Error('network error'); });
+  const hNet = await loadHandler({}, listContainersPath);
+  await assert.rejects(() => hNet(), /UNAVAILABLE/);
+});
+
+test('Alibaba API error codes are mapped correctly', async () => {
+  mockUpstream({ Code: 'InvalidAccessKeyId.NotFound', Message: 'not found' });
+  const h = await loadHandler({}, listContainersPath);
+  await assert.rejects(() => h(), /UNAUTHENTICATED/);
+
+  mockUpstream({ Code: '400', Message: 'bad request' });
+  const h2 = await loadHandler({}, listContainersPath);
+  await assert.rejects(() => h2(), /FAILED_PRECONDITION/);
+});
+
+test('Non-JSON and empty body handling', async () => {
+  setFetch(async () => ({ ok: true, status: 200, headers: new Map([['content-type', 'text/plain']]), text: async () => 'not json' }));
+  const h1 = await loadHandler({}, listContainersPath);
+  await assert.rejects(() => h1(), /UNKNOWN/);
+
+  setFetch(async () => ({ ok: true, status: 200, headers: new Map(), text: async () => '' }));
+  const h2 = await loadHandler({}, listContainersPath);
+  await assert.rejects(() => h2(), /UNKNOWN: empty response/);
+});
+
+// ── Response mappers handle missing fields ────────────────
+
+test('Response mappers handle missing fields', async () => {
+  const { _test } = await import('../src/alibaba-sas.js');
+  const c = _test.mapContainerInstance({});
+  assert.equal(c.instance_id, '');
+  assert.equal(c.container_name, '');
+
+  const img = _test.mapImageInstance({});
+  assert.equal(img.image_uuid, '');
+  assert.equal(img.vul_count, 0);
+
+  const vuln = _test.mapImageVulnerability({});
+  assert.equal(vuln.name, '');
+  assert.equal(vuln.is_fixed, false);
+});
+
+// ── SDK handlers ──────────────────────────────────────────
+
+test('SDK handlers accept two-arg (req, ctx) style', async () => {
+  setFetch(async (url, init) => ({
+    ok: true, status: 200,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => JSON.stringify({ ContainerInstanceList: [{ InstanceId: 'c1', ContainerName: 'web' }], TotalCount: 1 }),
+  }));
+
+  const { handlers, LIST_CONTAINER_INSTANCES_FULL } = await import('../src/alibaba-sas.js');
+  const res = await handlers[LIST_CONTAINER_INSTANCES_FULL](
+    {},
+    { config: { region: 'cn-beijing' }, secret: { access_key_id: 'sdk-id', access_key_secret: 'sdk-key' } },
+  );
+  assert.equal(res.items.length, 1);
+  assert.equal(res.items[0].container_name, 'web');
+});
+
+test('Handler fails with clear error when credentials are missing', async () => {
+  const handler = await loadHandler(
+    {}, listContainersPath,
+    { bindings: { access_key_id: '', access_key_secret: '', region: 'cn-hangzhou' } },
+  );
+  await assert.rejects(() => handler(), /FAILED_PRECONDITION/);
+});

--- a/services/alibaba__sas/verify_sas.mjs
+++ b/services/alibaba__sas/verify_sas.mjs
@@ -1,0 +1,101 @@
+// Alibaba Cloud SAS API 真实设备验证脚本
+// 运行方式: ACCESS_KEY_ID=xxx ACCESS_KEY_SECRET=xxx node verify_sas.mjs
+
+import { _test } from './src/alibaba-sas.js';
+
+const ACCESS_KEY_ID = process.env.ACCESS_KEY_ID;
+const ACCESS_KEY_SECRET = process.env.ACCESS_KEY_SECRET;
+
+if (!ACCESS_KEY_ID || !ACCESS_KEY_SECRET) {
+  console.error('错误：请设置环境变量 ACCESS_KEY_ID 和 ACCESS_KEY_SECRET');
+  console.error('  export ACCESS_KEY_ID=your_access_key_id');
+  console.error('  export ACCESS_KEY_SECRET=your_access_key_secret');
+  console.error('  node verify_sas.mjs');
+  process.exit(1);
+}
+
+const ctx = {
+  bindings: {
+    access_key_id: ACCESS_KEY_ID,
+    access_key_secret: ACCESS_KEY_SECRET,
+    region: 'cn-hangzhou',
+    endpoint: 'sas.aliyuncs.com',
+  },
+  limits: { timeoutMs: 30000 },
+  meta: { instance_id: 'verify', request_id: 'v001' },
+};
+
+async function main() {
+  console.log('========================================');
+  console.log('Alibaba Cloud SAS API 真实设备验证');
+  console.log('========================================\n');
+
+  // 1. ListContainerInstances
+  try {
+    console.log('1. ListContainerInstances ----------');
+    const containers = await _test.listContainerInstances({ page_size: 5 }, ctx);
+    console.log('   Total:', containers.total_count);
+    if (containers.items.length) {
+      containers.items.forEach(c => {
+        console.log(`   - ${c.container_name} | ${c.status} | cluster:${c.cluster_name}`);
+      });
+    }
+    console.log('   ✓ PASS\n');
+  } catch(e) { console.log('   ✗ FAIL:', e.message, '\n'); }
+
+  // 2. ListImageInstances
+  try {
+    console.log('2. ListImageInstances --------------');
+    const images = await _test.listImageInstances({ page_size: 5 }, ctx);
+    console.log('   Total:', images.total_count);
+    if (images.items.length) {
+      images.items.forEach(img => {
+        console.log(`   - ${img.image_tag} | vulns:${img.vul_count} | risk:${img.risk_level}`);
+      });
+    }
+    console.log('   ✓ PASS\n');
+  } catch(e) { console.log('   ✗ FAIL:', e.message, '\n'); }
+
+  // 3. ListImageVulnerabilities (needs image_uuid from step 2)
+  try {
+    console.log('3. ListImageVulnerabilities --------');
+    // Get first image UUID if available
+    const images = await _test.listImageInstances({ page_size: 1 }, ctx);
+    if (images.items.length > 0 && images.items[0].image_uuid) {
+      const uuid = images.items[0].image_uuid;
+      const vulns = await _test.listImageVulnerabilities({ image_uuid: uuid, page_size: 5 }, ctx);
+      console.log('   Total vulns:', vulns.total_count);
+      vulns.items.forEach(v => {
+        console.log(`   - ${v.cve_id} | ${v.level} | fix:${v.fix_version} | fixed:${v.is_fixed}`);
+      });
+    } else {
+      console.log('   (no images found, skipping)');
+    }
+    console.log('   ✓ PASS\n');
+  } catch(e) { console.log('   ✗ FAIL:', e.message, '\n'); }
+
+  // 4. GetClusterSuspEventStatistics
+  try {
+    console.log('4. GetClusterSuspEventStatistics ---');
+    const stats = await _test.getClusterSuspEventStatistics({}, ctx);
+    console.log('   Result:', JSON.stringify(stats.statistics));
+    console.log('   ✓ PASS\n');
+  } catch(e) { console.log('   ✗ FAIL:', e.message, '\n'); }
+
+  // 5. ListClusterInterceptionConfig
+  try {
+    console.log('5. ListClusterInterceptionConfig ---');
+    const configs = await _test.listClusterInterceptionConfig({ page_size: 5 }, ctx);
+    console.log('   Total:', configs.total_count);
+    configs.items.forEach(c => {
+      console.log(`   - ${c.cluster_name} | type:${c.intercept_type} | rules:${c.rule_count} | state:${c.state}`);
+    });
+    console.log('   ✓ PASS\n');
+  } catch(e) { console.log('   ✗ FAIL:', e.message, '\n'); }
+
+  console.log('========================================');
+  console.log('验证完成');
+  console.log('========================================');
+}
+
+main().catch(console.error);

--- a/services/bin/alibaba-sas.js
+++ b/services/bin/alibaba-sas.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import { runServiceMain } from "@chaitin-ai/octobus-sdk";
+
+import { service } from "../alibaba__sas/src/service.js";
+
+runServiceMain(service, {
+  entryFile: fileURLToPath(new URL("../alibaba__sas/bin/alibaba-sas.js", import.meta.url)),
+});

--- a/services/bin/octobus-tentacles.js
+++ b/services/bin/octobus-tentacles.js
@@ -157,6 +157,10 @@ const services = {
     entryFile: "../wd__k01/bin/wd-k01.js",
     serviceModule: "../wd__k01/src/service.js",
   },
+  "tencent-bh": {
+    entryFile: "../tencent__bh/bin/tencent-bh.js",
+    serviceModule: "../tencent__bh/src/service.js",
+  },
 };
 
 const serviceNames = Object.keys(services);

--- a/services/bin/octobus-tentacles.js
+++ b/services/bin/octobus-tentacles.js
@@ -161,6 +161,10 @@ const services = {
     entryFile: "../tencent__bh/bin/tencent-bh.js",
     serviceModule: "../tencent__bh/src/service.js",
   },
+  "alibaba-sas": {
+    entryFile: "../alibaba__sas/bin/alibaba-sas.js",
+    serviceModule: "../alibaba__sas/src/service.js",
+  },
 };
 
 const serviceNames = Object.keys(services);

--- a/services/bin/tencent-bh.js
+++ b/services/bin/tencent-bh.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import { runServiceMain } from "@chaitin-ai/octobus-sdk";
+
+import { service } from "../tencent__bh/src/service.js";
+
+runServiceMain(service, {
+  entryFile: fileURLToPath(new URL("../tencent__bh/bin/tencent-bh.js", import.meta.url)),
+});

--- a/services/package.json
+++ b/services/package.json
@@ -42,7 +42,8 @@
     "topsec-fw-2u": "bin/topsec-fw-2u.js",
     "venus-ads-v3-6": "bin/venus-ads-v3-6.js",
     "wangsu-label-ip": "bin/wangsu-label-ip.js",
-    "wd-k01": "bin/wd-k01.js"
+    "wd-k01": "bin/wd-k01.js",
+    "tencent-bh": "bin/tencent-bh.js"
   },
   "files": [
     "bin/das-gateway-v3.js",
@@ -82,6 +83,7 @@
     "bin/topsec-fw-v3-7-6.js",
     "bin/venus-ads-v3-6.js",
     "bin/wd-k01.js",
+    "bin/tencent-bh.js",
     "bin/wangsu-label-ip.js",
     "das__gateway_v3",
     "das__tgfw_v6",
@@ -120,6 +122,7 @@
     "topsec__fw_v3-7-6",
     "venus__ads_v3-6",
     "wd__k01",
+    "tencent__bh",
     "wangsu__label-ip",
     "scripts",
     "bin/octobus-tentacles.js"

--- a/services/package.json
+++ b/services/package.json
@@ -43,7 +43,8 @@
     "venus-ads-v3-6": "bin/venus-ads-v3-6.js",
     "wangsu-label-ip": "bin/wangsu-label-ip.js",
     "wd-k01": "bin/wd-k01.js",
-    "tencent-bh": "bin/tencent-bh.js"
+    "tencent-bh": "bin/tencent-bh.js",
+    "alibaba-sas": "bin/alibaba-sas.js"
   },
   "files": [
     "bin/das-gateway-v3.js",
@@ -84,6 +85,7 @@
     "bin/venus-ads-v3-6.js",
     "bin/wd-k01.js",
     "bin/tencent-bh.js",
+    "bin/alibaba-sas.js",
     "bin/wangsu-label-ip.js",
     "das__gateway_v3",
     "das__tgfw_v6",
@@ -123,6 +125,7 @@
     "venus__ads_v3-6",
     "wd__k01",
     "tencent__bh",
+    "alibaba__sas",
     "wangsu__label-ip",
     "scripts",
     "bin/octobus-tentacles.js"

--- a/services/tencent__bh/README.md
+++ b/services/tencent__bh/README.md
@@ -133,10 +133,13 @@ octobus service import --id tencent-bh ./services//tencent__bh
 ## Behavior Notes
 
 - All API calls use **POST** to `bh.tencentcloudapi.com` with TC3-HMAC-SHA256 signing.
-- HTTP 401/403 maps to `PERMISSION_DENIED`.
+- HTTP 401 maps to `UNAUTHENTICATED`; HTTP 403 maps to `PERMISSION_DENIED`.
 - Other HTTP 4xx maps to `FAILED_PRECONDITION`.
 - HTTP 5xx and network errors map to `UNAVAILABLE`.
-- Tencent Cloud API-level errors (e.g., `AuthFailure`) map to `PERMISSION_DENIED` or `FAILED_PRECONDITION`.
+- Tencent Cloud API `AuthFailure` errors map to `UNAUTHENTICATED` or `PERMISSION_DENIED`.
+- Other HTTP 4xx maps to `FAILED_PRECONDITION`.
+- HTTP 5xx and network errors map to `UNAVAILABLE`.
+- Tencent Cloud API `AuthFailure` errors map to `UNAUTHENTICATED` or `PERMISSION_DENIED`.
 - Non-JSON responses map to `UNKNOWN`.
 - Missing credentials (secret_id/secret_key) map to `FAILED_PRECONDITION`.
 - Missing required request parameters (e.g., `session_id`, `user_id`) map to `INVALID_ARGUMENT`.

--- a/services/tencent__bh/README.md
+++ b/services/tencent__bh/README.md
@@ -140,6 +140,36 @@ octobus service import --id tencent-bh ./services//tencent__bh
 - Non-JSON responses map to `UNKNOWN`.
 - Missing credentials (secret_id/secret_key) map to `FAILED_PRECONDITION`.
 - Missing required request parameters (e.g., `session_id`, `user_id`) map to `INVALID_ARGUMENT`.
+- All API calls log `x-engine-instance` and `x-request-id` headers for traceability.
+
+## Write Operation Semantics
+
+### KillSession
+
+| Aspect | Description |
+|--------|-------------|
+| **Default parameters** | `session_id` 必填，无默认值 |
+| **Idempotency** | 幂等。对已终止的会话再次执行 KillSession 返回成功（BH API 幂等处理） |
+| **Rollback** | 不可回滚。会话终止后无法恢复，用户需重新建立连接 |
+| **Audit fields** | 请求通过 `x-engine-instance` 和 `x-request-id` 追踪；Tencent Cloud BH 侧自动记录操作审计日志 |
+
+### LockUser
+
+| Aspect | Description |
+|--------|-------------|
+| **Default parameters** | `user_id` 必填，无默认值 |
+| **Idempotency** | 幂等。对已锁定的用户再次执行 LockUser 为 no-op |
+| **Rollback** | 通过 `UnlockUser` 操作回滚解锁 |
+| **Audit fields** | 同 KillSession，通过请求头和工作台审计日志追踪 |
+
+### UnlockUser
+
+| Aspect | Description |
+|--------|-------------|
+| **Default parameters** | `user_id` 必填，无默认值 |
+| **Idempotency** | 幂等。对未锁定的用户执行 UnlockUser 为 no-op |
+| **Rollback** | 通过 `LockUser` 操作重新锁定 |
+| **Audit fields** | 同 KillSession，通过请求头和工作台审计日志追踪 |
 
 ## Risk & Recommended Capset
 

--- a/services/tencent__bh/README.md
+++ b/services/tencent__bh/README.md
@@ -1,0 +1,165 @@
+# Tencent Cloud Bastion Host (T-Sec 堡垒机) Service Package
+
+OctoBus service package for [Tencent Cloud T-Sec Bastion Host](https://cloud.tencent.com/product/bh) (运维安全中心/堡垒机).
+
+## Supported Version
+
+Tencent Cloud BH API version `2023-04-18`.
+
+## Authentication
+
+Uses [Tencent Cloud API TC3-HMAC-SHA256](https://cloud.tencent.com/document/api) signing with `SecretId` and `SecretKey`.
+
+- **SecretId**: Tencent Cloud API access key ID.
+- **SecretKey**: Tencent Cloud API access key secret.
+
+Obtain credentials from [Tencent Cloud CAM](https://console.cloud.tencent.com/cam/capi).
+
+## Package Structure
+
+```
+services/tencent__bh/
+  service.json          — OctoBus service manifest
+  proto/tencent_bh.proto  — gRPC API definitions
+  config.schema.json    — non-secret configuration schema
+  secret.schema.json    — secret credentials schema
+  src/service.js        — OctoBus SDK defineService wrapper
+  src/tencent-bh.js     — TC3-HMAC-SHA256 signed API implementation
+  bin/tencent-bh.js     — service-local executable entry point
+  test/tencent-bh.test.js — node:test coverage for TC3 signing, request/response mapping, error handling
+  README.md             — this file
+```
+
+## Configuration
+
+### Config (non-secret fields)
+
+```json
+{
+  "region": "ap-guangzhou",
+  "endpoint": "bh.tencentcloudapi.com",
+  "timeoutMs": 10000,
+  "skipTlsVerify": false
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `region` | `ap-guangzhou` | Tencent Cloud region |
+| `endpoint` | `bh.tencentcloudapi.com` | API endpoint hostname |
+| `timeoutMs` | `10000` | HTTP request timeout (ms) |
+| `skipTlsVerify` | `false` | Skip TLS verification |
+
+### Secret (sensitive fields)
+
+```json
+{
+  "secret_id": "your-secret-id-here",
+  "secret_key": "your-secret-key-here"
+}
+```
+
+Both `snake_case` (`secret_id`, `secret_key`) and `camelCase` (`secretId`, `secretKey`) field names are accepted.
+
+## Import
+
+```bash
+octobus service import --id tencent-bh ./services//tencent__bh
+```
+
+## RPC Methods
+
+| gRPC Method | CLI Command | Description |
+|-------------|-------------|-------------|
+| `Tencent_BH.Tencent_BH/ListSessions` | `list-sessions` | Query Bastion Host session list |
+| `Tencent_BH.Tencent_BH/KillSession` | `kill-session` | Force terminate a session |
+| `Tencent_BH.Tencent_BH/ListDevices` | `list-devices` | List managed devices/assets |
+| `Tencent_BH.Tencent_BH/ListUsers` | `list-users` | List managed users |
+| `Tencent_BH.Tencent_BH/LockUser` | `lock-user` | Lock a user account |
+| `Tencent_BH.Tencent_BH/UnlockUser` | `unlock-user` | Unlock a user account |
+
+### Session Management
+
+**ListSessions** — Query sessions with optional filters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `offset` | int64 | Page offset (0-based) |
+| `limit` | int64 | Page size (default 20, max 200) |
+| `status` | string[] | Filter by status: `ACTIVE`, `FINISHED` |
+| `user_name` | string | Filter by username (fuzzy) |
+| `device_name` | string | Filter by device name (fuzzy) |
+
+**KillSession** — Force terminate a session:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `session_id` | string | Yes | Session ID to terminate |
+
+### Asset Management
+
+**ListDevices** — List managed devices (assets):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `offset` | int64 | Page offset |
+| `limit` | int64 | Page size |
+| `name` | string | Filter by device name (fuzzy) |
+| `ip` | string | Filter by IP address |
+
+### User Management
+
+**ListUsers** — List users with optional filters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `offset` | int64 | Page offset |
+| `limit` | int64 | Page size |
+| `name` | string | Filter by username (fuzzy) |
+| `status` | string | Filter by status: `NORMAL`, `LOCKED`, `DISABLED` |
+
+**LockUser** — Lock a user account:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_id` | string | Yes | User ID to lock |
+
+**UnlockUser** — Unlock a user account:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_id` | string | Yes | User ID to unlock |
+
+## Behavior Notes
+
+- All API calls use **POST** to `bh.tencentcloudapi.com` with TC3-HMAC-SHA256 signing.
+- HTTP 401/403 maps to `PERMISSION_DENIED`.
+- Other HTTP 4xx maps to `FAILED_PRECONDITION`.
+- HTTP 5xx and network errors map to `UNAVAILABLE`.
+- Tencent Cloud API-level errors (e.g., `AuthFailure`) map to `PERMISSION_DENIED` or `FAILED_PRECONDITION`.
+- Non-JSON responses map to `UNKNOWN`.
+- Missing credentials (secret_id/secret_key) map to `FAILED_PRECONDITION`.
+- Missing required request parameters (e.g., `session_id`, `user_id`) map to `INVALID_ARGUMENT`.
+
+## Risk & Recommended Capset
+
+**Risk**: Write operations (`KillSession`, `LockUser`, `UnlockUser`) can disrupt normal operations. Use with caution.
+
+**Recommended `capset`**:
+- Read operations (`ListSessions`, `ListDevices`, `ListUsers`): `["recon"]` capability.
+- Write operations (`KillSession`, `LockUser`, `UnlockUser`): `["recon", "intrusion-response"]` capability.
+
+## Validation
+
+```bash
+cd services
+npm run validate -- --service-dir tencent__bh
+npm test -- --service-dir tencent__bh --coverage
+npm run pack:check
+```
+
+## Known Limitations
+
+1. Pagination for BH APIs with large result sets may require multiple calls.
+2. The API filters support fuzzy matching for user/device names; exact behavior depends on Tencent Cloud BH API implementation.
+3. Some BH API fields may use different naming conventions in raw API responses vs. the proto mapping.

--- a/services/tencent__bh/bin/tencent-bh.js
+++ b/services/tencent__bh/bin/tencent-bh.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+import { runServiceMain } from '@chaitin-ai/octobus-sdk';
+
+import { service } from '../src/service.js';
+
+runServiceMain(service);

--- a/services/tencent__bh/config.schema.json
+++ b/services/tencent__bh/config.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "region": {
+      "type": "string",
+      "default": "ap-guangzhou",
+      "description": "Tencent Cloud region for Bastion Host API, e.g. ap-guangzhou, ap-beijing."
+    },
+    "endpoint": {
+      "type": "string",
+      "default": "bh.tencentcloudapi.com",
+      "description": "Tencent Cloud BH API endpoint hostname."
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 10000,
+      "description": "HTTP request timeout in milliseconds."
+    },
+    "skipTlsVerify": {
+      "type": "boolean",
+      "default": false,
+      "description": "Skip TLS certificate verification."
+    },
+    "tlsInsecureSkipVerify": {
+      "type": "boolean",
+      "default": false,
+      "description": "Alias for skipTlsVerify."
+    }
+  }
+}

--- a/services/tencent__bh/package.json
+++ b/services/tencent__bh/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "tencent-bh",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@chaitin-ai/octobus-sdk": "^0.5.0"
+  }
+}

--- a/services/tencent__bh/proto/tencent_bh.proto
+++ b/services/tencent__bh/proto/tencent_bh.proto
@@ -1,0 +1,155 @@
+syntax = "proto3";
+
+package Tencent_BH;
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+option go_package = "miner/grpc-service/Tencent_BH";
+
+service Tencent_BH {
+  // 查询堡垒机会话列表
+  rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse) {}
+  // 强制关闭会话
+  rpc KillSession(KillSessionRequest) returns (KillSessionResponse) {}
+  // 查询堡垒机托管的资产/设备列表
+  rpc ListDevices(ListDevicesRequest) returns (ListDevicesResponse) {}
+  // 查询用户列表
+  rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {}
+  // 锁定用户
+  rpc LockUser(LockUserRequest) returns (LockUserResponse) {}
+  // 解锁用户
+  rpc UnlockUser(UnlockUserRequest) returns (UnlockUserResponse) {}
+}
+
+// ── 会话管理 ───────────────────────────────────────────
+
+message ListSessionsRequest {
+  // 页码，从 0 开始
+  google.protobuf.Int64Value offset = 1;
+  // 每页数量，默认 20，最大 200
+  google.protobuf.Int64Value limit = 2;
+  // 过滤条件：按状态筛选（如 "ACTIVE", "FINISHED"）
+  repeated string status = 3;
+  // 过滤条件：按用户名模糊搜索
+  string user_name = 4;
+  // 过滤条件：按资产名称模糊搜索
+  string device_name = 5;
+}
+
+message ListSessionsResponse {
+  // 会话列表
+  repeated SessionRecord items = 1;
+  // 总数
+  int64 total_count = 2;
+}
+
+message SessionRecord {
+  // 会话 ID
+  string id = 1;
+  // 用户名
+  string user_name = 2;
+  // 资产/设备名
+  string device_name = 3;
+  // 会话状态（ACTIVE / FINISHED）
+  string status = 4;
+  // 开始时间
+  string start_time = 5;
+  // 结束时间
+  string end_time = 6;
+}
+
+message KillSessionRequest {
+  // 会话 ID（必填）
+  string session_id = 1;
+}
+
+message KillSessionResponse {
+  // 操作结果
+  google.protobuf.Value err = 1;
+  google.protobuf.Value msg = 2;
+}
+
+// ── 资产管理 ───────────────────────────────────────────
+
+message ListDevicesRequest {
+  google.protobuf.Int64Value offset = 1;
+  google.protobuf.Int64Value limit = 2;
+  // 过滤：资产名称模糊搜索
+  string name = 3;
+  // 过滤：资产 IP
+  string ip = 4;
+}
+
+message ListDevicesResponse {
+  repeated DeviceRecord items = 1;
+  int64 total_count = 2;
+}
+
+message DeviceRecord {
+  // 资产 ID
+  string id = 1;
+  // 资产名称
+  string name = 2;
+  // 资产 IP
+  string ip = 3;
+  // 资产类型
+  string type = 4;
+  // 资产状态
+  string state = 5;
+  // 部门
+  string department = 6;
+}
+
+// ── 用户管理 ───────────────────────────────────────────
+
+message ListUsersRequest {
+  google.protobuf.Int64Value offset = 1;
+  google.protobuf.Int64Value limit = 2;
+  // 过滤：用户名模糊搜索
+  string name = 3;
+  // 过滤：用户状态
+  string status = 4;
+}
+
+message ListUsersResponse {
+  repeated UserRecord items = 1;
+  int64 total_count = 2;
+}
+
+message UserRecord {
+  // 用户 ID
+  string id = 1;
+  // 用户名
+  string user_name = 2;
+  // 真实姓名
+  string real_name = 3;
+  // 手机号
+  string phone = 4;
+  // 邮箱
+  string email = 5;
+  // 状态（NORMAL / LOCKED / DISABLED）
+  string status = 6;
+  // 部门
+  string department = 7;
+}
+
+message LockUserRequest {
+  // 用户 ID（必填）
+  string user_id = 1;
+}
+
+message LockUserResponse {
+  google.protobuf.Value err = 1;
+  google.protobuf.Value msg = 2;
+}
+
+message UnlockUserRequest {
+  // 用户 ID（必填）
+  string user_id = 1;
+}
+
+message UnlockUserResponse {
+  google.protobuf.Value err = 1;
+  google.protobuf.Value msg = 2;
+}

--- a/services/tencent__bh/secret.schema.json
+++ b/services/tencent__bh/secret.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "secret_id": {
+      "type": "string",
+      "description": "Tencent Cloud API SecretId."
+    },
+    "secretId": {
+      "type": "string",
+      "description": "Alias for secret_id."
+    },
+    "secret_key": {
+      "type": "string",
+      "description": "Tencent Cloud API SecretKey."
+    },
+    "secretKey": {
+      "type": "string",
+      "description": "Alias for secret_key."
+    }
+  }
+}

--- a/services/tencent__bh/service.json
+++ b/services/tencent__bh/service.json
@@ -1,0 +1,49 @@
+{
+  "schema": "chaitin.octobus.service.v1",
+  "name": "tencent-bh",
+  "displayName": "Tencent Cloud Bastion Host",
+  "description": "OctoBus package for Tencent Cloud T-Sec Bastion Host (堡垒机) session, asset, and user management APIs.",
+  "runtime": {
+    "mode": "long-running"
+  },
+  "proto": {
+    "roots": [
+      "proto"
+    ],
+    "files": [
+      "proto/tencent_bh.proto"
+    ]
+  },
+  "configSchema": "config.schema.json",
+  "secretSchema": "secret.schema.json",
+  "sdk": {
+    "cli": {
+      "commands": {
+        "Tencent_BH.Tencent_BH/ListSessions": {
+          "name": "list-sessions",
+          "description": "List Bastion Host sessions with filters."
+        },
+        "Tencent_BH.Tencent_BH/KillSession": {
+          "name": "kill-session",
+          "description": "Force terminate a Bastion Host session."
+        },
+        "Tencent_BH.Tencent_BH/ListDevices": {
+          "name": "list-devices",
+          "description": "List managed devices/assets."
+        },
+        "Tencent_BH.Tencent_BH/ListUsers": {
+          "name": "list-users",
+          "description": "List managed users."
+        },
+        "Tencent_BH.Tencent_BH/LockUser": {
+          "name": "lock-user",
+          "description": "Lock a Bastion Host user account."
+        },
+        "Tencent_BH.Tencent_BH/UnlockUser": {
+          "name": "unlock-user",
+          "description": "Unlock a Bastion Host user account."
+        }
+      }
+    }
+  }
+}

--- a/services/tencent__bh/src/service.js
+++ b/services/tencent__bh/src/service.js
@@ -1,0 +1,7 @@
+import { defineService } from '@chaitin-ai/octobus-sdk';
+
+import { handlers } from './tencent-bh.js';
+
+export { handlers } from './tencent-bh.js';
+
+export const service = defineService({ handlers });

--- a/services/tencent__bh/src/tencent-bh.js
+++ b/services/tencent__bh/src/tencent-bh.js
@@ -259,7 +259,12 @@ const callAction = async (ctx, action, params) => {
 
   const text = await res.text();
 
-  if (res.status === 401 || res.status === 403) {
+  if (res.status === 401) {
+    logFlow(meta, `${action}:unauthenticated`, { status: res.status });
+    throw errorWithCode('UNAUTHENTICATED', `upstream http ${res.status}: ${text}`);
+  }
+
+  if (res.status === 403) {
     logFlow(meta, `${action}:auth-error`, { status: res.status });
     throw errorWithCode('PERMISSION_DENIED', `upstream http ${res.status}: ${text}`);
   }
@@ -288,7 +293,7 @@ const callAction = async (ctx, action, params) => {
   // Tencent Cloud API error
   if (json.Response?.Error) {
     const { Code, Message } = json.Response.Error;
-    const mappedCode = Code === 'AuthFailure' ? 'PERMISSION_DENIED' : 'FAILED_PRECONDITION';
+    const mappedCode = Code === 'AuthFailure' ? 'UNAUTHENTICATED' : (Code === 'AuthFailure.InvalidAuthorization' ? 'PERMISSION_DENIED' : 'FAILED_PRECONDITION');
     logFlow(meta, `${action}:api-error`, { code: Code, message: Message });
     throw errorWithCode(mappedCode, `Tencent API error: ${Code} - ${Message}`);
   }

--- a/services/tencent__bh/src/tencent-bh.js
+++ b/services/tencent__bh/src/tencent-bh.js
@@ -109,89 +109,45 @@ const sha256 = (data) => crypto.createHash('sha256').update(data).digest('hex');
 
 const hmacSha256 = (key, data) => crypto.createHmac('sha256', key).update(data).digest();
 
-const buildCanonicalRequest = (method, uri, query, headers, signedHeaders, payloadHash) => {
-  const canonicalHeaders = signedHeaders
-    .map((h) => `${h}:${headers[h].trim()}\n`)
-    .join('');
-  return [
-    method,
-    uri,
-    query,
-    canonicalHeaders,
-    signedHeaders.join(';'),
-    payloadHash,
-  ].join('\n');
-};
-
-const buildStringToSign = (timestamp, credentialScope, canonicalRequest) => {
-  return [
-    ALGORITHM,
-    String(timestamp),
-    credentialScope,
-    sha256(canonicalRequest),
-  ].join('\n');
-};
-
-const buildSigningKey = (secretKey, date, service) => {
-  const kDate = hmacSha256(`TC3${secretKey}`, date);
-  const kService = hmacSha256(kDate, service);
-  const kSigning = hmacSha256(kService, 'tc3_request');
-  return kSigning;
-};
-
-const buildSignature = (signingKey, stringToSign) => {
-  return crypto.createHmac('sha256', signingKey).update(stringToSign).digest('hex');
-};
-
-const buildAuthorization = (secretId, timestamp, credentialScope, signedHeaders, signature) => {
-  return `${ALGORITHM} Credential=${secretId}/${credentialScope}, SignedHeaders=${signedHeaders.join(';')}, Signature=${signature}`;
-};
-
 const tc3Sign = (params, secretId, secretKey, region, endpoint, action) => {
   const timestamp = Math.floor(Date.now() / 1000);
-  const date = new Date(timestamp * 1000).toISOString().slice(0, 10).replace(/-/g, '');
+  const date = new Date(timestamp * 1000);
+  const y = date.getUTCFullYear();
+  const m = ('0' + (date.getUTCMonth() + 1)).slice(-2);
+  const d = ('0' + date.getUTCDate()).slice(-2);
+  const dateStr = y + '-' + m + '-' + d;
   const service = 'bh';
-
-  const credentialScope = `${date}/${service}/tc3_request`;
+  const credentialScope = dateStr + '/' + service + '/tc3_request';
 
   const payload = JSON.stringify(params);
   const payloadHash = sha256(payload);
 
-  const headers = {
-    'content-type': 'application/json',
-    host: endpoint,
-    'x-tc-action': action.toLowerCase(),
-    'x-tc-region': region,
-    'x-tc-timestamp': String(timestamp),
-    'x-tc-version': API_VERSION,
-  };
+  // Canonical request: only content-type and host are signed
+  const contentType = 'application/json';
+  const canonicalHeaders = 'content-type:' + contentType + '\n' + 'host:' + endpoint + '\n';
+  const signedHeaders = 'content-type;host';
+  const canonicalRequest = 'POST\n/\n\n' + canonicalHeaders + '\n' + signedHeaders + '\n' + payloadHash;
 
-  const sortedKeys = Object.keys(headers).sort();
-  const signedHeaders = sortedKeys;
-  const canonicalHeaders = {};
-  for (const key of sortedKeys) {
-    canonicalHeaders[key] = headers[key];
-  }
+  const stringToSign = 'TC3-HMAC-SHA256\n' + timestamp + '\n' + credentialScope + '\n' + sha256(canonicalRequest);
 
-  const canonicalRequest = buildCanonicalRequest(
-    'POST',
-    '/',
-    '',
-    canonicalHeaders,
-    signedHeaders,
-    payloadHash,
-  );
+  const dateCompact = y + m + d;
+  const kDate = hmacSha256('TC3' + secretKey, dateStr); // NOTE: SDK uses YYYY-MM-DD format, not YYYYMMDD
+  const kService = hmacSha256(kDate, service);
+  const kSigning = hmacSha256(kService, 'tc3_request');
+  const signature = crypto.createHmac('sha256', kSigning).update(stringToSign).digest('hex');
 
-  const stringToSign = buildStringToSign(timestamp, credentialScope, canonicalRequest);
-  const signingKey = buildSigningKey(secretKey, date, service);
-  const signature = buildSignature(signingKey, stringToSign);
-  const authorization = buildAuthorization(secretId, timestamp, credentialScope, signedHeaders, signature);
+  const authorization = 'TC3-HMAC-SHA256 Credential=' + secretId + '/' + credentialScope + ', SignedHeaders=' + signedHeaders + ', Signature=' + signature;
 
   return {
-    url: `https://${endpoint}`,
+    url: 'https://' + endpoint,
     headers: {
-      ...headers,
-      authorization,
+      'Content-Type': contentType,
+      'Host': endpoint,
+      'X-TC-Action': action,
+      'X-TC-Region': region,
+      'X-TC-Timestamp': String(timestamp),
+      'X-TC-Version': API_VERSION,
+      'Authorization': authorization,
     },
     body: payload,
     timestamp,
@@ -459,7 +415,7 @@ const buildListUsersParams = (req = {}) => {
 const mapSessionRecord = (item) => ({
   id: String(item?.Id ?? item?.id ?? ''),
   user_name: String(item?.UserName ?? item?.user_name ?? ''),
-  device_name: String(item?.DeviceName ?? item?.device_name ?? ''),
+  device_name: String(item?.DeviceName ?? item?.device_name ?? item?.Name ?? ''),
   status: String(item?.Status ?? item?.status ?? ''),
   start_time: String(item?.StartTime ?? item?.start_time ?? ''),
   end_time: String(item?.EndTime ?? item?.end_time ?? ''),
@@ -467,21 +423,25 @@ const mapSessionRecord = (item) => ({
 
 const mapDeviceRecord = (item) => ({
   id: String(item?.Id ?? item?.id ?? ''),
-  name: String(item?.DeviceName ?? item?.name ?? ''),
-  ip: String(item?.Ip ?? item?.ip ?? ''),
-  type: String(item?.DeviceType ?? item?.type ?? ''),
+  name: String(item?.Name ?? item?.name ?? item?.DeviceName ?? ''),
+  ip: String(item?.PrivateIp ?? item?.privateIp ?? item?.Ip ?? item?.ip ?? ''),
+  type: String(item?.OsName ?? item?.osName ?? item?.DeviceType ?? item?.type ?? ''),
   state: String(item?.State ?? item?.state ?? ''),
-  department: String(item?.Department ?? item?.department ?? ''),
+  department: typeof item?.Department === 'object' && item?.Department !== null
+    ? String(item.Department.Name ?? item.Department.name ?? '')
+    : String(item?.Department ?? item?.department ?? ''),
 });
 
 const mapUserRecord = (item) => ({
-  id: String(item?.UserId ?? item?.id ?? ''),
+  id: String(item?.Id ?? item?.id ?? ''),
   user_name: String(item?.UserName ?? item?.user_name ?? ''),
   real_name: String(item?.RealName ?? item?.real_name ?? ''),
   phone: String(item?.Phone ?? item?.phone ?? ''),
   email: String(item?.Email ?? item?.email ?? ''),
   status: String(item?.Status ?? item?.status ?? ''),
-  department: String(item?.Department ?? item?.department ?? ''),
+  department: typeof item?.Department === 'object' && item?.Department !== null
+    ? String(item.Department.Name ?? item.Department.name ?? '')
+    : String(item?.Department ?? item?.department ?? ''),
 });
 
 // ── API method implementations ─────────────────────────────
@@ -527,11 +487,12 @@ const listUsers = async (req = {}, ctx = {}) => {
 };
 
 const lockUser = async (req = {}, ctx = {}) => {
-  const userId = toTrimmedString(firstDefined(req.user_id, req.userId));
-  if (!userId) {
-    throw errorWithCode('INVALID_ARGUMENT', 'user_id is required');
+  const rawId = firstDefined(req.user_id, req.userId);
+  const idNum = toInt64(rawId);
+  if (idNum === null) {
+    throw errorWithCode('INVALID_ARGUMENT', 'user_id is required and must be an integer');
   }
-  const params = { UserId: userId };
+  const params = { IdSet: [idNum] };
   const response = await callAction(ctx, 'LockUser', params);
   return {
     err: toValue(response?.err ?? null),
@@ -540,11 +501,12 @@ const lockUser = async (req = {}, ctx = {}) => {
 };
 
 const unlockUser = async (req = {}, ctx = {}) => {
-  const userId = toTrimmedString(firstDefined(req.user_id, req.userId));
-  if (!userId) {
-    throw errorWithCode('INVALID_ARGUMENT', 'user_id is required');
+  const rawId = firstDefined(req.user_id, req.userId);
+  const idNum = toInt64(rawId);
+  if (idNum === null) {
+    throw errorWithCode('INVALID_ARGUMENT', 'user_id is required and must be an integer');
   }
-  const params = { UserId: userId };
+  const params = { IdSet: [idNum] };
   const response = await callAction(ctx, 'UnlockUser', params);
   return {
     err: toValue(response?.err ?? null),
@@ -580,11 +542,6 @@ export const handlers = {
 // ── Test exports ───────────────────────────────────────────
 
 export const _test = {
-  buildCanonicalRequest,
-  buildStringToSign,
-  buildSigningKey,
-  buildSignature,
-  buildAuthorization,
   tc3Sign,
   callAction,
   errorWithCode,

--- a/services/tencent__bh/src/tencent-bh.js
+++ b/services/tencent__bh/src/tencent-bh.js
@@ -1,0 +1,616 @@
+// Tencent Cloud Bastion Host (BH / 堡垒机) API implementation
+// Uses TC3-HMAC-SHA256 signing for Tencent Cloud API v3.
+//
+// API version: 2023-04-18
+// Endpoint: bh.tencentcloudapi.com
+
+import crypto from 'node:crypto';
+import { GrpcError, grpcStatus } from '@chaitin-ai/octobus-sdk';
+
+// ── Constants ──────────────────────────────────────────────
+
+const SERVICE_NAME = 'Tencent_BH';
+const API_VERSION = '2023-04-18';
+const DEFAULT_REGION = 'ap-guangzhou';
+const DEFAULT_ENDPOINT = 'bh.tencentcloudapi.com';
+const DEFAULT_TIMEOUT_MS = 10000;
+const ALGORITHM = 'TC3-HMAC-SHA256';
+const MAX_LIMIT = 200;
+const DEFAULT_LIMIT = 20;
+
+// ── Method paths ───────────────────────────────────────────
+
+export const LIST_SESSIONS_PATH = '/Tencent_BH.Tencent_BH/ListSessions';
+export const KILL_SESSION_PATH = '/Tencent_BH.Tencent_BH/KillSession';
+export const LIST_DEVICES_PATH = '/Tencent_BH.Tencent_BH/ListDevices';
+export const LIST_USERS_PATH = '/Tencent_BH.Tencent_BH/ListUsers';
+export const LOCK_USER_PATH = '/Tencent_BH.Tencent_BH/LockUser';
+export const UNLOCK_USER_PATH = '/Tencent_BH.Tencent_BH/UnlockUser';
+
+export const LIST_SESSIONS_FULL = 'Tencent_BH.Tencent_BH/ListSessions';
+export const KILL_SESSION_FULL = 'Tencent_BH.Tencent_BH/KillSession';
+export const LIST_DEVICES_FULL = 'Tencent_BH.Tencent_BH/ListDevices';
+export const LIST_USERS_FULL = 'Tencent_BH.Tencent_BH/ListUsers';
+export const LOCK_USER_FULL = 'Tencent_BH.Tencent_BH/LockUser';
+export const UNLOCK_USER_FULL = 'Tencent_BH.Tencent_BH/UnlockUser';
+
+// ── Error helpers ──────────────────────────────────────────
+
+const grpcCodeFor = (code) => ({
+  INVALID_ARGUMENT: grpcStatus.INVALID_ARGUMENT,
+  FAILED_PRECONDITION: grpcStatus.FAILED_PRECONDITION,
+  PERMISSION_DENIED: grpcStatus.PERMISSION_DENIED,
+  UNAUTHENTICATED: grpcStatus.UNAUTHENTICATED,
+  UNAVAILABLE: grpcStatus.UNAVAILABLE,
+  UNKNOWN: grpcStatus.UNKNOWN,
+})[code] ?? grpcStatus.UNKNOWN;
+
+const errorWithCode = (code, message) => {
+  const err = new GrpcError(grpcCodeFor(code), `${code}: ${message}`);
+  err.legacyCode = code;
+  return err;
+};
+
+// ── Internal helpers ───────────────────────────────────────
+
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj ?? {}, key);
+
+const firstDefined = (...values) => values.find((v) => v !== undefined && v !== null);
+
+const toTrimmedString = (value) => {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'object' && value !== null && hasOwn(value, 'value')) return toTrimmedString(value.value);
+  return String(value).trim();
+};
+
+const toInt64 = (value) => {
+  if (value === undefined || value === null) return null;
+  const raw = typeof value === 'object' && value !== null && hasOwn(value, 'value') ? value.value : value;
+  if (raw === undefined || raw === null || raw === '') return null;
+  const num = Number(raw);
+  if (!Number.isInteger(num) || Number.isNaN(num)) return null;
+  return num;
+};
+
+const toBoolean = (value) => {
+  if (value === undefined || value === null) return false;
+  const raw = typeof value === 'object' && value !== null && hasOwn(value, 'value') ? value.value : value;
+  if (typeof raw === 'boolean') return raw;
+  if (typeof raw === 'number') return raw !== 0;
+  if (typeof raw === 'string') {
+    const text = raw.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(text)) return true;
+    if (['0', 'false', 'no', 'n', 'off', ''].includes(text)) return false;
+  }
+  return Boolean(raw);
+};
+
+const toValue = (value) => {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') return { stringValue: value };
+  if (typeof value === 'number') return { numberValue: value };
+  if (typeof value === 'boolean') return { boolValue: value };
+  if (Array.isArray(value)) {
+    return { listValue: { values: value.map(toValue).filter((v) => v !== undefined) } };
+  }
+  if (typeof value === 'object') {
+    const fields = {};
+    for (const [key, v] of Object.entries(value)) {
+      fields[key] = toValue(v) ?? { nullValue: 'NULL_VALUE' };
+    }
+    return { structValue: { fields } };
+  }
+  return { stringValue: String(value) };
+};
+
+// ── TC3-HMAC-SHA256 Signing ────────────────────────────────
+
+const sha256 = (data) => crypto.createHash('sha256').update(data).digest('hex');
+
+const hmacSha256 = (key, data) => crypto.createHmac('sha256', key).update(data).digest();
+
+const buildCanonicalRequest = (method, uri, query, headers, signedHeaders, payloadHash) => {
+  const canonicalHeaders = signedHeaders
+    .map((h) => `${h}:${headers[h].trim()}\n`)
+    .join('');
+  return [
+    method,
+    uri,
+    query,
+    canonicalHeaders,
+    signedHeaders.join(';'),
+    payloadHash,
+  ].join('\n');
+};
+
+const buildStringToSign = (timestamp, credentialScope, canonicalRequest) => {
+  return [
+    ALGORITHM,
+    String(timestamp),
+    credentialScope,
+    sha256(canonicalRequest),
+  ].join('\n');
+};
+
+const buildSigningKey = (secretKey, date, service) => {
+  const kDate = hmacSha256(`TC3${secretKey}`, date);
+  const kService = hmacSha256(kDate, service);
+  const kSigning = hmacSha256(kService, 'tc3_request');
+  return kSigning;
+};
+
+const buildSignature = (signingKey, stringToSign) => {
+  return crypto.createHmac('sha256', signingKey).update(stringToSign).digest('hex');
+};
+
+const buildAuthorization = (secretId, timestamp, credentialScope, signedHeaders, signature) => {
+  return `${ALGORITHM} Credential=${secretId}/${credentialScope}, SignedHeaders=${signedHeaders.join(';')}, Signature=${signature}`;
+};
+
+const tc3Sign = (params, secretId, secretKey, region, endpoint, action) => {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const date = new Date(timestamp * 1000).toISOString().slice(0, 10).replace(/-/g, '');
+  const service = 'bh';
+
+  const credentialScope = `${date}/${service}/tc3_request`;
+
+  const payload = JSON.stringify(params);
+  const payloadHash = sha256(payload);
+
+  const headers = {
+    'content-type': 'application/json',
+    host: endpoint,
+    'x-tc-action': action.toLowerCase(),
+    'x-tc-region': region,
+    'x-tc-timestamp': String(timestamp),
+    'x-tc-version': API_VERSION,
+  };
+
+  const sortedKeys = Object.keys(headers).sort();
+  const signedHeaders = sortedKeys;
+  const canonicalHeaders = {};
+  for (const key of sortedKeys) {
+    canonicalHeaders[key] = headers[key];
+  }
+
+  const canonicalRequest = buildCanonicalRequest(
+    'POST',
+    '/',
+    '',
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  );
+
+  const stringToSign = buildStringToSign(timestamp, credentialScope, canonicalRequest);
+  const signingKey = buildSigningKey(secretKey, date, service);
+  const signature = buildSignature(signingKey, stringToSign);
+  const authorization = buildAuthorization(secretId, timestamp, credentialScope, signedHeaders, signature);
+
+  return {
+    url: `https://${endpoint}`,
+    headers: {
+      ...headers,
+      authorization,
+    },
+    body: payload,
+    timestamp,
+  };
+};
+
+// ── Binding and context resolution ─────────────────────────
+
+const mergedBindings = (ctx = {}) => ({
+  ...(ctx.config ?? {}),
+  ...(ctx.secret ?? {}),
+  ...(ctx.bindings ?? {}),
+});
+
+const resolveCallContext = (ctx = {}) => ({
+  ...ctx,
+  bindings: mergedBindings(ctx),
+  limits: ctx.limits ?? {},
+  meta: ctx.meta ?? {},
+  req: ctx.req ?? ctx.request ?? {},
+});
+
+const resolveTimeoutMs = (bindings = {}, limits = {}) => {
+  const fromBinding = toInt64(bindings.timeoutMs);
+  if (fromBinding !== null) return fromBinding;
+  const fromLimits = toInt64(limits.timeoutMs);
+  if (fromLimits !== null) return fromLimits;
+  return DEFAULT_TIMEOUT_MS;
+};
+
+const buildHeaders = (bindings = {}, meta = {}) => ({
+  ...(bindings.headers && typeof bindings.headers === 'object' ? bindings.headers : {}),
+  'x-engine-instance': meta.instance_id || meta.instanceId || 'unknown',
+  'x-request-id': meta.request_id || meta.requestId || 'unknown',
+});
+
+const buildLogPrefix = (meta = {}, action) => {
+  const parts = [];
+  if (meta.instance_id || meta.instanceId) parts.push(`inst=${meta.instance_id || meta.instanceId}`);
+  if (meta.request_id || meta.requestId) parts.push(`req=${meta.request_id || meta.requestId}`);
+  return `[${SERVICE_NAME}][${action}]${parts.length ? `[${parts.join(' ')}]` : ''}`;
+};
+
+const logFlow = (meta, action, details) => {
+  const prefix = buildLogPrefix(meta, action);
+  const safe = { ...details };
+  if (safe.body) safe.body = '[REDACTED]';
+  try {
+    console.log(prefix, JSON.stringify(safe));
+  } catch {
+    console.log(prefix, safe);
+  }
+};
+
+// ── Security credential extraction ─────────────────────────
+
+const resolveCredentials = (bindings = {}) => {
+  const secretId = toTrimmedString(firstDefined(bindings.secret_id, bindings.secretId));
+  const secretKey = toTrimmedString(firstDefined(bindings.secret_key, bindings.secretKey));
+  if (!secretId) throw errorWithCode('FAILED_PRECONDITION', 'binding "secret_id" or "secretId" is required but not configured');
+  if (!secretKey) throw errorWithCode('FAILED_PRECONDITION', 'binding "secret_key" or "secretKey" is required but not configured');
+  return { secretId, secretKey };
+};
+
+const resolveRegion = (bindings = {}) => {
+  return toTrimmedString(bindings.region) || DEFAULT_REGION;
+};
+
+const resolveEndpoint = (bindings = {}) => {
+  return toTrimmedString(bindings.endpoint) || DEFAULT_ENDPOINT;
+};
+
+// ── API call ────────────────────────────────────────────────
+
+const callAction = async (ctx, action, params) => {
+  const bindings = mergedBindings(ctx);
+  const credentials = resolveCredentials(bindings);
+  const region = resolveRegion(bindings);
+  const endpoint = resolveEndpoint(bindings);
+  const timeoutMs = resolveTimeoutMs(bindings, ctx.limits);
+  const meta = ctx.meta || {};
+
+  const signed = tc3Sign(params, credentials.secretId, credentials.secretKey, region, endpoint, action);
+
+  const extraHeaders = buildHeaders(bindings, meta);
+  const requestHeaders = {
+    ...signed.headers,
+    ...extraHeaders,
+  };
+
+  logFlow(meta, `${action}:start`, { region, endpoint });
+
+  let res;
+  try {
+    res = await fetch(signed.url, {
+      method: 'POST',
+      headers: requestHeaders,
+      body: signed.body,
+      timeoutMs,
+      ...(toBoolean(bindings.skipTlsVerify) || toBoolean(bindings.tlsInsecureSkipVerify)
+        ? { insecureSkipVerify: true, tlsInsecureSkipVerify: true }
+        : {}),
+    });
+  } catch (err) {
+    const reason = err?.cause?.message || err?.message || 'fetch failed';
+    logFlow(meta, `${action}:error`, { error: reason });
+    throw errorWithCode('UNAVAILABLE', `upstream error: ${reason}`);
+  }
+
+  const text = await res.text();
+
+  if (res.status === 401 || res.status === 403) {
+    logFlow(meta, `${action}:auth-error`, { status: res.status });
+    throw errorWithCode('PERMISSION_DENIED', `upstream http ${res.status}: ${text}`);
+  }
+
+  if (res.status >= 400 && res.status < 500) {
+    logFlow(meta, `${action}:client-error`, { status: res.status, response: text });
+    throw errorWithCode('FAILED_PRECONDITION', `upstream http ${res.status}: ${text}`);
+  }
+
+  if (res.status >= 500) {
+    logFlow(meta, `${action}:server-error`, { status: res.status });
+    throw errorWithCode('UNAVAILABLE', `upstream http ${res.status}: ${text}`);
+  }
+
+  if (!text.trim()) {
+    throw errorWithCode('UNKNOWN', 'empty response from upstream');
+  }
+
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw errorWithCode('UNKNOWN', 'response is not valid JSON');
+  }
+
+  // Tencent Cloud API error
+  if (json.Response?.Error) {
+    const { Code, Message } = json.Response.Error;
+    const mappedCode = Code === 'AuthFailure' ? 'PERMISSION_DENIED' : 'FAILED_PRECONDITION';
+    logFlow(meta, `${action}:api-error`, { code: Code, message: Message });
+    throw errorWithCode(mappedCode, `Tencent API error: ${Code} - ${Message}`);
+  }
+
+  logFlow(meta, `${action}:done`, {});
+  return json.Response || {};
+};
+
+// ── Request builders ───────────────────────────────────────
+
+const buildListSessionsParams = (req = {}) => {
+  const params = {};
+
+  const offset = toInt64(firstDefined(req.offset, req.Offset));
+  if (offset !== null && offset >= 0) {
+    params.Offset = offset;
+  }
+
+  const limit = toInt64(firstDefined(req.limit, req.Limit));
+  if (limit !== null && limit > 0 && limit <= MAX_LIMIT) {
+    params.Limit = limit;
+  } else {
+    params.Limit = DEFAULT_LIMIT;
+  }
+
+  // Build filters
+  const filters = [];
+
+  const rawStatus = firstDefined(req.status, req.Status);
+  if (rawStatus) {
+    const statuses = Array.isArray(rawStatus) ? rawStatus : [rawStatus];
+    if (statuses.length > 0) {
+      filters.push({ Name: 'Status', Values: statuses.map(String) });
+    }
+  }
+
+  const userName = toTrimmedString(firstDefined(req.user_name, req.userName));
+  if (userName) {
+    filters.push({ Name: 'UserName', Values: [userName] });
+  }
+
+  const deviceName = toTrimmedString(firstDefined(req.device_name, req.deviceName));
+  if (deviceName) {
+    filters.push({ Name: 'DeviceName', Values: [deviceName] });
+  }
+
+  if (filters.length > 0) {
+    params.Filters = filters;
+  }
+
+  return params;
+};
+
+const buildListDevicesParams = (req = {}) => {
+  const params = {};
+
+  const offset = toInt64(firstDefined(req.offset, req.Offset));
+  if (offset !== null && offset >= 0) {
+    params.Offset = offset;
+  }
+
+  const limit = toInt64(firstDefined(req.limit, req.Limit));
+  if (limit !== null && limit > 0 && limit <= MAX_LIMIT) {
+    params.Limit = limit;
+  } else {
+    params.Limit = DEFAULT_LIMIT;
+  }
+
+  const filters = [];
+
+  const name = toTrimmedString(firstDefined(req.name, req.Name));
+  if (name) {
+    filters.push({ Name: 'DeviceName', Values: [name] });
+  }
+
+  const ip = toTrimmedString(firstDefined(req.ip, req.Ip));
+  if (ip) {
+    filters.push({ Name: 'Ip', Values: [ip] });
+  }
+
+  if (filters.length > 0) {
+    params.Filters = filters;
+  }
+
+  return params;
+};
+
+const buildListUsersParams = (req = {}) => {
+  const params = {};
+
+  const offset = toInt64(firstDefined(req.offset, req.Offset));
+  if (offset !== null && offset >= 0) {
+    params.Offset = offset;
+  }
+
+  const limit = toInt64(firstDefined(req.limit, req.Limit));
+  if (limit !== null && limit > 0 && limit <= MAX_LIMIT) {
+    params.Limit = limit;
+  } else {
+    params.Limit = DEFAULT_LIMIT;
+  }
+
+  const filters = [];
+
+  const name = toTrimmedString(firstDefined(req.name, req.Name));
+  if (name) {
+    filters.push({ Name: 'UserName', Values: [name] });
+  }
+
+  const status = toTrimmedString(firstDefined(req.status, req.Status));
+  if (status) {
+    filters.push({ Name: 'Status', Values: [status] });
+  }
+
+  if (filters.length > 0) {
+    params.Filters = filters;
+  }
+
+  return params;
+};
+
+// ── Response mappers ───────────────────────────────────────
+
+const mapSessionRecord = (item) => ({
+  id: String(item?.Id ?? item?.id ?? ''),
+  user_name: String(item?.UserName ?? item?.user_name ?? ''),
+  device_name: String(item?.DeviceName ?? item?.device_name ?? ''),
+  status: String(item?.Status ?? item?.status ?? ''),
+  start_time: String(item?.StartTime ?? item?.start_time ?? ''),
+  end_time: String(item?.EndTime ?? item?.end_time ?? ''),
+});
+
+const mapDeviceRecord = (item) => ({
+  id: String(item?.Id ?? item?.id ?? ''),
+  name: String(item?.DeviceName ?? item?.name ?? ''),
+  ip: String(item?.Ip ?? item?.ip ?? ''),
+  type: String(item?.DeviceType ?? item?.type ?? ''),
+  state: String(item?.State ?? item?.state ?? ''),
+  department: String(item?.Department ?? item?.department ?? ''),
+});
+
+const mapUserRecord = (item) => ({
+  id: String(item?.UserId ?? item?.id ?? ''),
+  user_name: String(item?.UserName ?? item?.user_name ?? ''),
+  real_name: String(item?.RealName ?? item?.real_name ?? ''),
+  phone: String(item?.Phone ?? item?.phone ?? ''),
+  email: String(item?.Email ?? item?.email ?? ''),
+  status: String(item?.Status ?? item?.status ?? ''),
+  department: String(item?.Department ?? item?.department ?? ''),
+});
+
+// ── API method implementations ─────────────────────────────
+
+const listSessions = async (req = {}, ctx = {}) => {
+  const params = buildListSessionsParams(req);
+  const response = await callAction(ctx, 'DescribeSessions', params);
+  return {
+    items: (response?.SessionSet ?? response?.sessionSet ?? []).map(mapSessionRecord),
+    total_count: toInt64(response?.TotalCount ?? response?.totalCount) ?? 0,
+  };
+};
+
+const killSession = async (req = {}, ctx = {}) => {
+  const sessionId = toTrimmedString(firstDefined(req.session_id, req.sessionId));
+  if (!sessionId) {
+    throw errorWithCode('INVALID_ARGUMENT', 'session_id is required');
+  }
+  const params = { SessionId: sessionId };
+  const response = await callAction(ctx, 'KillSession', params);
+  return {
+    err: toValue(response?.err ?? null),
+    msg: toValue(response?.msg ?? 'ok'),
+  };
+};
+
+const listDevices = async (req = {}, ctx = {}) => {
+  const params = buildListDevicesParams(req);
+  const response = await callAction(ctx, 'DescribeDevices', params);
+  return {
+    items: (response?.DeviceSet ?? response?.deviceSet ?? []).map(mapDeviceRecord),
+    total_count: toInt64(response?.TotalCount ?? response?.totalCount) ?? 0,
+  };
+};
+
+const listUsers = async (req = {}, ctx = {}) => {
+  const params = buildListUsersParams(req);
+  const response = await callAction(ctx, 'DescribeUsers', params);
+  return {
+    items: (response?.UserSet ?? response?.userSet ?? []).map(mapUserRecord),
+    total_count: toInt64(response?.TotalCount ?? response?.totalCount) ?? 0,
+  };
+};
+
+const lockUser = async (req = {}, ctx = {}) => {
+  const userId = toTrimmedString(firstDefined(req.user_id, req.userId));
+  if (!userId) {
+    throw errorWithCode('INVALID_ARGUMENT', 'user_id is required');
+  }
+  const params = { UserId: userId };
+  const response = await callAction(ctx, 'LockUser', params);
+  return {
+    err: toValue(response?.err ?? null),
+    msg: toValue(response?.msg ?? 'ok'),
+  };
+};
+
+const unlockUser = async (req = {}, ctx = {}) => {
+  const userId = toTrimmedString(firstDefined(req.user_id, req.userId));
+  if (!userId) {
+    throw errorWithCode('INVALID_ARGUMENT', 'user_id is required');
+  }
+  const params = { UserId: userId };
+  const response = await callAction(ctx, 'UnlockUser', params);
+  return {
+    err: toValue(response?.err ?? null),
+    msg: toValue(response?.msg ?? 'ok'),
+  };
+};
+
+// ── rpcdef (filter-style handler) ──────────────────────────
+
+export function rpcdef(ctx = {}) {
+  const callCtx = resolveCallContext(ctx);
+  return {
+    [LIST_SESSIONS_PATH]: async (req) => listSessions(req ?? callCtx.req, callCtx),
+    [KILL_SESSION_PATH]: async (req) => killSession(req ?? callCtx.req, callCtx),
+    [LIST_DEVICES_PATH]: async (req) => listDevices(req ?? callCtx.req, callCtx),
+    [LIST_USERS_PATH]: async (req) => listUsers(req ?? callCtx.req, callCtx),
+    [LOCK_USER_PATH]: async (req) => lockUser(req ?? callCtx.req, callCtx),
+    [UNLOCK_USER_PATH]: async (req) => unlockUser(req ?? callCtx.req, callCtx),
+  };
+}
+
+// ── SDK handlers (two-arg style) ───────────────────────────
+
+export const handlers = {
+  [LIST_SESSIONS_FULL]: (req, ctx = {}) => listSessions(req, ctx),
+  [KILL_SESSION_FULL]: (req, ctx = {}) => killSession(req, ctx),
+  [LIST_DEVICES_FULL]: (req, ctx = {}) => listDevices(req, ctx),
+  [LIST_USERS_FULL]: (req, ctx = {}) => listUsers(req, ctx),
+  [LOCK_USER_FULL]: (req, ctx = {}) => lockUser(req, ctx),
+  [UNLOCK_USER_FULL]: (req, ctx = {}) => unlockUser(req, ctx),
+};
+
+// ── Test exports ───────────────────────────────────────────
+
+export const _test = {
+  buildCanonicalRequest,
+  buildStringToSign,
+  buildSigningKey,
+  buildSignature,
+  buildAuthorization,
+  tc3Sign,
+  callAction,
+  errorWithCode,
+  firstDefined,
+  hasOwn,
+  logFlow,
+  mergedBindings,
+  resolveCallContext,
+  resolveCredentials,
+  resolveRegion,
+  resolveEndpoint,
+  resolveTimeoutMs,
+  toBoolean,
+  toInt64,
+  toTrimmedString,
+  toValue,
+  buildListSessionsParams,
+  buildListDevicesParams,
+  buildListUsersParams,
+  mapSessionRecord,
+  mapDeviceRecord,
+  mapUserRecord,
+  listSessions,
+  killSession,
+  listDevices,
+  listUsers,
+  lockUser,
+  unlockUser,
+};

--- a/services/tencent__bh/test/tencent-bh.test.js
+++ b/services/tencent__bh/test/tencent-bh.test.js
@@ -1,0 +1,593 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const listSessionsPath = '/Tencent_BH.Tencent_BH/ListSessions';
+const killSessionPath = '/Tencent_BH.Tencent_BH/KillSession';
+const listDevicesPath = '/Tencent_BH.Tencent_BH/ListDevices';
+const listUsersPath = '/Tencent_BH.Tencent_BH/ListUsers';
+const lockUserPath = '/Tencent_BH.Tencent_BH/LockUser';
+const unlockUserPath = '/Tencent_BH.Tencent_BH/UnlockUser';
+
+const buildCtx = (req = {}, overrides = {}) => ({
+  bindings: {
+    secret_id: 'test-secret-id',
+    secret_key: 'test-secret-key',
+    region: 'ap-guangzhou',
+    ...overrides.bindings,
+  },
+  limits: { timeoutMs: 10000, ...overrides.limits },
+  meta: { instance_id: 'inst', request_id: 'req', ...overrides.meta },
+  req,
+});
+
+const loadHandler = async (req, path, overrides = {}) => {
+  const { rpcdef } = await import('../src/tencent-bh.js');
+  const ctx = buildCtx(req, overrides);
+  return rpcdef(ctx)[path];
+};
+
+const setFetch = (impl) => {
+  global.fetch = impl;
+};
+
+const mockUpstream = (responseBody, status = 200) => {
+  setFetch(async (url, init) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => JSON.stringify(responseBody),
+  }));
+};
+
+// ── Internal helpers ──────────────────────────────────────
+
+test('internal helpers work correctly', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+
+  // mergedBindings
+  const merged = _test.mergedBindings({
+    config: { region: 'ap-beijing' },
+    secret: { secret_id: 'from-secret' },
+    bindings: { endpoint: 'custom.bh.com' },
+  });
+  assert.equal(merged.region, 'ap-beijing');
+  assert.equal(merged.secret_id, 'from-secret');
+  assert.equal(merged.endpoint, 'custom.bh.com');
+
+  // toTrimmedString
+  assert.equal(_test.toTrimmedString(undefined), '');
+  assert.equal(_test.toTrimmedString(' hello '), 'hello');
+  assert.equal(_test.toTrimmedString({ value: ' world ' }), 'world');
+
+  // toInt64
+  assert.equal(_test.toInt64(null), null);
+  assert.equal(_test.toInt64({ value: 42 }), 42);
+  assert.equal(_test.toInt64('abc'), null);
+
+  // firstDefined
+  assert.equal(_test.firstDefined(undefined, null, 'a'), 'a');
+  assert.equal(_test.firstDefined('b'), 'b');
+
+  // toBoolean - various types
+  assert.equal(_test.toBoolean(true), true);
+  assert.equal(_test.toBoolean(false), false);
+  assert.equal(_test.toBoolean('true'), true);
+  assert.equal(_test.toBoolean('false'), false);
+  assert.equal(_test.toBoolean({ value: 'true' }), true);
+  assert.equal(_test.toBoolean({}), true);  // object → Boolean({}) = true
+  assert.equal(_test.toBoolean(0), false);  // number 0
+  assert.equal(_test.toBoolean(1), true);   // number non-zero
+
+  // toValue - various types including edge cases
+  assert.deepEqual(_test.toValue('hello'), { stringValue: 'hello' });
+  assert.deepEqual(_test.toValue(42), { numberValue: 42 });
+  assert.deepEqual(_test.toValue(true), { boolValue: true });
+  // toValue with object
+  const objVal = _test.toValue({ key: 'val' });
+  assert.ok(objVal.structValue);
+  assert.equal(objVal.structValue.fields.key.stringValue, 'val');
+  // toValue with array
+  const arrVal = _test.toValue(['a', 'b']);
+  assert.equal(arrVal.listValue.values.length, 2);
+  // toValue with symbol (other type)
+  const symVal = _test.toValue(Symbol.for('test'));
+  assert.equal(symVal.stringValue, 'Symbol(test)');
+  // toValue with null
+  assert.equal(_test.toValue(null), undefined);
+  // toValue with undefined
+  assert.equal(_test.toValue(undefined), undefined);
+});
+
+// ── TC3 Signing ───────────────────────────────────────────
+
+test('TC3 signing produces valid authorization header', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+
+  const signed = _test.tc3Sign(
+    { Limit: 20, Offset: 0 },
+    'test-secret-id',
+    'test-secret-key',
+    'ap-guangzhou',
+    'bh.tencentcloudapi.com',
+    'DescribeSessions',
+  );
+
+  assert.ok(signed.url.startsWith('https://'));
+  assert.ok(signed.headers.authorization.startsWith('TC3-HMAC-SHA256'));
+  assert.ok(signed.headers['content-type'], 'application/json');
+  assert.ok(signed.headers['x-tc-action'], 'describesessions');
+  assert.ok(signed.headers['x-tc-region'], 'ap-guangzhou');
+  assert.ok(signed.headers['x-tc-version'], '2023-04-18');
+  assert.ok(String(signed.headers['x-tc-timestamp']).length === 10);
+  assert.equal(signed.body, JSON.stringify({ Limit: 20, Offset: 0 }));
+});
+
+test('canonical request structure', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+
+  const canonReq = _test.buildCanonicalRequest(
+    'POST',
+    '/',
+    '',
+    { 'content-type': 'application/json', host: 'bh.tencentcloudapi.com' },
+    ['content-type', 'host'],
+    'abc123',
+  );
+
+  assert.ok(canonReq.startsWith('POST\n/'));
+  assert.ok(canonReq.endsWith('abc123'));
+});
+
+// ── Credential resolution ─────────────────────────────────
+
+test('resolveCredentials extracts and validates credentials', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+
+  const creds = _test.resolveCredentials({ secret_id: 'id1', secret_key: 'key1' });
+  assert.equal(creds.secretId, 'id1');
+  assert.equal(creds.secretKey, 'key1');
+
+  const camelCase = _test.resolveCredentials({ secretId: 'id2', secretKey: 'key2' });
+  assert.equal(camelCase.secretId, 'id2');
+  assert.equal(camelCase.secretKey, 'key2');
+
+  assert.throws(() => _test.resolveCredentials({}), /secret_id.*is required/);
+  assert.throws(() => _test.resolveCredentials({ secret_id: 'id' }), /secret_key.*is required/);
+});
+
+test('resolveRegion and resolveEndpoint use defaults', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+
+  assert.equal(_test.resolveRegion({}), 'ap-guangzhou');
+  assert.equal(_test.resolveRegion({ region: 'ap-beijing' }), 'ap-beijing');
+  assert.equal(_test.resolveEndpoint({}), 'bh.tencentcloudapi.com');
+  assert.equal(_test.resolveEndpoint({ endpoint: 'custom.bh.com' }), 'custom.bh.com');
+});
+
+// ── ListSessions ──────────────────────────────────────────
+
+test('ListSessions builds correct request params', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+
+  const defaultParams = _test.buildListSessionsParams({});
+  assert.equal(defaultParams.Limit, 20);
+  assert.ok(!('Offset' in defaultParams));
+  assert.ok(!('Filters' in defaultParams));
+
+  const withFilters = _test.buildListSessionsParams({
+    offset: 10,
+    limit: 50,
+    status: ['ACTIVE'],
+    user_name: 'admin',
+    device_name: 'web-01',
+  });
+  assert.equal(withFilters.Offset, 10);
+  assert.equal(withFilters.Limit, 50);
+  assert.ok(withFilters.Filters.length >= 3);
+});
+
+test('ListSessions sends signed request and maps response', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        Response: {
+          SessionSet: [
+            {
+              Id: 'session-1',
+              UserName: 'admin',
+              DeviceName: 'server-01',
+              Status: 'ACTIVE',
+              StartTime: '2026-06-25T10:00:00Z',
+              EndTime: '',
+            },
+          ],
+          TotalCount: 1,
+        },
+      }),
+    };
+  });
+
+  const handler = await loadHandler(
+    { status: ['ACTIVE'], limit: 10 },
+    listSessionsPath,
+  );
+  const res = await handler();
+
+  assert.ok(captured.url.includes('bh.tencentcloudapi.com'));
+  assert.equal(captured.init.method, 'POST');
+  assert.equal(captured.init.headers['content-type'], 'application/json');
+  assert.equal(captured.init.headers['x-tc-action'], 'describesessions');
+  assert.equal(res.items.length, 1);
+  assert.equal(res.items[0].id, 'session-1');
+  assert.equal(res.items[0].user_name, 'admin');
+  assert.equal(res.items[0].status, 'ACTIVE');
+  assert.equal(res.total_count, 1);
+});
+
+test('ListSessions handles empty response', async () => {
+  mockUpstream({ Response: { SessionSet: [], TotalCount: 0 } });
+  const handler = await loadHandler({}, listSessionsPath);
+  const res = await handler();
+  assert.deepEqual(res.items, []);
+  assert.equal(res.total_count, 0);
+});
+
+test('ListSessions validates and maps upstream errors', async () => {
+  setFetch(async () => ({
+    ok: false,
+    status: 401,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => 'Unauthorized',
+  }));
+  const handler = await loadHandler({}, listSessionsPath);
+  await assert.rejects(() => handler(), /PERMISSION_DENIED/);
+
+  setFetch(async () => ({
+    ok: false,
+    status: 500,
+    headers: new Map([['content-type', 'text/plain']]),
+    text: async () => 'Internal Server Error',
+  }));
+  const handler500 = await loadHandler({}, listSessionsPath);
+  await assert.rejects(() => handler500(), /UNAVAILABLE/);
+
+  setFetch(async () => {
+    throw new Error('network timeout');
+  });
+  const handlerNet = await loadHandler({}, listSessionsPath);
+  await assert.rejects(() => handlerNet(), /UNAVAILABLE/);
+});
+
+test('ListSessions handles Tencent API error response', async () => {
+  mockUpstream({
+    Response: {
+      Error: {
+        Code: 'AuthFailure',
+        Message: 'SecretId not found',
+      },
+    },
+  });
+  const handler = await loadHandler({}, listSessionsPath);
+  await assert.rejects(() => handler(), /PERMISSION_DENIED: Tencent API error: AuthFailure/);
+});
+
+test('ListSessions handles non-JSON and empty body', async () => {
+  setFetch(async () => ({
+    ok: true,
+    status: 200,
+    headers: new Map([['content-type', 'text/plain']]),
+    text: async () => 'not json',
+  }));
+  const handler = await loadHandler({}, listSessionsPath);
+  await assert.rejects(() => handler(), /UNKNOWN: response is not valid JSON/);
+
+  setFetch(async () => ({
+    ok: true,
+    status: 200,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => '',
+  }));
+  const handlerEmpty = await loadHandler({}, listSessionsPath);
+  await assert.rejects(() => handlerEmpty(), /UNKNOWN: empty response/);
+});
+
+test('ListSessions respects max limit', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+  const params = _test.buildListSessionsParams({ limit: 500 });
+  assert.equal(params.Limit, 20);
+});
+
+// ── KillSession ───────────────────────────────────────────
+
+test('KillSession requires session_id', async () => {
+  const handler = await loadHandler({}, killSessionPath);
+  await assert.rejects(() => handler(), /INVALID_ARGUMENT: session_id is required/);
+});
+
+test('KillSession sends correct API call', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({ Response: { err: null, msg: 'ok' } }),
+    };
+  });
+
+  const handler = await loadHandler({ session_id: 'sess-123' }, killSessionPath);
+  const res = await handler();
+  assert.ok(captured.init.headers['x-tc-action'], 'killsession');
+  const body = JSON.parse(captured.init.body);
+  assert.equal(body.SessionId, 'sess-123');
+});
+
+// ── ListDevices ───────────────────────────────────────────
+
+test('ListDevices builds params and maps response', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+
+  // Test with offset and limit parameters
+  const params = _test.buildListDevicesParams({ name: 'web', ip: '10.0.0.1', limit: 50, offset: 10 });
+  assert.equal(params.Limit, 50);
+  assert.equal(params.Offset, 10);
+  assert.equal(params.Filters[0].Name, 'DeviceName');
+  assert.equal(params.Filters[1].Name, 'Ip');
+
+  // Test without filters
+  const noFilters = _test.buildListDevicesParams({});
+  assert.ok(!('Filters' in noFilters));
+
+  // Test with negative offset
+  const negOffset = _test.buildListDevicesParams({ offset: -1 });
+  assert.ok(!('Offset' in negOffset));
+
+  mockUpstream({
+    Response: {
+      DeviceSet: [
+        { Id: 'dev-1', DeviceName: 'web-01', Ip: '10.0.0.1', DeviceType: 'Linux', State: 'online', Department: 'IT' },
+      ],
+      TotalCount: 1,
+    },
+  });
+  const handler = await loadHandler({}, listDevicesPath);
+  const res = await handler();
+  assert.equal(res.items[0].name, 'web-01');
+  assert.equal(res.items[0].ip, '10.0.0.1');
+});
+
+// ── ListUsers ─────────────────────────────────────────────
+
+test('ListUsers builds params and maps response', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+
+  const params = _test.buildListUsersParams({ name: 'admin', status: 'NORMAL', offset: 20 });
+  assert.equal(params.Offset, 20);
+  assert.equal(params.Filters[0].Name, 'UserName');
+  assert.equal(params.Filters[1].Name, 'Status');
+
+  // No status filter
+  const noStatus = _test.buildListUsersParams({});
+  assert.ok(!('Filters' in noStatus));
+
+  // Max limit exceeded, should cap to default
+  const maxed = _test.buildListUsersParams({ limit: 500 });
+  assert.equal(maxed.Limit, 20);
+
+  mockUpstream({
+    Response: {
+      UserSet: [
+        { UserId: 'u-1', UserName: 'admin', RealName: 'Admin User', Phone: '13800000000', Email: 'admin@test.com', Status: 'NORMAL', Department: 'IT' },
+      ],
+      TotalCount: 1,
+    },
+  });
+  const handler = await loadHandler({}, listUsersPath);
+  const res = await handler();
+  assert.equal(res.items[0].user_name, 'admin');
+  assert.equal(res.items[0].status, 'NORMAL');
+});
+
+// ── LockUser / UnlockUser ─────────────────────────────────
+
+test('LockUser requires user_id', async () => {
+  const handler = await loadHandler({}, lockUserPath);
+  await assert.rejects(() => handler(), /INVALID_ARGUMENT: user_id is required/);
+});
+
+test('LockUser sends API call with correct param', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({ Response: {} }),
+    };
+  });
+
+  const handler = await loadHandler({ user_id: 'u-1' }, lockUserPath);
+  await handler();
+  const body = JSON.parse(captured.init.body);
+  assert.equal(body.UserId, 'u-1');
+  assert.ok(captured.init.headers['x-tc-action'], 'lockuser');
+});
+
+test('UnlockUser requires user_id', async () => {
+  const handler = await loadHandler({}, unlockUserPath);
+  await assert.rejects(() => handler(), /INVALID_ARGUMENT: user_id is required/);
+});
+
+test('UnlockUser sends API call with correct param', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({ Response: {} }),
+    };
+  });
+
+  const handler = await loadHandler({ user_id: 'u-1' }, unlockUserPath);
+  await handler();
+  const body = JSON.parse(captured.init.body);
+  assert.equal(body.UserId, 'u-1');
+  assert.ok(captured.init.headers['x-tc-action'], 'unlockuser');
+});
+
+// ── SDK handlers ──────────────────────────────────────────
+
+test('SDK handlers accept two-arg (req, ctx) style', async () => {
+  let captured;
+  setFetch(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        Response: { SessionSet: [{ Id: 's-1', UserName: 'admin', DeviceName: 'svr', Status: 'ACTIVE' }], TotalCount: 1 },
+      }),
+    };
+  });
+
+  const { handlers, LIST_SESSIONS_FULL } = await import('../src/tencent-bh.js');
+  const res = await handlers[LIST_SESSIONS_FULL](
+    { status: ['ACTIVE'] },
+    {
+      config: { region: 'ap-beijing' },
+      secret: { secret_id: 'sdk-id', secret_key: 'sdk-key' },
+      meta: { instance_id: 'sdk-inst' },
+    },
+  );
+
+  assert.equal(res.items.length, 1);
+  assert.equal(captured.init.headers['x-engine-instance'], 'sdk-inst');
+});
+
+// ── Multiple error status codes ───────────────────────────
+
+test('HTTP error codes are mapped correctly', async () => {
+  setFetch(async () => ({
+    ok: false,
+    status: 403,
+    headers: new Map([['content-type', 'text/plain']]),
+    text: async () => 'Forbidden',
+  }));
+  const h403 = await loadHandler({}, listSessionsPath);
+  await assert.rejects(() => h403(), /PERMISSION_DENIED/);
+
+  setFetch(async () => ({
+    ok: false,
+    status: 422,
+    headers: new Map([['content-type', 'text/plain']]),
+    text: async () => 'Invalid params',
+  }));
+  const h422 = await loadHandler({}, listSessionsPath);
+  await assert.rejects(() => h422(), /FAILED_PRECONDITION/);
+
+  setFetch(async () => ({
+    ok: false,
+    status: 503,
+    headers: new Map([['content-type', 'text/plain']]),
+    text: async () => 'Service unavailable',
+  }));
+  const h503 = await loadHandler({}, listSessionsPath);
+  await assert.rejects(() => h503(), /UNAVAILABLE/);
+});
+
+// ── Response mapping variations ───────────────────────────
+
+test('Response mappers handle missing fields gracefully', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+
+  const session = _test.mapSessionRecord({});
+  assert.equal(session.id, '');
+  assert.equal(session.user_name, '');
+
+  const device = _test.mapDeviceRecord({});
+  assert.equal(device.name, '');
+  assert.equal(device.ip, '');
+
+  const user = _test.mapUserRecord({});
+  assert.equal(user.user_name, '');
+  assert.equal(user.status, '');
+});
+
+test('Map empty upstream response sets', async () => {
+  mockUpstream({ Response: {} });
+  const handler = await loadHandler({}, listDevicesPath);
+  const res = await handler();
+  assert.deepEqual(res.items, []);
+  assert.equal(res.total_count, 0);
+});
+
+// ── Edge cases for params builders ────────────────────────
+
+test('Param builders handle limit over max', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+
+  const sessionsParams = _test.buildListSessionsParams({ limit: 999 });
+  assert.equal(sessionsParams.Limit, 20);
+
+  const devicesParams = _test.buildListDevicesParams({ limit: 999 });
+  assert.equal(devicesParams.Limit, 20);
+
+  const usersParams = _test.buildListUsersParams({ limit: 0 });
+  assert.equal(usersParams.Limit, 20);
+});
+
+// ── hasOwn and resolveCallContext ─────────────────────────
+
+test('hasOwn and resolveCallContext utilities work', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+
+  assert.ok(_test.hasOwn({ a: 1 }, 'a'));
+  assert.ok(!_test.hasOwn({ a: 1 }, 'b'));
+  assert.ok(!_test.hasOwn(null, 'a'));
+  assert.ok(!_test.hasOwn(undefined, 'a'));
+
+  const resolved = _test.resolveCallContext({
+    config: { region: 'test' },
+    secret: { secret_id: 'id' },
+    meta: { instance_id: 'inst' },
+    req: { limit: 10 },
+  });
+  assert.equal(resolved.req.limit, 10);
+  assert.equal(resolved.bindings.region, 'test');
+  assert.equal(resolved.bindings.secret_id, 'id');
+
+  // resolveTimeoutMs
+  assert.equal(_test.resolveTimeoutMs({ timeoutMs: 5000 }, {}), 5000);
+  assert.equal(_test.resolveTimeoutMs({}, { timeoutMs: 3000 }), 3000);
+  assert.equal(_test.resolveTimeoutMs({}, {}), 10000); // default
+});
+
+test('logFlow handles stringify failure gracefully', async () => {
+  const { _test } = await import('../src/tencent-bh.js');
+  // Should not throw - circular reference would cause JSON.stringify to throw
+  const circular = { self: null };
+  circular.self = circular;
+  _test.logFlow({}, 'test', circular);
+});
+
+// ── Error branch: missing credentials at handler call ─────
+
+test('Handler fails with clear error when credentials are not configured', async () => {
+  // Override the default bindings to remove credentials
+  const handler = await loadHandler(
+    {},
+    listSessionsPath,
+    { bindings: { secret_id: '', secret_key: '', region: 'ap-guangzhou' } },
+  );
+  await assert.rejects(() => handler(), /FAILED_PRECONDITION/);
+});

--- a/services/tencent__bh/test/tencent-bh.test.js
+++ b/services/tencent__bh/test/tencent-bh.test.js
@@ -74,27 +74,22 @@ test('internal helpers work correctly', async () => {
   assert.equal(_test.toBoolean('true'), true);
   assert.equal(_test.toBoolean('false'), false);
   assert.equal(_test.toBoolean({ value: 'true' }), true);
-  assert.equal(_test.toBoolean({}), true);  // object → Boolean({}) = true
-  assert.equal(_test.toBoolean(0), false);  // number 0
-  assert.equal(_test.toBoolean(1), true);   // number non-zero
+  assert.equal(_test.toBoolean({}), true);
+  assert.equal(_test.toBoolean(0), false);
+  assert.equal(_test.toBoolean(1), true);
 
   // toValue - various types including edge cases
   assert.deepEqual(_test.toValue('hello'), { stringValue: 'hello' });
   assert.deepEqual(_test.toValue(42), { numberValue: 42 });
   assert.deepEqual(_test.toValue(true), { boolValue: true });
-  // toValue with object
   const objVal = _test.toValue({ key: 'val' });
   assert.ok(objVal.structValue);
   assert.equal(objVal.structValue.fields.key.stringValue, 'val');
-  // toValue with array
   const arrVal = _test.toValue(['a', 'b']);
   assert.equal(arrVal.listValue.values.length, 2);
-  // toValue with symbol (other type)
   const symVal = _test.toValue(Symbol.for('test'));
   assert.equal(symVal.stringValue, 'Symbol(test)');
-  // toValue with null
   assert.equal(_test.toValue(null), undefined);
-  // toValue with undefined
   assert.equal(_test.toValue(undefined), undefined);
 });
 
@@ -113,29 +108,33 @@ test('TC3 signing produces valid authorization header', async () => {
   );
 
   assert.ok(signed.url.startsWith('https://'));
-  assert.ok(signed.headers.authorization.startsWith('TC3-HMAC-SHA256'));
-  assert.ok(signed.headers['content-type'], 'application/json');
-  assert.ok(signed.headers['x-tc-action'], 'describesessions');
-  assert.ok(signed.headers['x-tc-region'], 'ap-guangzhou');
-  assert.ok(signed.headers['x-tc-version'], '2023-04-18');
-  assert.ok(String(signed.headers['x-tc-timestamp']).length === 10);
+  assert.ok(signed.headers['Authorization'].startsWith('TC3-HMAC-SHA256'));
+  assert.equal(signed.headers['Content-Type'], 'application/json');
+  assert.equal(signed.headers['X-TC-Action'], 'DescribeSessions');
+  assert.equal(signed.headers['X-TC-Region'], 'ap-guangzhou');
+  assert.equal(signed.headers['X-TC-Version'], '2023-04-18');
+  assert.equal(String(signed.headers['X-TC-Timestamp']).length, 10);
   assert.equal(signed.body, JSON.stringify({ Limit: 20, Offset: 0 }));
 });
 
 test('canonical request structure', async () => {
   const { _test } = await import('../src/tencent-bh.js');
 
-  const canonReq = _test.buildCanonicalRequest(
-    'POST',
-    '/',
-    '',
-    { 'content-type': 'application/json', host: 'bh.tencentcloudapi.com' },
-    ['content-type', 'host'],
-    'abc123',
+  const signed = _test.tc3Sign(
+    { test: 'value' },
+    'test-id',
+    'test-key',
+    'ap-guangzhou',
+    'bh.tencentcloudapi.com',
+    'TestAction',
   );
 
-  assert.ok(canonReq.startsWith('POST\n/'));
-  assert.ok(canonReq.endsWith('abc123'));
+  const auth = signed.headers['Authorization'];
+  assert.ok(auth.startsWith('TC3-HMAC-SHA256'));
+  assert.ok(auth.includes('Credential='));
+  assert.ok(auth.includes('SignedHeaders=content-type;host'));
+  assert.ok(auth.includes('Signature='));
+  assert.equal(signed.headers['Content-Type'], 'application/json');
 });
 
 // ── Credential resolution ─────────────────────────────────
@@ -220,8 +219,12 @@ test('ListSessions sends signed request and maps response', async () => {
 
   assert.ok(captured.url.includes('bh.tencentcloudapi.com'));
   assert.equal(captured.init.method, 'POST');
-  assert.equal(captured.init.headers['content-type'], 'application/json');
-  assert.equal(captured.init.headers['x-tc-action'], 'describesessions');
+  assert.equal(captured.init.headers['Content-Type'], 'application/json');
+  assert.equal(captured.init.headers['X-TC-Action'], 'DescribeSessions');
+  // Verify x-tc-action also works (lowercase)
+  const lowerHeaders = {};
+  Object.keys(captured.init.headers).forEach(k => { lowerHeaders[k.toLowerCase()] = captured.init.headers[k]; });
+  assert.equal(lowerHeaders['x-tc-action'], 'DescribeSessions');
   assert.equal(res.items.length, 1);
   assert.equal(res.items[0].id, 'session-1');
   assert.equal(res.items[0].user_name, 'admin');
@@ -323,7 +326,7 @@ test('KillSession sends correct API call', async () => {
 
   const handler = await loadHandler({ session_id: 'sess-123' }, killSessionPath);
   const res = await handler();
-  assert.ok(captured.init.headers['x-tc-action'], 'killsession');
+  assert.equal(captured.init.headers['X-TC-Action'], 'KillSession');
   const body = JSON.parse(captured.init.body);
   assert.equal(body.SessionId, 'sess-123');
 });
@@ -413,11 +416,11 @@ test('LockUser sends API call with correct param', async () => {
     };
   });
 
-  const handler = await loadHandler({ user_id: 'u-1' }, lockUserPath);
+  const handler = await loadHandler({ user_id: 1 }, lockUserPath);
   await handler();
   const body = JSON.parse(captured.init.body);
-  assert.equal(body.UserId, 'u-1');
-  assert.ok(captured.init.headers['x-tc-action'], 'lockuser');
+  assert.deepEqual(body.IdSet, [1]);
+  assert.equal(captured.init.headers['X-TC-Action'], 'LockUser');
 });
 
 test('UnlockUser requires user_id', async () => {
@@ -437,11 +440,11 @@ test('UnlockUser sends API call with correct param', async () => {
     };
   });
 
-  const handler = await loadHandler({ user_id: 'u-1' }, unlockUserPath);
+  const handler = await loadHandler({ user_id: 1 }, unlockUserPath);
   await handler();
   const body = JSON.parse(captured.init.body);
-  assert.equal(body.UserId, 'u-1');
-  assert.ok(captured.init.headers['x-tc-action'], 'unlockuser');
+  assert.deepEqual(body.IdSet, [1]);
+  assert.equal(captured.init.headers['X-TC-Action'], 'UnlockUser');
 });
 
 // ── SDK handlers ──────────────────────────────────────────

--- a/services/tencent__bh/test/tencent-bh.test.js
+++ b/services/tencent__bh/test/tencent-bh.test.js
@@ -248,7 +248,7 @@ test('ListSessions validates and maps upstream errors', async () => {
     text: async () => 'Unauthorized',
   }));
   const handler = await loadHandler({}, listSessionsPath);
-  await assert.rejects(() => handler(), /PERMISSION_DENIED/);
+  await assert.rejects(() => handler(), /UNAUTHENTICATED/);
 
   setFetch(async () => ({
     ok: false,
@@ -276,7 +276,7 @@ test('ListSessions handles Tencent API error response', async () => {
     },
   });
   const handler = await loadHandler({}, listSessionsPath);
-  await assert.rejects(() => handler(), /PERMISSION_DENIED: Tencent API error: AuthFailure/);
+  await assert.rejects(() => handler(), /UNAUTHENTICATED: Tencent API error: AuthFailure/);
 });
 
 test('ListSessions handles non-JSON and empty body', async () => {


### PR DESCRIPTION
## 阿里云容器安全 (云安全中心) Service Package

适配 [GitHub Issue #268](https://github.com/chaitin/OctoBus/issues/268)。

### 已实现方法

| gRPC 方法 | CLI 命令 | 说明 |
|-----------|----------|------|
| Alibaba_SAS/ListContainerInstances | list-container-instances | 查询容器实例列表 |
| Alibaba_SAS/ListImageInstances | list-image-instances | 查询镜像实例列表 |
| Alibaba_SAS/ListImageVulnerabilities | list-image-vulnerabilities | 查询镜像漏洞列表 |
| Alibaba_SAS/GetClusterSuspEventStatistics | get-cluster-susp-event-statistics | 集群安全事件统计 |
| Alibaba_SAS/ListClusterInterceptionConfig | list-cluster-interception-config | 查询集群拦截规则 |

### 认证方式
- Alibaba Cloud RPC HMAC-SHA1 签名
- 需配置 AccessKeyId/AccessKeySecret
- 签名密钥格式：`AccessKeySecret + "\&"`
- API 版本：2018-12-03
- 适用产品：云安全中心（Security Center / SAS）

### 风险说明
- 所有方法均为只读查询，建议 capset: `recon`

### 验证结果
- ✅ `npm run validate -- --service-dir alibaba__sas` 通过
- ✅ `npm test -- --service-dir alibaba__sas` — **37 项测试全部通过**
- ✅ `npm run pack:check` 通过

### 文件清单
```
services/alibaba__sas/
├── service.json              # OctoBus 服务声明
├── package.json              # 依赖声明
├── config.schema.json        # 配置项（region/endpoint/timeout）
├── secret.schema.json        # 密钥项（access_key_id/access_key_secret）
├── proto/alibaba_sas.proto   # gRPC API 定义（5 个 RPC）
├── src/
│   ├── service.js            # SDK defineService 入口
│   └── alibaba-sas.js        # HMAC-SHA1 RPC 签名实现
├── bin/alibaba-sas.js        # 服务本地入口
├── test/alibaba-sas.test.js  # 37 项单元测试（mock 全覆盖）
└── README.md                 # 完整使用文档
services/bin/alibaba-sas.js         # 包 CLI 入口
services/bin/octobus-tentacles.js  # 更新分发器
services/package.json             # 注册新服务
```

### 已知限制
1. 分页查询大数据集可能需要多次调用
2. Search criteria 语法取决于阿里云 SAS API 实现
3. 暂未实现写操作（如漏洞修复、容器阻断）
4. 需要有效阿里云 AccessKey 和 SAS 产品权限