### PR TITLE
chore: support docker build mirrors

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,55 +1,62 @@
-FROM ubuntu:26.04 AS builder
+ARG REGISTRY_MIRROR=docker.io
+ARG GO_VERSION=1.26.1
 
+FROM ${REGISTRY_MIRROR}/library/golang:${GO_VERSION}-bookworm AS golang-toolchain
+
+FROM ${REGISTRY_MIRROR}/library/ubuntu:26.04 AS builder
+
+ARG GOPROXY=https://goproxy.cn,direct
 ENV DEBIAN_FRONTEND=noninteractive \
-	GOTOOLCHAIN=auto
+    GOTOOLCHAIN=local \
+    PATH=/usr/local/go/bin:${PATH}
 WORKDIR /src
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		ca-certificates \
-		git \
-		golang-go \
-		make \
-		nodejs \
-		npm \
-		protobuf-compiler \
-		libprotobuf-dev \
-	&& rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    make \
+    nodejs \
+    npm \
+    protobuf-compiler \
+    libprotobuf-dev \
+    && rm -rf /var/lib/apt/lists/*
 
+COPY --from=golang-toolchain /usr/local/go /usr/local/go
 COPY go.mod go.sum ./
-RUN go mod download
+RUN go env -w GOPROXY="${GOPROXY}" && go mod download
 
 COPY . .
 ARG OCTOBUS_VERSION
 ARG OCTOBUS_COMMIT
 ARG OCTOBUS_BUILD_DATE
 RUN bash ./scripts/build-octobus.sh /out/octobus \
-	&& if LC_ALL=C ldd /out/octobus 2>&1 | grep -q "not a dynamic executable"; then \
-		true; \
-	else \
-		echo "/out/octobus is dynamically linked; expected a static binary" >&2; \
-		LC_ALL=C ldd /out/octobus >&2; \
-		exit 1; \
-	fi
+    && if LC_ALL=C ldd /out/octobus 2>&1 | grep -q "not a dynamic executable"; then \
+    true; \
+    else \
+    echo "/out/octobus is dynamically linked; expected a static binary" >&2; \
+    LC_ALL=C ldd /out/octobus >&2; \
+    exit 1; \
+    fi
 
-FROM ubuntu:26.04
+FROM ${REGISTRY_MIRROR}/library/ubuntu:26.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
-	OCTOBUS_ADDR=0.0.0.0:9000 \
-	OCTOBUS_DATA_DIR=/var/lib/octobus
+    OCTOBUS_ADDR=0.0.0.0:9000 \
+    OCTOBUS_DATA_DIR=/var/lib/octobus
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		git \
-		nodejs \
-		npm \
-		protobuf-compiler \
-		libprotobuf-dev \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& groupadd --system octobus \
-	&& useradd --system --gid octobus --home-dir /var/lib/octobus --create-home --shell /usr/sbin/nologin octobus
+    && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    nodejs \
+    npm \
+    protobuf-compiler \
+    libprotobuf-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system octobus \
+    && useradd --system --gid octobus --home-dir /var/lib/octobus --create-home --shell /usr/sbin/nologin octobus
 
 COPY --from=builder /out/octobus /usr/local/bin/octobus
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,12 +32,12 @@ ARG OCTOBUS_COMMIT
 ARG OCTOBUS_BUILD_DATE
 RUN bash ./scripts/build-octobus.sh /out/octobus \
     && if LC_ALL=C ldd /out/octobus 2>&1 | grep -q "not a dynamic executable"; then \
-    true; \
-    else \
-    echo "/out/octobus is dynamically linked; expected a static binary" >&2; \
-    LC_ALL=C ldd /out/octobus >&2; \
-    exit 1; \
-    fi
+		true; \
+	else \
+		echo "/out/octobus is dynamically linked; expected a static binary" >&2; \
+		LC_ALL=C ldd /out/octobus >&2; \
+		exit 1; \
+	fi
 
 FROM ${REGISTRY_MIRROR}/library/ubuntu:26.04
 
@@ -47,16 +47,16 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    git \
-    nodejs \
-    npm \
-    protobuf-compiler \
-    libprotobuf-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    && groupadd --system octobus \
-    && useradd --system --gid octobus --home-dir /var/lib/octobus --create-home --shell /usr/sbin/nologin octobus
+		ca-certificates \
+		curl \
+		git \
+		nodejs \
+		npm \
+		protobuf-compiler \
+		libprotobuf-dev \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& groupadd --system octobus \
+	&& useradd --system --gid octobus --home-dir /var/lib/octobus --create-home --shell /usr/sbin/nologin octobus
 
 COPY --from=builder /out/octobus /usr/local/bin/octobus
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,13 +13,13 @@ WORKDIR /src
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    git \
-    make \
-    nodejs \
-    npm \
-    protobuf-compiler \
-    libprotobuf-dev \
+        ca-certificates \
+        git \
+        make \
+        nodejs \
+        npm \
+        protobuf-compiler \
+        libprotobuf-dev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=golang-toolchain /usr/local/go /usr/local/go


### PR DESCRIPTION
OctoBus/docker/Dockerfile 支持 REGISTRY_MIRROR
用 golang:${GO_VERSION}-bookworm 提供 Go 1.26.1 工具链
设置 GOTOOLCHAIN=local，避免 go mod download 时再去拉 golang.org/toolchain
保留 GOPROXY 用于 Go module 下载