### PR TITLE
feat: add Wazuh SIEM v4.9 service — dual-endpoint alert & vulnerability query

### DIFF
--- a/services/bin/octobus-tentacles.js
+++ b/services/bin/octobus-tentacles.js
@@ -514,6 +514,10 @@ const services = {
     entryFile: "../nist__nvd-v2/bin/nist-nvd-v2.js",
     serviceModule: "../nist__nvd-v2/src/service.js",
   },
+  "siem": {
+    entryFile: "../wazuh__siem/bin/siem.js",
+    serviceModule: "../wazuh__siem/src/service.js",
+  },
 };
 
 const serviceNames = Object.keys(services);

--- a/services/bin/siem.js
+++ b/services/bin/siem.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import { runServiceMain } from "@chaitin-ai/octobus-sdk";
+
+import { service } from "../wazuh__siem/src/service.js";
+
+runServiceMain(service, {
+  entryFile: fileURLToPath(new URL("../wazuh__siem/bin/siem.js", import.meta.url)),
+});

--- a/services/package.json
+++ b/services/package.json
@@ -129,7 +129,8 @@
     "tencent-ssl": "bin/tencent-ssl.js",
     "reportedip": "bin/reportedip.js",
     "tencent-bh": "bin/tencent-bh.js",
-    "nist-nvd-v2": "bin/nist-nvd-v2.js"
+    "nist-nvd-v2": "bin/nist-nvd-v2.js",
+    "siem": "bin/siem.js"
   },
   "files": [
     "bin/huawei-ccm.js",
@@ -383,7 +384,9 @@
     "tencent__bh",
     "bin/tencent-bh.js",
     "nist__nvd-v2",
-    "bin/nist-nvd-v2.js"
+    "bin/nist-nvd-v2.js",
+    "wazuh__siem",
+    "bin/siem.js"
   ],
   "scripts": {
     "validate": "node scripts/validate-service-package.mjs",

--- a/services/wazuh__siem/README.md
+++ b/services/wazuh__siem/README.md
@@ -1,0 +1,133 @@
+# Wazuh SIEM OctoBus Service
+
+This package provides OctoBus integration for Wazuh SIEM security monitoring platform.
+
+Import it into OctoBus with:
+
+```bash
+octobus service import siem ./services/wazuh__siem
+```
+
+## Package Files
+
+- `service.json`: OctoBus service manifest.
+- `proto/wazuh_siem.proto`: gRPC API definition.
+- `config.schema.json`: dual endpoint, headers, timeout, and TLS settings.
+- `secret.schema.json`: Manager JWT credentials and Indexer Basic Auth credentials.
+- `src/wazuh-siem.js`: dual-endpoint REST proxy (Manager JWT + Indexer OpenSearch).
+- `src/service.js`: OctoBus SDK `defineService` wrapper.
+- `bin/siem.js`: service-local executable entrypoint.
+- `test/wazuh-siem.test.js`: node:test coverage for both endpoints.
+- `test/mock_upstream.js`: optional local mock (JWT auth + OpenSearch).
+
+## Architecture
+
+Wazuh 4.9.x uses a dual-endpoint architecture:
+
+| Endpoint | Component | Auth | Used By |
+|----------|-----------|------|---------|
+| `endpoint` | Manager API (port 55000) | JWT (Basic Auth → Bearer) | ListAgents |
+| `indexerEndpoint` | Indexer (OpenSearch, port 9200) | Basic Auth | ListAlerts, GetAlertSummary, ListVulnerabilities, GetVulnerabilitySummary |
+
+- The **Manager API** provides management operations (agents, rules, config).
+- The **Indexer** (OpenSearch) stores alert and vulnerability data in `wazuh-alerts-*` and `wazuh-vulnerabilities-*` indices.
+
+## Configuration
+
+Use `endpoint` for the Wazuh Manager API and `indexerEndpoint` for the Wazuh Indexer (OpenSearch):
+
+```json
+{
+  "endpoint": "https://wazuh-manager:55000",
+  "indexerEndpoint": "https://wazuh-indexer:9200",
+  "headers": {
+    "X-Extra": "demo"
+  },
+  "timeoutMs": 5000,
+  "skipTlsVerify": true
+}
+```
+
+Use `secret.username` / `secret.password` for Manager JWT auth, and `secret.indexerUsername` / `secret.indexerPassword` for Indexer Basic Auth:
+
+```json
+{
+  "username": "wazuh",
+  "password": "your-manager-password",
+  "indexerUsername": "admin",
+  "indexerPassword": "your-indexer-password"
+}
+```
+
+Requests may still pass `username` and `password` for Manager JWT auth; request values take precedence over the configured secret values.
+
+## Authentication
+
+### Manager API (JWT Token)
+
+Wazuh Manager uses JWT token authentication:
+
+1. **Token acquisition**: `POST /security/user/authenticate` with Basic Auth (`username:password`)
+2. **Token caching**: JWT token cached with expiry time (default 900s/15min)
+3. **Token refresh**: Token refreshed 60s before expiry
+4. **Auto-retry**: On HTTP 401 (expired token), automatically re-authenticates and retries once
+
+### Indexer API (Basic Auth)
+
+Wazuh Indexer (OpenSearch) uses HTTP Basic Auth:
+
+- `Authorization: Basic <base64(username:password)>`
+- Default username is `admin`; password depends on your deployment
+
+## RPC Methods
+
+- `Wazuh_SIEM.Wazuh_SIEM/ListAlerts` — Query security alerts via OpenSearch `wazuh-alerts-*` indices with DSL query, time range, severity level filtering, and pagination.
+- `Wazuh_SIEM.Wazuh_SIEM/GetAlertSummary` — Get alert severity distribution via OpenSearch range aggregation on `rule.level`.
+- `Wazuh_SIEM.Wazuh_SIEM/ListVulnerabilities` — Query vulnerability results from `wazuh-vulnerabilities-*` indices for a specific agent (requires `agent_id`).
+- `Wazuh_SIEM.Wazuh_SIEM/GetVulnerabilitySummary` — Get vulnerability severity counts via OpenSearch terms aggregation on `vulnerability.severity` (requires `agent_id`).
+- `Wazuh_SIEM.Wazuh_SIEM/ListAgents` — List Wazuh agents via Manager API `/agents` with status, OS, and group information (useful for discovering `agent_id` for vulnerability queries).
+
+## Behavior Notes
+
+- `ListAlerts` sends `POST /wazuh-alerts-*/_search` to the Indexer with OpenSearch query DSL. The `query` field is built from `start_time`, `end_time`, `severity_min` (converted to range filters), and any raw `query` string (converted to `query_string`). Default sort is `timestamp:desc`.
+- `GetAlertSummary` sends `POST /wazuh-alerts-*/_search` to the Indexer with `size: 0` and a range aggregation on `rule.level` (buckets: level_12_plus ≥12, level_8_11 8-11, level_4_7 4-7, level_0_3 <4).
+- `ListVulnerabilities` sends `POST /wazuh-vulnerabilities-*/_search` to the Indexer with `agent.id` term filter plus optional `query_string` from the `query` field. `agent_id` is required.
+- `GetVulnerabilitySummary` sends `POST /wazuh-vulnerabilities-*/_search` to the Indexer with `agent.id` term filter and `vulnerability.severity` terms aggregation. `agent_id` is required.
+- `ListAgents` calls `GET /agents` on the Manager API with `status`, `limit`, `offset`, `search`, `q` parameters. Default status is "active".
+- HTTP 401/403 maps to `PERMISSION_DENIED`.
+- Other HTTP 4xx responses map to `FAILED_PRECONDITION`.
+- HTTP 5xx, network, and TLS failures map to `UNAVAILABLE`.
+- Non-JSON success bodies map to `UNKNOWN`.
+
+## Local Checks
+
+```bash
+cd services
+npm run validate -- --service-dir wazuh__siem
+npm test -- --service-dir wazuh__siem --coverage
+npm run pack:check
+```
+
+## Deployment
+
+```bash
+# Import service
+octobus service import siem ./services/wazuh__siem
+
+# Create instance with dual endpoint
+octobus instance create wazuh-local \
+  --service siem \
+  --config-json '{"endpoint":"https://localhost:55000","indexerEndpoint":"https://localhost:9200","skipTlsVerify":true}' \
+  --secret-json '{"username":"wazuh","password":"wazuh","indexerUsername":"admin","indexerPassword":"admin"}'
+
+# Create capset
+octobus capset create wazuh-readonly --name "Wazuh Read-Only"
+octobus capset add-instance wazuh-readonly wazuh-local
+octobus capset add-token wazuh-readonly wazuh-test-token --token wazuh-test-token
+
+# Verify
+grpcurl -plaintext -protoset <descriptor.protoset> \
+  -H "authorization: Bearer wazuh-test-token" \
+  -d '{"username":"wazuh","password":"wazuh"}' \
+  <host>:<port> Wazuh_SIEM.Wazuh_SIEM/ListAgents
+```

--- a/services/wazuh__siem/bin/siem.js
+++ b/services/wazuh__siem/bin/siem.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+import { runServiceMain } from "@chaitin-ai/octobus-sdk";
+
+import { service } from "../src/service.js";
+
+runServiceMain(service);

--- a/services/wazuh__siem/config.schema.json
+++ b/services/wazuh__siem/config.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["endpoint", "indexerEndpoint"],
+  "properties": {
+    "endpoint": {
+      "type": "string",
+      "description": "Wazuh Manager API URL (JWT auth), for example https://wazuh.example.com:55000. Required for ListAgents."
+    },
+    "indexerEndpoint": {
+      "type": "string",
+      "description": "Wazuh Indexer URL (OpenSearch), for example https://wazuh.example.com:9200. Required for ListAlerts/GetAlertSummary/ListVulnerabilities/GetVulnerabilitySummary."
+    },
+    "restBaseUrl": {
+      "type": "string",
+      "description": "Legacy alias for endpoint."
+    },
+    "baseUrl": {
+      "type": "string",
+      "description": "Legacy alias for endpoint."
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Optional extra HTTP headers sent to Wazuh API."
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 5000,
+      "description": "HTTP timeout in milliseconds."
+    },
+    "skipTlsVerify": {
+      "type": "boolean",
+      "default": false,
+      "description": "Skip TLS certificate verification for private Wazuh deployments."
+    },
+    "tlsInsecureSkipVerify": {
+      "type": "boolean",
+      "default": false,
+      "description": "Alias for skipTlsVerify. Use only with trusted private endpoints."
+    }
+  }
+}

--- a/services/wazuh__siem/package.json
+++ b/services/wazuh__siem/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "siem",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "siem": "bin/siem.js"
+  },
+  "dependencies": {
+    "@chaitin-ai/octobus-sdk": "^0.6.0",
+    "undici": "^7.16.0"
+  }
+}

--- a/services/wazuh__siem/proto/wazuh_siem.proto
+++ b/services/wazuh__siem/proto/wazuh_siem.proto
@@ -1,0 +1,185 @@
+syntax = "proto3";
+
+package Wazuh_SIEM;
+
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/struct.proto";
+
+option go_package = "miner/grpc-service/Wazuh_SIEM";
+
+service Wazuh_SIEM {
+  // 查询安全告警列表，支持 Wazuh 查询语法、时间范围和严重级别过滤
+  rpc ListAlerts(ListAlertsRequest) returns (ListAlertsResponse) {}
+
+  // 获取告警概览统计
+  rpc GetAlertSummary(GetAlertSummaryRequest) returns (GetAlertSummaryResponse) {}
+
+  // 查询指定代理的漏洞检测结果
+  rpc ListVulnerabilities(ListVulnerabilitiesRequest) returns (ListVulnerabilitiesResponse) {}
+
+  // 获取指定代理的漏洞摘要统计
+  rpc GetVulnerabilitySummary(GetVulnerabilitySummaryRequest) returns (GetVulnerabilitySummaryResponse) {}
+
+  // 查询代理列表（用于发现 agent_id）
+  rpc ListAgents(ListAgentsRequest) returns (ListAgentsResponse) {}
+}
+
+// ==================== ListAlerts ====================
+
+message ListAlertsRequest {
+  string username = 1;                          // Wazuh 用户名，可选（优先用 secret）
+  string password = 2;                          // Wazuh 密码，可选（优先用 secret）
+  string query = 3;                             // Wazuh 查询语法，如 "rule.level>=5"
+  google.protobuf.Int64Value start_time = 4;    // 开始时间（Unix秒），可选
+  google.protobuf.Int64Value end_time = 5;      // 结束时间（Unix秒），可选
+  google.protobuf.Int64Value severity_min = 6;  // 最低严重级别（0-16），可选
+  google.protobuf.Int64Value limit = 7;         // 每页条数，默认 10
+  google.protobuf.Int64Value offset = 8;        // 分页偏移，默认 0
+  string sort = 9;                              // 排序字段，默认 "-timestamp"
+  string search = 10;                           // 全文本搜索，可选
+}
+
+message ListAlertsResponse {
+  google.protobuf.Value err = 1;                // 错误信息
+  google.protobuf.Value msg = 2;                // 消息
+  AlertListResult data = 3;                     // 告警列表结果
+}
+
+message AlertListResult {
+  repeated AlertRecord alerts = 1;              // 告警记录列表
+  int64 total = 2;                              // 总条数
+  int64 limit = 3;                              // 每页条数
+  int64 offset = 4;                             // 分页偏移
+}
+
+message AlertRecord {
+  string id = 1;                                // 告警 ID
+  string timestamp = 2;                         // 时间戳
+  string rule_description = 3;                  // 规则描述
+  int32 rule_level = 4;                         // 规则级别（0-16）
+  string rule_groups = 5;                       // 规则分组（逗号分隔）
+  string rule_mitre_id = 6;                     // MITRE ATT&CK 技术 ID（逗号分隔）
+  string agent_id = 7;                          // 代理 ID
+  string agent_name = 8;                        // 代理名称
+  string agent_ip = 9;                          // 代理 IP
+  string full_log = 10;                         // 完整日志
+  google.protobuf.Struct raw = 11;              // 原始数据透传
+}
+
+// ==================== GetAlertSummary ====================
+
+message GetAlertSummaryRequest {
+  string username = 1;                          // Wazuh 用户名，可选
+  string password = 2;                          // Wazuh 密码，可选
+}
+
+message GetAlertSummaryResponse {
+  google.protobuf.Value err = 1;                // 错误信息
+  google.protobuf.Value msg = 2;                // 消息
+  AlertSummary data = 3;                        // 告警概览
+}
+
+message AlertSummary {
+  int64 total_alerts = 1;                       // 总告警数
+  int64 level_12_plus = 2;                      // 严重告警数（level >= 12）
+  int64 level_8_11 = 3;                         // 高危告警数（level 8-11）
+  int64 level_4_7 = 4;                          // 中危告警数（level 4-7）
+  int64 level_0_3 = 5;                          // 低危/信息告警数（level 0-3）
+  google.protobuf.Struct raw = 6;               // 原始数据透传
+}
+
+// ==================== ListVulnerabilities ====================
+
+message ListVulnerabilitiesRequest {
+  string username = 1;                          // Wazuh 用户名，可选
+  string password = 2;                          // Wazuh 密码，可选
+  string agent_id = 3;                          // Wazuh agent ID（必填，如 "001"）
+  google.protobuf.Int64Value limit = 4;         // 每页条数，默认 10
+  google.protobuf.Int64Value offset = 5;        // 分页偏移，默认 0
+  string sort = 6;                              // 排序字段
+  string search = 7;                            // 全文本搜索
+  string query = 8;                             // Wazuh 查询语法过滤
+}
+
+message ListVulnerabilitiesResponse {
+  google.protobuf.Value err = 1;                // 错误信息
+  google.protobuf.Value msg = 2;                // 消息
+  VulnerabilityListResult data = 3;             // 漏洞列表结果
+}
+
+message VulnerabilityListResult {
+  repeated VulnerabilityRecord vulnerabilities = 1; // 漏洞记录列表
+  int64 total = 2;                              // 总条数
+  int64 limit = 3;                              // 每页条数
+  int64 offset = 4;                             // 分页偏移
+}
+
+message VulnerabilityRecord {
+  string cve = 1;                               // CVE 编号
+  string severity = 2;                          // 严重级别（Low/Medium/High/Critical）
+  string package_name = 3;                      // 受影响软件包名称
+  string package_version = 4;                   // 受影响软件包版本
+  string title = 5;                             // 漏洞标题
+  string description = 6;                       // 漏洞描述
+  string reference = 7;                         // CVE 参考链接
+  string type = 8;                              // 漏洞类型（Package/Advisory）
+  google.protobuf.Struct raw = 9;               // 原始数据透传
+}
+
+// ==================== GetVulnerabilitySummary ====================
+
+message GetVulnerabilitySummaryRequest {
+  string username = 1;                          // Wazuh 用户名，可选
+  string password = 2;                          // Wazuh 密码，可选
+  string agent_id = 3;                          // Wazuh agent ID（必填）
+}
+
+message GetVulnerabilitySummaryResponse {
+  google.protobuf.Value err = 1;                // 错误信息
+  google.protobuf.Value msg = 2;                // 消息
+  VulnerabilitySummary data = 3;                // 漏洞摘要
+}
+
+message VulnerabilitySummary {
+  int64 critical_count = 1;                     // Critical 级别漏洞数
+  int64 high_count = 2;                         // High 级别漏洞数
+  int64 medium_count = 3;                       // Medium 级别漏洞数
+  int64 low_count = 4;                          // Low 级别漏洞数
+  int64 total = 5;                              // 总漏洞数
+  google.protobuf.Struct raw = 6;               // 原始数据透传
+}
+
+// ==================== ListAgents ====================
+
+message ListAgentsRequest {
+  string username = 1;                          // Wazuh 用户名，可选
+  string password = 2;                          // Wazuh 密码，可选
+  string status = 3;                            // 代理状态过滤（active/disconnected/pending/all），默认 active
+  string search = 4;                            // 全文本搜索
+  google.protobuf.Int64Value limit = 5;         // 每页条数，默认 10
+  google.protobuf.Int64Value offset = 6;        // 分页偏移，默认 0
+  string query = 7;                             // Wazuh 查询语法过滤
+}
+
+message ListAgentsResponse {
+  google.protobuf.Value err = 1;                // 错误信息
+  google.protobuf.Value msg = 2;                // 消息
+  AgentListResult data = 3;                     // 代理列表结果
+}
+
+message AgentListResult {
+  repeated AgentRecord agents = 1;              // 代理记录列表
+  int64 total = 2;                              // 总条数
+}
+
+message AgentRecord {
+  string id = 1;                                // 代理 ID
+  string name = 2;                              // 代理名称
+  string ip = 3;                                // 代理 IP
+  string status = 4;                            // 代理状态
+  string os_name = 5;                           // 操作系统名称
+  string os_version = 6;                        // 操作系统版本
+  string wazuh_version = 7;                     // Wazuh 代理版本
+  string last_keep_alive = 8;                   // 最后心跳时间
+  string group = 9;                             // 所属分组（逗号分隔）
+}

--- a/services/wazuh__siem/secret.schema.json
+++ b/services/wazuh__siem/secret.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["username", "password", "indexerUsername", "indexerPassword"],
+  "properties": {
+    "username": {
+      "type": "string",
+      "description": "Wazuh Manager API username for JWT authentication."
+    },
+    "password": {
+      "type": "string",
+      "description": "Wazuh Manager API password for JWT authentication."
+    },
+    "indexerUsername": {
+      "type": "string",
+      "description": "Wazuh Indexer username for Basic Auth."
+    },
+    "indexerPassword": {
+      "type": "string",
+      "description": "Wazuh Indexer password for Basic Auth."
+    }
+  }
+}

--- a/services/wazuh__siem/service.json
+++ b/services/wazuh__siem/service.json
@@ -1,0 +1,45 @@
+{
+  "schema": "chaitin.octobus.service.v1",
+  "name": "siem",
+  "displayName": "Wazuh SIEM",
+  "description": "OctoBus package for Wazuh SIEM alert query, vulnerability detection, and agent monitoring APIs.",
+  "runtime": {
+    "mode": "long-running"
+  },
+  "proto": {
+    "roots": [
+      "proto"
+    ],
+    "files": [
+      "proto/wazuh_siem.proto"
+    ]
+  },
+  "configSchema": "config.schema.json",
+  "secretSchema": "secret.schema.json",
+  "sdk": {
+    "cli": {
+      "commands": {
+        "Wazuh_SIEM.Wazuh_SIEM/ListAlerts": {
+          "name": "list-alerts",
+          "description": "Query Wazuh security alerts with filtering by query syntax, time range, severity level, and pagination."
+        },
+        "Wazuh_SIEM.Wazuh_SIEM/GetAlertSummary": {
+          "name": "get-alert-summary",
+          "description": "Get Wazuh alert overview statistics grouped by severity level."
+        },
+        "Wazuh_SIEM.Wazuh_SIEM/ListVulnerabilities": {
+          "name": "list-vulnerabilities",
+          "description": "Query vulnerability detection results for a specific Wazuh agent."
+        },
+        "Wazuh_SIEM.Wazuh_SIEM/GetVulnerabilitySummary": {
+          "name": "get-vulnerability-summary",
+          "description": "Get vulnerability detection summary for a specific Wazuh agent."
+        },
+        "Wazuh_SIEM.Wazuh_SIEM/ListAgents": {
+          "name": "list-agents",
+          "description": "List Wazuh agents with status and OS information."
+        }
+      }
+    }
+  }
+}

--- a/services/wazuh__siem/src/service.js
+++ b/services/wazuh__siem/src/service.js
@@ -1,0 +1,7 @@
+import { defineService } from "@chaitin-ai/octobus-sdk";
+
+import { handlers } from "./wazuh-siem.js";
+
+export { handlers } from "./wazuh-siem.js";
+
+export const service = defineService({ handlers });

--- a/services/wazuh__siem/src/wazuh-siem.js
+++ b/services/wazuh__siem/src/wazuh-siem.js
@@ -1,0 +1,896 @@
+// Wazuh_SIEM dual-endpoint REST proxy implementation
+// Manager API (endpoint) → ListAgents (JWT auth via POST /security/user/authenticate)
+// Indexer API (indexerEndpoint) → ListAlerts/GetAlertSummary/ListVulnerabilities/GetVulnerabilitySummary (Basic Auth + OpenSearch DSL)
+// TLS: when skipTlsVerify is enabled, uses undici Agent with rejectUnauthorized: false
+
+import { GrpcError, grpcStatus } from '@chaitin-ai/octobus-sdk';
+import { createHash } from 'node:crypto';
+import { Agent as UndiciAgent } from 'undici';
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_LIMIT = 10;
+const DEFAULT_OFFSET = 0;
+const TOKEN_REFRESH_MARGIN_MS = 60_000; // refresh token 60s before expiry
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+const MAX_CACHE_ENTRIES = 128;
+const MAX_PAGE_SIZE = 1000;
+
+const METHOD_LIST_ALERTS = '/Wazuh_SIEM.Wazuh_SIEM/ListAlerts';
+const METHOD_GET_ALERT_SUMMARY = '/Wazuh_SIEM.Wazuh_SIEM/GetAlertSummary';
+const METHOD_LIST_VULNERABILITIES = '/Wazuh_SIEM.Wazuh_SIEM/ListVulnerabilities';
+const METHOD_GET_VULNERABILITY_SUMMARY = '/Wazuh_SIEM.Wazuh_SIEM/GetVulnerabilitySummary';
+const METHOD_LIST_AGENTS = '/Wazuh_SIEM.Wazuh_SIEM/ListAgents';
+
+// ─── Module-level JWT token cache ──────────────────────────────────
+// Shared across all rpcdef() calls so that the cache persists between
+// requests. The one-way password digest isolates credential rotations without
+// retaining plaintext credentials in module state.
+const jwtTokenCache = new Map();
+
+const tokenCacheKey = (baseUrl, username, password) => {
+  const credentialDigest = createHash('sha256').update(String(password)).digest('hex');
+  return `${baseUrl}|${username}|${credentialDigest}`;
+};
+
+const cacheToken = (key, value) => {
+  jwtTokenCache.delete(key);
+  jwtTokenCache.set(key, value);
+  while (jwtTokenCache.size > MAX_CACHE_ENTRIES) {
+    jwtTokenCache.delete(jwtTokenCache.keys().next().value);
+  }
+};
+
+// ─── Error helpers ────────────────────────────────────────────────────
+
+const grpcCodeFor = (code) => ({
+  INVALID_ARGUMENT: grpcStatus.INVALID_ARGUMENT,
+  FAILED_PRECONDITION: grpcStatus.FAILED_PRECONDITION,
+  UNAUTHENTICATED: grpcStatus.UNAUTHENTICATED,
+  PERMISSION_DENIED: grpcStatus.PERMISSION_DENIED,
+  UNAVAILABLE: grpcStatus.UNAVAILABLE,
+  DEADLINE_EXCEEDED: grpcStatus.DEADLINE_EXCEEDED,
+})[code] ?? grpcStatus.UNKNOWN;
+
+const errorWithCode = (code, message) => {
+  const err = new GrpcError(grpcCodeFor(code), `${code}: ${message}`);
+  err.legacyCode = code;
+  return err;
+};
+
+// ─── Utility helpers ──────────────────────────────────────────────────
+
+const firstDefined = (...vals) => vals.find((v) => v !== undefined && v !== null);
+
+const mergedBindings = (ctx = {}) => ({
+  ...(ctx?.config ?? {}),
+  ...(ctx?.secret ?? {}),
+  ...(ctx?.bindings ?? {}),
+});
+
+const parseHeaders = (value) => {
+  if (value === undefined || value === null || value === '') return {};
+  if (typeof value === 'object' && !Array.isArray(value)) return value;
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+    } catch {
+      return {};
+    }
+  }
+  return {};
+};
+
+const normalizeBaseUrl = (url) => {
+  const base = String(url || '').trim();
+  if (!/^https?:\/\//i.test(base)) return null;
+  return base.replace(/\/$/, '');
+};
+
+const toPositiveInt = (val) => {
+  if (val === undefined || val === null) return null;
+  if (typeof val === 'object') {
+    if ('value' in val) return toPositiveInt(val.value);
+    return null;
+  }
+  const n = Number(val);
+  if (!Number.isInteger(n) || Number.isNaN(n) || n < 0) return null;
+  return n;
+};
+
+const paginationValue = (req, keys, fallback, name, maximum = Number.MAX_SAFE_INTEGER) => {
+  const raw = firstDefined(...keys.map((key) => req?.[key]));
+  if (raw === undefined || raw === null) return fallback;
+  const parsed = toPositiveInt(raw);
+  if (parsed === null || parsed > maximum) {
+    throw errorWithCode('INVALID_ARGUMENT', `${name} must be an integer between 0 and ${maximum}`);
+  }
+  return parsed;
+};
+
+const toValue = (val) => {
+  if (val === undefined || val === null) return { stringValue: '' };
+  if (typeof val === 'string') return { stringValue: val };
+  if (typeof val === 'number') return { numberValue: val };
+  if (typeof val === 'boolean') return { boolValue: val };
+  if (Array.isArray(val)) {
+    const values = val.map((item) => toValue(item)).filter((item) => item !== undefined);
+    return { listValue: { values } };
+  }
+  if (typeof val === 'object') {
+    const fields = {};
+    for (const [k, v] of Object.entries(val)) {
+      const normalized = toValue(v);
+      fields[k] = normalized === undefined ? { nullValue: 'NULL_VALUE' } : normalized;
+    }
+    return { structValue: { fields } };
+  }
+  return { stringValue: String(val) };
+};
+
+const unwrapString = (source) => {
+  if (source === undefined || source === null) return '';
+  if (typeof source === 'object' && source !== null && 'value' in source) {
+    return String(source.value ?? '');
+  }
+  return String(source);
+};
+
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj ?? {}, key);
+
+const pickStringField = (req, keys) => {
+  for (const key of keys) {
+    if (hasOwn(req, key)) {
+      return unwrapString(req[key]);
+    }
+  }
+  return undefined;
+};
+
+const readResponseText = async (res) => {
+  const declaredLength = Number(res?.headers?.get?.('content-length') || 0);
+  if (declaredLength > MAX_RESPONSE_BYTES) {
+    throw errorWithCode('FAILED_PRECONDITION', 'upstream response exceeds 4 MiB limit');
+  }
+
+  if (!res?.body?.getReader) {
+    const text = await res.text();
+    if (Buffer.byteLength(text, 'utf8') > MAX_RESPONSE_BYTES) {
+      throw errorWithCode('FAILED_PRECONDITION', 'upstream response exceeds 4 MiB limit');
+    }
+    return text;
+  }
+
+  const reader = res.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw errorWithCode('FAILED_PRECONDITION', 'upstream response exceeds 4 MiB limit');
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString('utf8');
+};
+
+// ─── OpenSearch query builder ──────────────────────────────────────
+
+const buildAlertsOpenSearchQuery = (req) => {
+  const must = [];
+
+  const startTime = toPositiveInt(firstDefined(req?.start_time, req?.startTime));
+  if (startTime !== null) {
+    must.push({ range: { timestamp: { gte: new Date(startTime * 1000).toISOString() } } });
+  }
+
+  const endTime = toPositiveInt(firstDefined(req?.end_time, req?.endTime));
+  if (endTime !== null) {
+    must.push({ range: { timestamp: { lte: new Date(endTime * 1000).toISOString() } } });
+  }
+
+  const severityMin = toPositiveInt(firstDefined(req?.severity_min, req?.severityMin));
+  if (severityMin !== null) {
+    must.push({ range: { 'rule.level': { gte: severityMin } } });
+  }
+
+  // If user also passed a raw query string, use query_string
+  const rawQuery = pickStringField(req, ['query', 'Query']);
+  if (rawQuery) {
+    must.push({ query_string: { query: rawQuery } });
+  }
+  const search = pickStringField(req, ['search', 'Search']);
+  if (search) {
+    must.push({ multi_match: { query: search, fields: ['rule.description', 'full_log', 'agent.name', 'agent.ip'] } });
+  }
+
+  if (must.length === 0) return { match_all: {} };
+  return { bool: { must } };
+};
+
+// ─── Wazuh API response mapper ────────────────────────────────────────
+
+// Wazuh Manager API 4.x standard response: { data: { affected_items: [...], total_affected_items: N, ... }, ... }
+const extractAffectedItems = (json) => {
+  const data = json?.data;
+  if (data && typeof data === 'object') {
+    if (Array.isArray(data.affected_items)) {
+      return {
+        items: data.affected_items,
+        total: data.total_affected_items ?? data.affected_items.length,
+      };
+    }
+    // Some endpoints return data directly as array
+    if (Array.isArray(data)) {
+      return { items: data, total: data.length };
+    }
+    // Overview/stats endpoints return data as object
+    return { items: [], total: 0, stats: data };
+  }
+  return { items: [], total: 0 };
+};
+
+// OpenSearch response format: { hits: { hits: [{ _source: {...} }], total: { value: N } } }
+const extractOpenSearchHits = (json) => ({
+  items: json?.hits?.hits?.map((h) => ({ ...h._source, _id: h._id })) ?? [],
+  total: json?.hits?.total?.value ?? 0,
+});
+
+const mapAlertRecord = (item) => ({
+  id: String(item?.id ?? item?._id ?? ''),
+  timestamp: String(item?.timestamp ?? ''),
+  rule_description: String(item?.rule?.description ?? item?.rule_description ?? ''),
+  rule_level: Number(item?.rule?.level ?? item?.rule_level ?? 0),
+  rule_groups: Array.isArray(item?.rule?.groups) ? item.rule.groups.join(',') : String(item?.rule?.groups ?? item?.rule_groups ?? ''),
+  rule_mitre_id: Array.isArray(item?.rule?.mitre?.id)
+    ? item.rule.mitre.id.join(',')
+    : String(item?.rule?.mitre?.id ?? item?.rule_mitre_id ?? ''),
+  agent_id: String(item?.agent?.id ?? item?.agent_id ?? ''),
+  agent_name: String(item?.agent?.name ?? item?.agent_name ?? ''),
+  agent_ip: String(item?.agent?.ip ?? item?.agent_ip ?? ''),
+  full_log: String(item?.full_log ?? ''),
+  raw: item ?? {},
+});
+
+const mapAgentRecord = (item) => ({
+  id: String(item?.id ?? ''),
+  name: String(item?.name ?? ''),
+  ip: String(item?.ip ?? ''),
+  status: String(item?.status ?? ''),
+  os_name: String(item?.os?.name ?? item?.os_name ?? ''),
+  os_version: String(item?.os?.version ?? item?.os_version ?? ''),
+  wazuh_version: String(item?.version ?? item?.wazuh_version ?? ''),
+  last_keep_alive: String(item?.lastKeepAlive ?? item?.last_keep_alive ?? ''),
+  group: Array.isArray(item?.group) ? item.group.join(',') : String(item?.group ?? ''),
+});
+
+const mapVulnerabilityRecord = (item) => ({
+  cve: String(item?.vulnerability?.cve ?? item?.cve ?? ''),
+  severity: String(item?.vulnerability?.severity ?? item?.severity ?? ''),
+  package_name: String(item?.vulnerability?.package?.name ?? item?.package?.name ?? item?.package_name ?? ''),
+  package_version: String(item?.vulnerability?.package?.version ?? item?.package?.version ?? item?.package_version ?? ''),
+  title: String(item?.vulnerability?.title ?? item?.title ?? ''),
+  description: String(item?.vulnerability?.description ?? item?.description ?? ''),
+  reference: String(item?.vulnerability?.reference ?? item?.references ?? item?.reference ?? ''),
+  type: String(item?.vulnerability?.type ?? item?.type ?? ''),
+  raw: item ?? {},
+});
+
+// ─── rpcdef ───────────────────────────────────────────────────────────
+
+export function rpcdef(ctx) {
+  const bindings = mergedBindings(ctx);
+  // Manager API endpoint (JWT auth) — for ListAgents
+  const restBaseUrl = bindings.restBaseUrl || bindings.rest_base_url || bindings.baseUrl || bindings.base_url || bindings.endpoint || '';
+
+  // Indexer endpoint (Basic Auth) — for alerts/vulnerability
+  const indexerBaseUrl = bindings.indexerEndpoint || bindings.indexer_endpoint || '';
+  const indexerUsername = firstDefined(bindings.indexerUsername, bindings.indexer_username) || 'admin';
+  const indexerPassword = firstDefined(bindings.indexerPassword, bindings.indexer_password) || '';
+
+  const timeoutMs = Number(bindings.timeoutMs || ctx.limits?.timeoutMs || DEFAULT_TIMEOUT_MS);
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > 300_000) {
+    throw errorWithCode('INVALID_ARGUMENT', 'timeoutMs must be an integer between 1 and 300000');
+  }
+  const baseHeaders = parseHeaders(bindings.headers);
+  const meta = ctx.meta || {};
+  const skipTlsVerify = Boolean(bindings.tlsInsecureSkipVerify || bindings.skipTlsVerify || bindings.skip_tls_verify || bindings.tls_insecure_skip_verify);
+
+  const requestWithDefaults = (req = {}) => {
+    const username = firstDefined(req?.username, bindings.username);
+    const password = firstDefined(req?.password, bindings.password);
+    const result = { ...req };
+    if (username !== undefined && username !== null) result.username = username;
+    if (password !== undefined && password !== null) result.password = password;
+    return result;
+  };
+
+  const logFlow = (action, details) => {
+    const inst = meta.instance_id || meta.instanceId;
+    const reqId = meta.request_id || meta.requestId;
+    const trace = [];
+    if (inst) trace.push(`inst=${inst}`);
+    if (reqId) trace.push(`req=${reqId}`);
+    const prefix = `[Wazuh_SIEM][${action}]${trace.length ? `[${trace.join(' ')}]` : ''}`;
+    try {
+      console.log(prefix, JSON.stringify(details));
+    } catch {
+      console.log(prefix, details);
+    }
+  };
+
+  const getManagerBaseUrl = () => {
+    const baseUrl = normalizeBaseUrl(restBaseUrl);
+    if (!baseUrl) {
+      throw errorWithCode('INVALID_ARGUMENT', 'restBaseUrl/baseUrl/endpoint is required for Manager API (http/https)');
+    }
+    return baseUrl;
+  };
+
+  const getIndexerBaseUrl = () => {
+    const baseUrl = normalizeBaseUrl(indexerBaseUrl);
+    if (!baseUrl) {
+      throw errorWithCode('INVALID_ARGUMENT', 'indexerEndpoint is required for alert/vulnerability queries (http/https)');
+    }
+    return baseUrl;
+  };
+
+  // ─── TLS dispatcher (undici for skipTlsVerify, native fetch otherwise) ───
+
+  let insecureDispatcher = null;
+  const getDispatcher = () => {
+    if (!skipTlsVerify) return undefined;
+    if (!insecureDispatcher) {
+      insecureDispatcher = new UndiciAgent({ connect: { rejectUnauthorized: false } });
+    }
+    return insecureDispatcher;
+  };
+
+  // ─── JWT Authentication (Manager API) ────────────────────────────
+
+  const authenticate = async (reqOverride = {}) => {
+    const username = firstDefined(reqOverride.username, bindings.username);
+    const password = firstDefined(reqOverride.password, bindings.password);
+
+    if (!username || !password) {
+      throw errorWithCode('INVALID_ARGUMENT', 'username and password are required for Wazuh JWT authentication');
+    }
+
+    const baseUrl = getManagerBaseUrl();
+    const url = `${baseUrl}/security/user/authenticate`;
+    const cacheKey = tokenCacheKey(baseUrl, username, password);
+
+    logFlow('authenticate:start', { url: `${baseUrl}/security/user/authenticate` });
+
+    const headers = {
+      ...baseHeaders,
+      'Content-Type': 'application/json',
+      'Authorization': `Basic ${Buffer.from(`${username}:${password}`, 'utf8').toString('base64')}`,
+      'x-engine-instance': meta.instance_id || meta.instanceId || 'unknown',
+      'x-request-id': meta.request_id || meta.requestId || 'unknown',
+    };
+
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers,
+        redirect: 'manual',
+        signal: AbortSignal.timeout(timeoutMs),
+        ...(skipTlsVerify ? { dispatcher: getDispatcher() } : {}),
+      });
+
+      const text = await readResponseText(res);
+      if (!res.ok) {
+        logFlow('authenticate:auth-error', { status: res.status, bodyLength: text?.length });
+        if (res.status === 401) {
+          throw errorWithCode('UNAUTHENTICATED', `Wazuh authentication failed: invalid credentials (${res.status})`);
+        }
+        if (res.status === 403) {
+          throw errorWithCode('PERMISSION_DENIED', `Wazuh authentication forbidden (${res.status})`);
+        }
+        throw errorWithCode('UNAVAILABLE', `Wazuh authentication failed (http ${res.status})`);
+      }
+
+      let json;
+      try {
+        json = JSON.parse(text);
+      } catch {
+        throw errorWithCode('UNKNOWN', 'Wazuh authentication response is not valid JSON');
+      }
+
+      const token = json?.data?.token;
+      if (!token) {
+        throw errorWithCode('FAILED_PRECONDITION', 'Wazuh authentication succeeded but no token returned');
+      }
+
+      // Wazuh JWT token default TTL is 900s; parse expiry or assume 900s
+      let expiresIn = 900;
+      try {
+        const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'));
+        if (payload?.exp) {
+          expiresIn = Math.max(payload.exp - Math.floor(Date.now() / 1000), 60);
+        }
+      } catch {
+        // If we can't parse the JWT, use default 900s
+      }
+
+      cacheToken(cacheKey, { token, expiresAt: Date.now() + expiresIn * 1000 });
+
+      logFlow('authenticate:done', { expiresIn });
+
+      return token;
+    } catch (e) {
+      if (e instanceof GrpcError) throw e;
+      if (e.name === 'TimeoutError' || e.name === 'AbortError') {
+        throw errorWithCode('DEADLINE_EXCEEDED', `Wazuh authentication timeout after ${timeoutMs}ms`);
+      }
+      const reason = e?.cause?.message || e?.message || 'fetch failed';
+      throw errorWithCode('UNAVAILABLE', `Wazuh authentication request failed: ${reason}`);
+    }
+  };
+
+  const ensureToken = async (reqOverride = {}) => {
+    const username = firstDefined(reqOverride.username, bindings.username);
+    const password = firstDefined(reqOverride.password, bindings.password);
+    const baseUrl = getManagerBaseUrl();
+    const cacheKey = tokenCacheKey(baseUrl, username, password);
+    const cached = jwtTokenCache.get(cacheKey);
+    if (cached && cached.token && Date.now() < cached.expiresAt - TOKEN_REFRESH_MARGIN_MS) {
+      return cached.token;
+    }
+    return authenticate(reqOverride);
+  };
+
+  // ─── Manager API request (JWT Bearer) ────────────────────────────
+
+  const fetchWithRetry = async (url, init) => {
+    try {
+      return await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(timeoutMs),
+        redirect: 'manual',
+        ...(skipTlsVerify ? { dispatcher: getDispatcher() } : {}),
+      });
+    } catch (e) {
+      if (e.name === 'TimeoutError' || e.name === 'AbortError') {
+        throw errorWithCode('DEADLINE_EXCEEDED', `request timeout after ${timeoutMs}ms`);
+      }
+      throw errorWithCode('UNAVAILABLE', 'upstream request failed');
+    }
+  };
+
+  const throwForHttpError = (status, text, stage = 'request') => {
+    if (status === 401) {
+      logFlow(`${stage}:auth-error`, { status, bodyLength: text?.length });
+      throw errorWithCode('UNAUTHENTICATED', `${stage} unauthorized (${status})`);
+    }
+    if (status === 403) {
+      logFlow(`${stage}:forbidden`, { status, bodyLength: text?.length });
+      throw errorWithCode('PERMISSION_DENIED', `${stage} forbidden (${status})`);
+    }
+    if (status >= 400 && status < 500) {
+      logFlow(`${stage}:client-error`, { status, bodyLength: text?.length });
+      throw errorWithCode('FAILED_PRECONDITION', `upstream http ${status}`);
+    }
+    logFlow(`${stage}:server-error`, { status, bodyLength: text?.length });
+    throw errorWithCode('UNAVAILABLE', `upstream http ${status}`);
+  };
+
+  const readJsonResponse = async (res, stage = 'request') => {
+    const text = await readResponseText(res);
+    if (!res.ok) {
+      throwForHttpError(res.status, text, stage);
+    }
+    if (!text.trim()) {
+      return {};
+    }
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw errorWithCode('UNKNOWN', 'response is not valid JSON');
+    }
+  };
+
+  const wazuhGet = async (path, params = {}, retryOn401 = true, reqOverride = {}) => {
+    const token = await ensureToken(reqOverride);
+    const baseUrl = getManagerBaseUrl();
+
+    const url = new URL(`${baseUrl}${path}`);
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null && value !== '') {
+        url.searchParams.set(key, String(value));
+      }
+    }
+
+    const headers = {
+      ...baseHeaders,
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'x-engine-instance': meta.instance_id || meta.instanceId || 'unknown',
+      'x-request-id': meta.request_id || meta.requestId || 'unknown',
+    };
+
+    logFlow('wazuhGet', { path, params: Object.keys(params) });
+
+    const res = await fetchWithRetry(url.toString(), { method: 'GET', headers });
+
+    // Retry once on 401 (token expired)
+    if (res.status === 401 && retryOn401) {
+      logFlow('wazuhGet:tokenExpired', { path });
+      const username = firstDefined(reqOverride.username, bindings.username);
+      const password = firstDefined(reqOverride.password, bindings.password);
+      const baseUrl2 = getManagerBaseUrl();
+      const cacheKey = tokenCacheKey(baseUrl2, username, password);
+      const cached = jwtTokenCache.get(cacheKey);
+      if (cached) {
+        cached.token = null;
+        cached.expiresAt = 0;
+      }
+      return wazuhGet(path, params, false, reqOverride);
+    }
+
+    return readJsonResponse(res, 'wazuh-api');
+  };
+
+  // ─── Indexer API request (Basic Auth) ────────────────────────────
+
+  const indexerPost = async (path, body) => {
+    const baseUrl = getIndexerBaseUrl();
+    if (!indexerUsername || !indexerPassword) {
+      throw errorWithCode('INVALID_ARGUMENT', 'indexerUsername and indexerPassword are required for Indexer API');
+    }
+    const url = `${baseUrl}${path}`;
+
+    const authHeader = `Basic ${Buffer.from(`${indexerUsername}:${indexerPassword}`, 'utf8').toString('base64')}`;
+
+    const headers = {
+      ...baseHeaders,
+      'Authorization': authHeader,
+      'Content-Type': 'application/json',
+      'x-engine-instance': meta.instance_id || meta.instanceId || 'unknown',
+      'x-request-id': meta.request_id || meta.requestId || 'unknown',
+    };
+
+    logFlow('indexerPost', { path });
+
+    const res = await fetchWithRetry(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    return readJsonResponse(res, 'indexer-post');
+  };
+
+  // ─── RPC: ListAlerts (Indexer) ───────────────────────────────────
+
+  const callListAlerts = async (req) => {
+    const limit = paginationValue(req, ['limit', 'Limit'], DEFAULT_LIMIT, 'limit', MAX_PAGE_SIZE);
+    const offset = paginationValue(req, ['offset', 'Offset'], DEFAULT_OFFSET, 'offset');
+    const sort = pickStringField(req, ['sort', 'Sort']) || '-timestamp';
+
+    // Convert sort from Wazuh syntax to OpenSearch syntax
+    // "-timestamp" → { timestamp: "desc" }, "timestamp" → { timestamp: "asc" }
+    const sortField = sort.startsWith('-') ? sort.slice(1) : sort;
+    const sortOrder = sort.startsWith('-') ? 'desc' : 'asc';
+
+    const query = buildAlertsOpenSearchQuery(req);
+
+    logFlow('ListAlerts:start', { limit, offset });
+    const json = await indexerPost('/wazuh-alerts-*/_search', {
+      query,
+      from: offset,
+      size: limit,
+      sort: [{ [sortField]: { order: sortOrder } }],
+    });
+    logFlow('ListAlerts:done', {});
+
+    const extracted = extractOpenSearchHits(json);
+    const alertList = extracted.items;
+
+    return {
+      err: toValue(null),
+      msg: toValue('success'),
+      data: {
+        alerts: alertList.map(mapAlertRecord),
+        total: extracted.total || alertList.length,
+        limit,
+        offset,
+      },
+    };
+  };
+
+  // ─── RPC: GetAlertSummary (Indexer) ──────────────────────────────
+
+  const callGetAlertSummary = async (req) => {
+    logFlow('GetAlertSummary:start', {});
+    const json = await indexerPost('/wazuh-alerts-*/_search', {
+      size: 0,
+      aggs: {
+        by_level: {
+          range: {
+            field: 'rule.level',
+            ranges: [
+              { key: 'level_12_plus', from: 12 },
+              { key: 'level_8_11', from: 8, to: 12 },
+              { key: 'level_4_7', from: 4, to: 8 },
+              { key: 'level_0_3', to: 4 },
+            ],
+          },
+        },
+      },
+    });
+    logFlow('GetAlertSummary:done', {});
+
+    // Extract aggregation buckets
+    const buckets = json?.aggregations?.by_level?.buckets ?? [];
+    let level12Plus = 0;
+    let level8_11 = 0;
+    let level4_7 = 0;
+    let level0_3 = 0;
+    let totalAlerts = 0;
+
+    for (const bucket of buckets) {
+      const count = Number(bucket.doc_count ?? 0);
+      totalAlerts += count;
+      switch (bucket.key) {
+        case 'level_12_plus': level12Plus = count; break;
+        case 'level_8_11': level8_11 = count; break;
+        case 'level_4_7': level4_7 = count; break;
+        case 'level_0_3': level0_3 = count; break;
+      }
+    }
+
+    // Also try total from hits.total if aggregation is missing
+    if (totalAlerts === 0 && json?.hits?.total?.value) {
+      totalAlerts = json.hits.total.value;
+    }
+
+    return {
+      err: toValue(null),
+      msg: toValue('success'),
+      data: {
+        total_alerts: totalAlerts,
+        level_12_plus: level12Plus,
+        level_8_11: level8_11,
+        level_4_7: level4_7,
+        level_0_3: level0_3,
+        raw: json?.aggregations ?? {},
+      },
+    };
+  };
+
+  // ─── RPC: ListVulnerabilities (Indexer) ──────────────────────────
+
+  const callListVulnerabilities = async (req) => {
+    const agentId = pickStringField(req, ['agent_id', 'agentId']);
+    if (!agentId) {
+      throw errorWithCode('INVALID_ARGUMENT', 'agent_id is required');
+    }
+
+    const limit = paginationValue(req, ['limit', 'Limit'], DEFAULT_LIMIT, 'limit', MAX_PAGE_SIZE);
+    const offset = paginationValue(req, ['offset', 'Offset'], DEFAULT_OFFSET, 'offset');
+
+    const mustClauses = [{ term: { 'agent.id': agentId } }];
+    const rawQuery = pickStringField(req, ['query', 'Query']);
+    if (rawQuery) {
+      mustClauses.push({ query_string: { query: rawQuery } });
+    }
+    const search = pickStringField(req, ['search', 'Search']);
+    if (search) {
+      mustClauses.push({ multi_match: { query: search, fields: ['vulnerability.*', 'package.*', 'agent.*'] } });
+    }
+
+    logFlow('ListVulnerabilities:start', { agentId, limit, offset });
+    const json = await indexerPost('/wazuh-vulnerabilities-*/_search', {
+      query: { bool: { must: mustClauses } },
+      from: offset,
+      size: limit,
+      sort: [{ 'vulnerability.severity': { order: 'desc' } }],
+    });
+    logFlow('ListVulnerabilities:done', {});
+
+    const extracted = extractOpenSearchHits(json);
+    const vulnList = extracted.items;
+
+    return {
+      err: toValue(null),
+      msg: toValue('success'),
+      data: {
+        vulnerabilities: vulnList.map(mapVulnerabilityRecord),
+        total: extracted.total || vulnList.length,
+        limit,
+        offset,
+      },
+    };
+  };
+
+  // ─── RPC: GetVulnerabilitySummary (Indexer) ──────────────────────
+
+  const callGetVulnerabilitySummary = async (req) => {
+    const agentId = pickStringField(req, ['agent_id', 'agentId']);
+    if (!agentId) {
+      throw errorWithCode('INVALID_ARGUMENT', 'agent_id is required');
+    }
+
+    logFlow('GetVulnerabilitySummary:start', { agentId });
+    const json = await indexerPost('/wazuh-vulnerabilities-*/_search', {
+      size: 0,
+      query: { term: { 'agent.id': agentId } },
+      aggs: {
+        by_severity: {
+          terms: { field: 'vulnerability.severity', size: 10 },
+        },
+      },
+    });
+    logFlow('GetVulnerabilitySummary:done', {});
+
+    const buckets = json?.aggregations?.by_severity?.buckets ?? [];
+    let criticalCount = 0;
+    let highCount = 0;
+    let mediumCount = 0;
+    let lowCount = 0;
+    let total = 0;
+
+    for (const bucket of buckets) {
+      const count = Number(bucket.doc_count ?? 0);
+      total += count;
+      const severity = String(bucket.key ?? '').toLowerCase();
+      if (severity === 'critical') criticalCount = count;
+      else if (severity === 'high') highCount = count;
+      else if (severity === 'medium') mediumCount = count;
+      else if (severity === 'low') lowCount = count;
+      else if (severity === 'info' || severity === 'unknown') lowCount += count;
+    }
+
+    // Fallback: try total from hits.total
+    if (total === 0 && json?.hits?.total?.value) {
+      total = json.hits.total.value;
+    }
+
+    return {
+      err: toValue(null),
+      msg: toValue('success'),
+      data: {
+        critical_count: criticalCount,
+        high_count: highCount,
+        medium_count: mediumCount,
+        low_count: lowCount,
+        total,
+        raw: json?.aggregations ?? {},
+      },
+    };
+  };
+
+  // ─── RPC: ListAgents (Manager API) ──────────────────────────────
+
+  const callListAgents = async (req) => {
+    const baseUrl = normalizeBaseUrl(restBaseUrl);
+    if (!baseUrl) {
+      throw errorWithCode('INVALID_ARGUMENT', 'restBaseUrl/baseUrl/endpoint is required for Manager API (ListAgents)');
+    }
+
+    const status = pickStringField(req, ['status', 'Status']) || 'active';
+    const limit = paginationValue(req, ['limit', 'Limit'], DEFAULT_LIMIT, 'limit', MAX_PAGE_SIZE);
+    const offset = paginationValue(req, ['offset', 'Offset'], DEFAULT_OFFSET, 'offset');
+    const search = pickStringField(req, ['search', 'Search']) || undefined;
+    const q = pickStringField(req, ['query', 'Query']) || undefined;
+
+    const params = { limit, offset };
+    if (status && status !== 'all') params.status = status;
+    if (search) params.search = search;
+    if (q) params.q = q;
+
+    logFlow('ListAgents:start', { status, limit, offset });
+    const json = await wazuhGet('/agents', params, true, req);
+    logFlow('ListAgents:done', {});
+
+    const extracted = extractAffectedItems(json);
+    const agentList = extracted.items;
+
+    return {
+      err: toValue(null),
+      msg: toValue('success'),
+      data: {
+        agents: agentList.map(mapAgentRecord),
+        total: extracted.total || agentList.length,
+      },
+    };
+  };
+
+  // ─── Return method map ───────────────────────────────────────────
+
+  return {
+    [METHOD_LIST_ALERTS]: async () => callListAlerts(requestWithDefaults(ctx.req)),
+    [METHOD_GET_ALERT_SUMMARY]: async () => callGetAlertSummary(requestWithDefaults(ctx.req)),
+    [METHOD_LIST_VULNERABILITIES]: async () => callListVulnerabilities(requestWithDefaults(ctx.req)),
+    [METHOD_GET_VULNERABILITY_SUMMARY]: async () => callGetVulnerabilitySummary(requestWithDefaults(ctx.req)),
+    [METHOD_LIST_AGENTS]: async () => callListAgents(requestWithDefaults(ctx.req)),
+  };
+}
+
+// ─── resolveInvocation adapter ─────────────────────────────────────────
+
+const mergeCtx = (baseCtx, innerCtx) => ({
+  ...(baseCtx ?? {}),
+  ...(innerCtx ?? {}),
+  bindings: { ...(baseCtx?.bindings ?? {}), ...(innerCtx?.bindings ?? {}) },
+  config: { ...(baseCtx?.config ?? {}), ...(innerCtx?.config ?? {}) },
+  secret: { ...(baseCtx?.secret ?? {}), ...(innerCtx?.secret ?? {}) },
+  limits: innerCtx?.limits ?? baseCtx?.limits ?? {},
+  meta: innerCtx?.meta ?? baseCtx?.meta ?? {},
+  metadata: innerCtx?.metadata ?? baseCtx?.metadata ?? {},
+  getMetadata: innerCtx?.getMetadata ?? baseCtx?.getMetadata,
+});
+
+const resolveCallContext = (baseCtx, reqOrCtx, maybeInnerCtx) => {
+  if (maybeInnerCtx !== undefined) {
+    return { req: reqOrCtx ?? {}, ctx: mergeCtx(baseCtx, maybeInnerCtx) };
+  }
+  const innerCtx = reqOrCtx ?? {};
+  return {
+    req: innerCtx.request ?? innerCtx.req ?? {},
+    ctx: mergeCtx(baseCtx, innerCtx),
+  };
+};
+
+const wrapLegacyHandler = (baseCtx, methodPath) => async (reqOrCtx, maybeInnerCtx) => {
+  const call = resolveCallContext(baseCtx, reqOrCtx, maybeInnerCtx);
+  const legacyCtx = {
+    ...call.ctx,
+    req: call.req,
+  };
+  return rpcdef(legacyCtx)[methodPath]();
+};
+
+const registerHandlers = (ctx = {}) => ({
+  [METHOD_LIST_ALERTS]: wrapLegacyHandler(ctx, METHOD_LIST_ALERTS),
+  [METHOD_GET_ALERT_SUMMARY]: wrapLegacyHandler(ctx, METHOD_GET_ALERT_SUMMARY),
+  [METHOD_LIST_VULNERABILITIES]: wrapLegacyHandler(ctx, METHOD_LIST_VULNERABILITIES),
+  [METHOD_GET_VULNERABILITY_SUMMARY]: wrapLegacyHandler(ctx, METHOD_GET_VULNERABILITY_SUMMARY),
+  [METHOD_LIST_AGENTS]: wrapLegacyHandler(ctx, METHOD_LIST_AGENTS),
+});
+
+export const METHOD_LIST_ALERTS_FULL = 'Wazuh_SIEM.Wazuh_SIEM/ListAlerts';
+export const METHOD_GET_ALERT_SUMMARY_FULL = 'Wazuh_SIEM.Wazuh_SIEM/GetAlertSummary';
+export const METHOD_LIST_VULNERABILITIES_FULL = 'Wazuh_SIEM.Wazuh_SIEM/ListVulnerabilities';
+export const METHOD_GET_VULNERABILITY_SUMMARY_FULL = 'Wazuh_SIEM.Wazuh_SIEM/GetVulnerabilitySummary';
+export const METHOD_LIST_AGENTS_FULL = 'Wazuh_SIEM.Wazuh_SIEM/ListAgents';
+
+const sdkHandlers = registerHandlers({});
+
+export const handlers = {
+  [METHOD_LIST_ALERTS_FULL]: (ctx) => sdkHandlers[METHOD_LIST_ALERTS](ctx),
+  [METHOD_GET_ALERT_SUMMARY_FULL]: (ctx) => sdkHandlers[METHOD_GET_ALERT_SUMMARY](ctx),
+  [METHOD_LIST_VULNERABILITIES_FULL]: (ctx) => sdkHandlers[METHOD_LIST_VULNERABILITIES](ctx),
+  [METHOD_GET_VULNERABILITY_SUMMARY_FULL]: (ctx) => sdkHandlers[METHOD_GET_VULNERABILITY_SUMMARY](ctx),
+  [METHOD_LIST_AGENTS_FULL]: (ctx) => sdkHandlers[METHOD_LIST_AGENTS](ctx),
+};
+
+export const _test = {
+  buildAlertsOpenSearchQuery,
+  cacheToken,
+  clearJwtCache: () => jwtTokenCache.clear(),
+  errorWithCode,
+  extractAffectedItems,
+  extractOpenSearchHits,
+  mapAlertRecord,
+  mapAgentRecord,
+  mapVulnerabilityRecord,
+  mergedBindings,
+  normalizeBaseUrl,
+  parseHeaders,
+  paginationValue,
+  readResponseText,
+  registerHandlers,
+  resolveCallContext,
+  toPositiveInt,
+  toValue,
+};

--- a/services/wazuh__siem/test/mock_upstream.js
+++ b/services/wazuh__siem/test/mock_upstream.js
@@ -1,0 +1,276 @@
+// Mock upstream for Wazuh API (matching Wazuh 4.9.x API)
+import http from 'node:http';
+
+const httpPort = Number(process.env.HTTP_PORT || 19000);
+const log = (...args) => console.log('[mock-wazuh]', ...args);
+
+// Simulated JWT token store
+const validCredentials = { wazuh: 'wazuh' };
+const issuedTokens = new Map(); // token -> { username, expiresAt }
+
+const generateMockToken = (username) => {
+  const token = `mock-jwt-${username}-${Date.now()}`;
+  issuedTokens.set(token, {
+    username,
+    expiresAt: Date.now() + 900_000, // 15 min
+  });
+  return token;
+};
+
+const isValidToken = (authHeader) => {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return false;
+  const token = authHeader.slice(7);
+  const info = issuedTokens.get(token);
+  if (!info) return false;
+  if (Date.now() > info.expiresAt) {
+    issuedTokens.delete(token);
+    return false;
+  }
+  return true;
+};
+
+const sampleAlerts = [
+  {
+    id: '1',
+    timestamp: '2024-01-15T10:30:00Z',
+    rule: { description: 'SSH brute force attack detected', level: 10, groups: ['authentication_failed', 'sshd'], mitre: { id: ['T1110', 'T1021.004'] } },
+    agent: { id: '001', name: 'web-server', ip: '192.168.1.10' },
+    full_log: 'Jan 15 10:30:00 web-server sshd[1234]: Failed password for root from 10.0.0.5 port 22',
+  },
+  {
+    id: '2',
+    timestamp: '2024-01-15T11:00:00Z',
+    rule: { description: 'File modification detected', level: 7, groups: ['syscheck', 'rootcheck'], mitre: { id: ['T1565.001'] } },
+    agent: { id: '002', name: 'db-server', ip: '192.168.1.20' },
+    full_log: 'Jan 15 11:00:00 db-server ossec: File /etc/passwd modified',
+  },
+  {
+    id: '3',
+    timestamp: '2024-01-15T12:00:00Z',
+    rule: { description: 'Critical vulnerability detected', level: 14, groups: ['vulnerability-detector'], mitre: { id: ['T1190'] } },
+    agent: { id: '001', name: 'web-server', ip: '192.168.1.10' },
+    full_log: 'CVE-2024-0001 detected on web-server',
+  },
+];
+
+const sampleAgents = [
+  { id: '001', name: 'web-server', ip: '192.168.1.10', status: 'active', os: { name: 'Ubuntu', version: '22.04' }, version: 'Wazuh v4.9.0', lastKeepAlive: '2024-01-15T12:00:00Z', group: ['default', 'web'] },
+  { id: '002', name: 'db-server', ip: '192.168.1.20', status: 'active', os: { name: 'CentOS', version: '8' }, version: 'Wazuh v4.9.0', lastKeepAlive: '2024-01-15T12:00:00Z', group: ['default', 'database'] },
+  { id: '003', name: 'old-server', ip: '192.168.1.30', status: 'disconnected', os: { name: 'Debian', version: '11' }, version: 'Wazuh v4.8.0', lastKeepAlive: '2024-01-10T08:00:00Z', group: ['default'] },
+];
+
+const sampleVulnerabilities = [
+  { cve: 'CVE-2024-0001', severity: 'Critical', package: { name: 'openssl', version: '1.1.1f-1ubuntu2' }, title: 'OpenSSL Buffer Overflow', description: 'A buffer overflow vulnerability in OpenSSL', references: 'https://nvd.nist.gov/vuln/detail/CVE-2024-0001', type: 'Package' },
+  { cve: 'CVE-2024-0002', severity: 'High', package: { name: 'libcurl', version: '7.68.0-1' }, title: 'libcurl Use-After-Free', description: 'A use-after-free vulnerability in libcurl', references: 'https://nvd.nist.gov/vuln/detail/CVE-2024-0002', type: 'Package' },
+  { cve: 'CVE-2024-0003', severity: 'Medium', package: { name: 'nginx', version: '1.18.0-0ubuntu1' }, title: 'Nginx Information Disclosure', description: 'An information disclosure vulnerability in nginx', references: 'https://nvd.nist.gov/vuln/detail/CVE-2024-0003', type: 'Package' },
+  { cve: 'CVE-2024-0004', severity: 'Low', package: { name: 'bash', version: '5.0-6ubuntu1' }, title: 'Bash Denial of Service', description: 'A denial of service vulnerability in bash', references: 'https://nvd.nist.gov/vuln/detail/CVE-2024-0004', type: 'Advisory' },
+];
+
+const parseBody = (req) => new Promise((resolve) => {
+  const chunks = [];
+  req.on('data', (c) => chunks.push(c));
+  req.on('end', () => {
+    const raw = Buffer.concat(chunks).toString();
+    try { resolve(raw ? JSON.parse(raw) : {}); } catch { resolve({}); }
+  });
+});
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+  const authHeader = req.headers['authorization'] || '';
+
+  // ─── POST /security/user/authenticate ────────────────────────
+  if (req.method === 'POST' && url.pathname === '/security/user/authenticate') {
+    let username, password;
+
+    // Basic Auth
+    if (authHeader.startsWith('Basic ')) {
+      const decoded = Buffer.from(authHeader.slice(6), 'base64').toString();
+      const colonIdx = decoded.indexOf(':');
+      username = decoded.slice(0, colonIdx);
+      password = decoded.slice(colonIdx + 1);
+    } else {
+      const body = await parseBody(req);
+      username = body.username;
+      password = body.password;
+    }
+
+    if (validCredentials[username] === password) {
+      const token = generateMockToken(username);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        data: { token },
+        error: 0,
+        message: 'Authentication succeeded',
+      }));
+    } else {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        title: 'Unauthorized',
+        detail: 'Invalid credentials',
+        error: 401,
+      }));
+    }
+    return;
+  }
+
+  // ─── All other endpoints require Bearer token ────────────────
+  if (!isValidToken(authHeader)) {
+    res.writeHead(401, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({
+      title: 'Unauthorized',
+      detail: 'No valid token provided',
+      error: 401,
+    }));
+    return;
+  }
+
+  // ─── GET /alerts ────────────────────────────────────────────
+  if (req.method === 'GET' && url.pathname === '/alerts') {
+    const q = url.searchParams.get('q') || '';
+    const limit = parseInt(url.searchParams.get('limit') || '10', 10);
+    const offset = parseInt(url.searchParams.get('offset') || '0', 10);
+    const search = url.searchParams.get('search') || '';
+
+    let filtered = sampleAlerts;
+
+    // Apply severity filter from q parameter
+    const severityMatch = q.match(/rule\.level>=(\d+)/);
+    if (severityMatch) {
+      const minLevel = parseInt(severityMatch[1], 10);
+      filtered = filtered.filter((a) => a.rule.level >= minLevel);
+    }
+
+    if (search) {
+      const s = search.toLowerCase();
+      filtered = filtered.filter((a) =>
+        a.rule.description.toLowerCase().includes(s) ||
+        a.full_log.toLowerCase().includes(s)
+      );
+    }
+
+    const paged = filtered.slice(offset, offset + limit);
+
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({
+      data: {
+        affected_items: paged,
+        total_affected_items: filtered.length,
+      },
+      error: 0,
+      message: 'All alerts returned',
+    }));
+    return;
+  }
+
+  // ─── GET /overview/alerts ────────────────────────────────────
+  if (req.method === 'GET' && url.pathname === '/overview/alerts') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({
+      data: {
+        total_alerts: 3,
+        level_12_plus: 1,
+        level_8_11: 1,
+        level_4_7: 1,
+        level_0_3: 0,
+      },
+      error: 0,
+      message: 'Summary returned',
+    }));
+    return;
+  }
+
+  // ─── GET /vulnerability/:agent_id/summary ────────────────────
+  const vulnSummaryMatch = url.pathname.match(/^\/vulnerability\/([^/]+)\/summary$/);
+  if (req.method === 'GET' && vulnSummaryMatch) {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({
+      data: {
+        Critical: 1,
+        High: 1,
+        Medium: 1,
+        Low: 1,
+        total: 4,
+      },
+      error: 0,
+      message: 'Summary returned',
+    }));
+    return;
+  }
+
+  // ─── GET /vulnerability/:agent_id ────────────────────────────
+  const vulnMatch = url.pathname.match(/^\/vulnerability\/([^/]+)$/);
+  if (req.method === 'GET' && vulnMatch) {
+    const agentId = vulnMatch[1];
+    if (agentId === '000') {
+      // Manager has no vulnerabilities
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        data: { affected_items: [], total_affected_items: 0 },
+        error: 0,
+        message: 'No vulnerabilities found',
+      }));
+      return;
+    }
+
+    const limit = parseInt(url.searchParams.get('limit') || '10', 10);
+    const offset = parseInt(url.searchParams.get('offset') || '0', 10);
+    const paged = sampleVulnerabilities.slice(offset, offset + limit);
+
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({
+      data: {
+        affected_items: paged,
+        total_affected_items: sampleVulnerabilities.length,
+      },
+      error: 0,
+      message: 'Vulnerabilities returned',
+    }));
+    return;
+  }
+
+  // ─── GET /agents ─────────────────────────────────────────────
+  if (req.method === 'GET' && url.pathname === '/agents') {
+    const status = url.searchParams.get('status') || 'active';
+    const limit = parseInt(url.searchParams.get('limit') || '10', 10);
+    const offset = parseInt(url.searchParams.get('offset') || '0', 10);
+    const search = url.searchParams.get('search') || '';
+
+    let filtered = sampleAgents;
+    if (status && status !== 'all') {
+      filtered = filtered.filter((a) => a.status === status);
+    }
+
+    if (search) {
+      const s = search.toLowerCase();
+      filtered = filtered.filter((a) =>
+        a.name.toLowerCase().includes(s) ||
+        a.ip.includes(s)
+      );
+    }
+
+    const paged = filtered.slice(offset, offset + limit);
+
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({
+      data: {
+        affected_items: paged,
+        total_affected_items: filtered.length,
+      },
+      error: 0,
+      message: 'All agents returned',
+    }));
+    return;
+  }
+
+  // ─── 404 ─────────────────────────────────────────────────────
+  res.writeHead(404, { 'content-type': 'text/plain' });
+  res.end('not found');
+});
+
+server.listen(httpPort, () =>
+  log(
+    `listening on :${httpPort}`,
+    '\nEndpoints: POST /security/user/authenticate, GET /alerts, GET /overview/alerts, GET /vulnerability/{id}, GET /vulnerability/{id}/summary, GET /agents'
+  )
+);

--- a/services/wazuh__siem/test/wazuh-siem.test.js
+++ b/services/wazuh__siem/test/wazuh-siem.test.js
@@ -1,0 +1,1116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const listAlertsPath = '/Wazuh_SIEM.Wazuh_SIEM/ListAlerts';
+const getAlertSummaryPath = '/Wazuh_SIEM.Wazuh_SIEM/GetAlertSummary';
+const listVulnerabilitiesPath = '/Wazuh_SIEM.Wazuh_SIEM/ListVulnerabilities';
+const getVulnerabilitySummaryPath = '/Wazuh_SIEM.Wazuh_SIEM/GetVulnerabilitySummary';
+const listAgentsPath = '/Wazuh_SIEM.Wazuh_SIEM/ListAgents';
+
+const buildCtx = (req = {}, overrides = {}) => ({
+  bindings: {
+    endpoint: 'http://localhost:19000',
+    indexerEndpoint: 'http://localhost:19200',
+    ...overrides.bindings,
+  },
+  config: { ...overrides.config },
+  secret: { ...overrides.secret },
+  limits: { timeoutMs: 10_000, ...overrides.limits },
+  meta: { instance_id: 'inst', request_id: 'req', ...overrides.meta },
+  req,
+});
+
+const setFetch = (impl) => {
+  global.fetch = impl;
+};
+
+// ─── Mock helpers ────────────────────────────────────────────────
+
+// Mock Indexer API (Basic Auth + OpenSearch responses)
+const mockIndexer = (searchHandler) => {
+  const calls = { indexer: [] };
+
+  setFetch(async (url, init) => {
+    const urlString = typeof url === 'string' ? url : url.toString();
+
+    // Indexer API — Basic Auth check
+    calls.indexer.push({ url: urlString, init });
+
+    if (searchHandler) {
+      return searchHandler(urlString, init);
+    }
+
+    // Default empty OpenSearch response
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        hits: { hits: [], total: { value: 0, relation: 'eq' } },
+        aggregations: {},
+      }),
+    };
+  });
+
+  return calls;
+};
+
+// Mock Indexer API that fails auth
+const mockIndexerAuthFail = (status, body) => {
+  setFetch(async (url, init) => ({
+    ok: false,
+    status,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => body,
+  }));
+};
+
+// Mock Manager API (JWT auth + Wazuh Manager responses)
+const mockWithAuth = (token = 'test-token', apiHandler) => {
+  const calls = { auth: [], api: [] };
+
+  setFetch(async (url, init) => {
+    const urlString = typeof url === 'string' ? url : url.toString();
+
+    // Authentication endpoint
+    if (urlString.includes('/security/user/authenticate')) {
+      calls.auth.push({ url: urlString, init });
+      return {
+        ok: true,
+        status: 200,
+        headers: new Map([['content-type', 'application/json']]),
+        text: async () => JSON.stringify({
+          data: { token },
+          error: 0,
+          message: 'Authentication succeeded',
+        }),
+      };
+    }
+    // API endpoint
+    calls.api.push({ url: urlString, init });
+    if (apiHandler) {
+      return apiHandler(urlString, init);
+    }
+    // Default empty response
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        data: { affected_items: [], total_affected_items: 0 },
+        error: 0,
+      }),
+    };
+  });
+
+  return calls;
+};
+
+// Sets up a mock fetch that fails authentication with given HTTP status.
+const mockAuthFail = (status, body) => {
+  setFetch(async (url, init) => {
+    const urlString = typeof url === 'string' ? url : url.toString();
+    if (urlString.includes('/security/user/authenticate')) {
+      return {
+        ok: false,
+        status,
+        headers: new Map([['content-type', 'application/json']]),
+        text: async () => body,
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => '{}',
+    };
+  });
+};
+
+// Sets up mock that authenticates OK but returns HTTP error for API call.
+const mockAuthOkApiFail = (token = 'test-token', apiStatus, apiBody) => {
+  setFetch(async (url, init) => {
+    const urlString = typeof url === 'string' ? url : url.toString();
+    if (urlString.includes('/security/user/authenticate')) {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Map([['content-type', 'application/json']]),
+        text: async () => JSON.stringify({ data: { token }, error: 0 }),
+      };
+    }
+    return {
+      ok: false,
+      status: apiStatus,
+      headers: new Map([['content-type', 'text/plain']]),
+      text: async () => apiBody,
+    };
+  });
+};
+
+const loadHandler = async (methodPath, req, overrides = {}) => {
+  const { rpcdef } = await import('../src/wazuh-siem.js');
+  const ctx = buildCtx(req, overrides);
+  return rpcdef(ctx)[methodPath];
+};
+
+// Default context for Manager API (JWT auth)
+const defaultManagerSecretCtx = {
+  bindings: { endpoint: 'http://localhost:19000' },
+  secret: { username: 'wazuh', password: 'wazuh' },
+};
+
+// Default context for dual endpoint (Manager + Indexer)
+const defaultDualCtx = {
+  bindings: { endpoint: 'http://localhost:19000', indexerEndpoint: 'http://localhost:19200' },
+  secret: { username: 'wazuh', password: 'wazuh', indexerUsername: 'admin', indexerPassword: 'admin' },
+};
+
+// ─── Internal helpers ────────────────────────────────────────
+
+test('internal helpers normalize bindings, headers, errors, and call context', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+
+  assert.deepEqual(_test.mergedBindings({
+    config: { endpoint: 'http://config', keep: 'config' },
+    secret: { username: 'wazuh', password: 'secret' },
+    bindings: { endpoint: 'http://binding' },
+  }), {
+    endpoint: 'http://binding',
+    keep: 'config',
+    username: 'wazuh',
+    password: 'secret',
+  });
+
+  assert.deepEqual(_test.parseHeaders(undefined), {});
+  assert.deepEqual(_test.parseHeaders(''), {});
+  assert.deepEqual(_test.parseHeaders('{"X-Test":"yes"}'), { 'X-Test': 'yes' });
+  assert.deepEqual(_test.parseHeaders('{'), {});
+  assert.equal(_test.normalizeBaseUrl('ftp://bad'), null);
+  assert.equal(_test.normalizeBaseUrl('http://good'), 'http://good');
+  assert.equal(_test.normalizeBaseUrl('https://good/'), 'https://good');
+  assert.equal(_test.toPositiveInt({ value: '7' }), 7);
+  assert.equal(_test.toPositiveInt({}), null);
+
+  const unknown = _test.errorWithCode('SOMETHING_NEW', 'message');
+  assert.equal(unknown.legacyCode, 'SOMETHING_NEW');
+  assert.match(unknown.message, /SOMETHING_NEW: message/);
+
+  assert.deepEqual(_test.resolveCallContext({ config: { a: 1 } }, { x: 1 }, { secret: { b: 2 } }), {
+    req: { x: 1 },
+    ctx: {
+      config: { a: 1 },
+      secret: { b: 2 },
+      bindings: {},
+      limits: {},
+      meta: {},
+      metadata: {},
+      getMetadata: undefined,
+    },
+  });
+});
+
+// ─── buildAlertsOpenSearchQuery ────────────────────────────────
+
+test('buildAlertsOpenSearchQuery constructs OpenSearch DSL from structured fields', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+
+  // Empty request → match_all
+  const emptyQuery = _test.buildAlertsOpenSearchQuery({});
+  assert.deepEqual(emptyQuery, { match_all: {} });
+
+  // With severity_min
+  const severityQuery = _test.buildAlertsOpenSearchQuery({ severity_min: { value: 5 } });
+  assert.deepEqual(severityQuery, { bool: { must: [{ range: { 'rule.level': { gte: 5 } } }] } });
+
+  // With start_time and end_time
+  const timeQuery = _test.buildAlertsOpenSearchQuery({ start_time: { value: 1704067200 }, end_time: { value: 1704153600 } });
+  assert.equal(timeQuery.bool.must.length, 2);
+  assert.deepEqual(timeQuery.bool.must[0], { range: { timestamp: { gte: new Date(1704067200 * 1000).toISOString() } } });
+  assert.deepEqual(timeQuery.bool.must[1], { range: { timestamp: { lte: new Date(1704153600 * 1000).toISOString() } } });
+
+  // With raw query string
+  const rawQuery = _test.buildAlertsOpenSearchQuery({ query: 'rule.groups=authentication_failed', severity_min: { value: 5 } });
+  assert.equal(rawQuery.bool.must.length, 2);
+  assert.deepEqual(rawQuery.bool.must[0], { range: { 'rule.level': { gte: 5 } } });
+  assert.deepEqual(rawQuery.bool.must[1], { query_string: { query: 'rule.groups=authentication_failed' } });
+});
+
+// ─── extractAffectedItems ────────────────────────────────────
+
+test('extractAffectedItems handles Wazuh Manager API response formats', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+
+  assert.deepEqual(_test.extractAffectedItems({
+    data: { affected_items: [{ id: '1' }, { id: '2' }], total_affected_items: 2 },
+  }), { items: [{ id: '1' }, { id: '2' }], total: 2 });
+
+  assert.deepEqual(_test.extractAffectedItems({
+    data: { affected_items: [], total_affected_items: 0 },
+  }), { items: [], total: 0 });
+
+  assert.deepEqual(_test.extractAffectedItems({
+    data: { total_alerts: 100, level_12_plus: 10 },
+  }), { items: [], total: 0, stats: { total_alerts: 100, level_12_plus: 10 } });
+});
+
+// ─── extractOpenSearchHits ────────────────────────────────────
+
+test('extractOpenSearchHits handles OpenSearch response format', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+
+  const osResponse = {
+    hits: {
+      hits: [
+        { _id: 'alert-1', _source: { id: '1', timestamp: '2024-01-15T10:30:00Z', rule: { description: 'SSH brute force' } } },
+        { _id: 'alert-2', _source: { id: '2', timestamp: '2024-01-15T11:00:00Z', rule: { description: 'File modification' } } },
+      ],
+      total: { value: 2, relation: 'eq' },
+    },
+  };
+
+  const extracted = _test.extractOpenSearchHits(osResponse);
+  assert.equal(extracted.items.length, 2);
+  assert.equal(extracted.items[0]._id, 'alert-1');
+  assert.equal(extracted.items[0].id, '1');
+  assert.equal(extracted.total, 2);
+
+  // Empty response
+  assert.deepEqual(_test.extractOpenSearchHits({}), { items: [], total: 0 });
+  assert.deepEqual(_test.extractOpenSearchHits({ hits: { hits: [], total: { value: 0 } } }), { items: [], total: 0 });
+});
+
+// ─── mapAlertRecord ──────────────────────────────────────────
+
+test('mapAlertRecord maps Wazuh alert to proto AlertRecord', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+
+  const alert = {
+    id: '1',
+    timestamp: '2024-01-15T10:30:00Z',
+    rule: { description: 'SSH brute force', level: 10, groups: ['auth', 'sshd'], mitre: { id: ['T1110'] } },
+    agent: { id: '001', name: 'web', ip: '10.0.0.1' },
+    full_log: 'log line',
+  };
+
+  const mapped = _test.mapAlertRecord(alert);
+  assert.equal(mapped.id, '1');
+  assert.equal(mapped.timestamp, '2024-01-15T10:30:00Z');
+  assert.equal(mapped.rule_description, 'SSH brute force');
+  assert.equal(mapped.rule_level, 10);
+  assert.equal(mapped.rule_groups, 'auth,sshd');
+  assert.equal(mapped.rule_mitre_id, 'T1110');
+  assert.equal(mapped.agent_id, '001');
+  assert.equal(mapped.agent_name, 'web');
+  assert.equal(mapped.agent_ip, '10.0.0.1');
+  assert.equal(mapped.full_log, 'log line');
+});
+
+// ─── mapAgentRecord ──────────────────────────────────────────
+
+test('mapAgentRecord maps Wazuh agent to proto AgentRecord', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+
+  const agent = {
+    id: '001', name: 'web-server', ip: '192.168.1.10', status: 'active',
+    os: { name: 'Ubuntu', version: '22.04' }, version: 'Wazuh v4.9.0',
+    lastKeepAlive: '2024-01-15T12:00:00Z', group: ['default', 'web'],
+  };
+
+  const mapped = _test.mapAgentRecord(agent);
+  assert.equal(mapped.id, '001');
+  assert.equal(mapped.name, 'web-server');
+  assert.equal(mapped.ip, '192.168.1.10');
+  assert.equal(mapped.status, 'active');
+  assert.equal(mapped.os_name, 'Ubuntu');
+  assert.equal(mapped.os_version, '22.04');
+  assert.equal(mapped.wazuh_version, 'Wazuh v4.9.0');
+  assert.equal(mapped.group, 'default,web');
+});
+
+// ─── mapVulnerabilityRecord ──────────────────────────────────
+
+test('mapVulnerabilityRecord maps Wazuh vulnerability to proto VulnerabilityRecord', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+
+  // Old format (from Manager API)
+  const vulnOld = {
+    cve: 'CVE-2024-0001', severity: 'Critical',
+    package: { name: 'openssl', version: '1.1.1f' },
+    title: 'OpenSSL Overflow', description: 'Buffer overflow',
+    references: 'https://nvd.nist.gov/vuln/detail/CVE-2024-0001', type: 'Package',
+  };
+
+  const mappedOld = _test.mapVulnerabilityRecord(vulnOld);
+  assert.equal(mappedOld.cve, 'CVE-2024-0001');
+  assert.equal(mappedOld.severity, 'Critical');
+  assert.equal(mappedOld.package_name, 'openssl');
+  assert.equal(mappedOld.package_version, '1.1.1f');
+
+  // Indexer format (with vulnerability nested object)
+  const vulnNew = {
+    vulnerability: {
+      cve: 'CVE-2024-0002', severity: 'High',
+      package: { name: 'nginx', version: '1.18' },
+      title: 'Nginx Info Disclosure', description: 'Information disclosure',
+      reference: 'https://nvd.nist.gov/vuln/detail/CVE-2024-0002',
+      type: 'Package',
+    },
+  };
+
+  const mappedNew = _test.mapVulnerabilityRecord(vulnNew);
+  assert.equal(mappedNew.cve, 'CVE-2024-0002');
+  assert.equal(mappedNew.severity, 'High');
+  assert.equal(mappedNew.package_name, 'nginx');
+  assert.equal(mappedNew.package_version, '1.18');
+});
+
+// ─── Endpoint configuration validation ──────────────────────────
+
+test('ListAlerts requires indexerEndpoint', async () => {
+  const handler = await loadHandler(listAlertsPath, {}, {
+    bindings: { endpoint: 'http://localhost:19000', indexerEndpoint: '' },
+  });
+  await assert.rejects(() => handler(), /indexerEndpoint is required for alert/);
+});
+
+test('ListAgents requires endpoint (Manager API)', async () => {
+  const handler = await loadHandler(listAgentsPath, {}, {
+    bindings: { indexerEndpoint: 'http://localhost:19200', endpoint: '' },
+    secret: { username: 'wazuh', password: 'wazuh' },
+  });
+  await assert.rejects(() => handler(), /restBaseUrl\/baseUrl\/endpoint is required for Manager API/);
+});
+
+// ─── Indexer API: ListAlerts ──────────────────────────────────
+
+test('ListAlerts queries Indexer API with OpenSearch DSL and maps response', async () => {
+  const calls = mockIndexer((url, init) => {
+    // Verify it's an OpenSearch _search request
+    assert.match(url, /wazuh-alerts-.*\/_search/);
+    assert.equal(init.method, 'POST');
+    // Verify Basic Auth
+    assert.match(init.headers['Authorization'], /^Basic /);
+
+    // Parse request body
+    const body = JSON.parse(init.body);
+    assert.equal(body.size, 10);
+    assert.equal(body.from, 0);
+    // Verify sort
+    assert.deepEqual(body.sort, [{ timestamp: { order: 'desc' } }]);
+
+    // Return OpenSearch response
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        hits: {
+          hits: [
+            {
+              _id: 'alert-1',
+              _source: {
+                id: '1',
+                timestamp: '2024-01-15T10:30:00Z',
+                rule: { description: 'SSH brute force attack detected', level: 10, groups: ['authentication_failed', 'sshd'], mitre: { id: ['T1110'] } },
+                agent: { id: '001', name: 'web-server', ip: '192.168.1.10' },
+                full_log: 'Failed password',
+              },
+            },
+          ],
+          total: { value: 1, relation: 'eq' },
+        },
+      }),
+    };
+  });
+
+  const handler = await loadHandler(listAlertsPath, {
+    limit: { value: 10 },
+    offset: { value: 0 },
+    severity_min: { value: 5 },
+  }, defaultDualCtx);
+  const res = await handler();
+
+  assert.equal(res.data.alerts.length, 1);
+  assert.equal(res.data.alerts[0].rule_description, 'SSH brute force attack detected');
+  assert.equal(res.data.alerts[0].rule_level, 10);
+  assert.equal(res.data.alerts[0].rule_mitre_id, 'T1110');
+  assert.equal(res.data.total, 1);
+
+  // Verify the request was sent to Indexer
+  assert.equal(calls.indexer.length, 1);
+});
+
+test('ListAlerts handles empty Indexer response', async () => {
+  mockIndexer();
+
+  const handler = await loadHandler(listAlertsPath, {}, defaultDualCtx);
+  const res = await handler();
+
+  assert.equal(res.data.alerts.length, 0);
+  assert.equal(res.data.total, 0);
+});
+
+// ─── Indexer API: GetAlertSummary ──────────────────────────────────
+
+test('GetAlertSummary uses Indexer aggregation for severity distribution', async () => {
+  const calls = mockIndexer((url, init) => {
+    assert.match(url, /wazuh-alerts-.*\/_search/);
+    const body = JSON.parse(init.body);
+    assert.equal(body.size, 0);
+    assert.ok(body.aggs);
+    assert.ok(body.aggs.by_level);
+
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        hits: { total: { value: 100, relation: 'eq' }, hits: [] },
+        aggregations: {
+          by_level: {
+            buckets: [
+              { key: 'level_12_plus', doc_count: 10 },
+              { key: 'level_8_11', doc_count: 30 },
+              { key: 'level_4_7', doc_count: 50 },
+              { key: 'level_0_3', doc_count: 10 },
+            ],
+          },
+        },
+      }),
+    };
+  });
+
+  const handler = await loadHandler(getAlertSummaryPath, {}, defaultDualCtx);
+  const res = await handler();
+
+  assert.equal(res.data.total_alerts, 100);
+  assert.equal(res.data.level_12_plus, 10);
+  assert.equal(res.data.level_8_11, 30);
+  assert.equal(res.data.level_4_7, 50);
+  assert.equal(res.data.level_0_3, 10);
+});
+
+// ─── Indexer API: ListVulnerabilities ──────────────────────────────
+
+test('ListVulnerabilities validates agent_id is required', async () => {
+  mockIndexer();
+
+  const handler = await loadHandler(listVulnerabilitiesPath, {}, defaultDualCtx);
+  await assert.rejects(() => handler(), /INVALID_ARGUMENT: agent_id is required/);
+});
+
+test('ListVulnerabilities queries Indexer with agent filter and maps response', async () => {
+  const calls = mockIndexer((url, init) => {
+    assert.match(url, /wazuh-vulnerabilities-.*\/_search/);
+    const body = JSON.parse(init.body);
+    assert.ok(body.query);
+    assert.ok(body.query.bool.must);
+    // Verify agent.id filter
+    const agentFilter = body.query.bool.must.find((m) => m.term && m.term['agent.id']);
+    assert.ok(agentFilter);
+    assert.equal(agentFilter.term['agent.id'], '001');
+
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        hits: {
+          hits: [
+            {
+              _id: 'vuln-1',
+              _source: {
+                vulnerability: {
+                  cve: 'CVE-2024-0001',
+                  severity: 'Critical',
+                  package: { name: 'openssl', version: '1.1.1f' },
+                  title: 'OpenSSL Buffer Overflow',
+                  description: 'Buffer overflow',
+                  reference: 'https://nvd.nist.gov/vuln/detail/CVE-2024-0001',
+                  type: 'Package',
+                },
+                agent: { id: '001', name: 'web-server' },
+              },
+            },
+          ],
+          total: { value: 1, relation: 'eq' },
+        },
+      }),
+    };
+  });
+
+  const handler = await loadHandler(listVulnerabilitiesPath, {
+    agent_id: '001',
+    limit: { value: 10 },
+  }, defaultDualCtx);
+  const res = await handler();
+
+  assert.equal(res.data.vulnerabilities.length, 1);
+  assert.equal(res.data.vulnerabilities[0].cve, 'CVE-2024-0001');
+  assert.equal(res.data.vulnerabilities[0].severity, 'Critical');
+  assert.equal(res.data.vulnerabilities[0].package_name, 'openssl');
+  assert.equal(res.data.total, 1);
+});
+
+// ─── Indexer API: GetVulnerabilitySummary ──────────────────────────────
+
+test('GetVulnerabilitySummary validates agent_id is required', async () => {
+  mockIndexer();
+
+  const handler = await loadHandler(getVulnerabilitySummaryPath, {}, defaultDualCtx);
+  await assert.rejects(() => handler(), /INVALID_ARGUMENT: agent_id is required/);
+});
+
+test('GetVulnerabilitySummary uses Indexer aggregation for severity counts', async () => {
+  mockIndexer((url, init) => {
+    const body = JSON.parse(init.body);
+    assert.equal(body.size, 0);
+    assert.ok(body.query);
+    assert.ok(body.aggs.by_severity);
+
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        hits: { total: { value: 50, relation: 'eq' }, hits: [] },
+        aggregations: {
+          by_severity: {
+            buckets: [
+              { key: 'Critical', doc_count: 5 },
+              { key: 'High', doc_count: 10 },
+              { key: 'Medium', doc_count: 20 },
+              { key: 'Low', doc_count: 15 },
+            ],
+          },
+        },
+      }),
+    };
+  });
+
+  const handler = await loadHandler(getVulnerabilitySummaryPath, {
+    agent_id: '001',
+  }, defaultDualCtx);
+  const res = await handler();
+
+  assert.equal(res.data.critical_count, 5);
+  assert.equal(res.data.high_count, 10);
+  assert.equal(res.data.medium_count, 20);
+  assert.equal(res.data.low_count, 15);
+  assert.equal(res.data.total, 50);
+});
+
+// ─── Manager API: ListAgents ──────────────────────────────────
+
+test('ListAgents queries Manager API and maps agent data', async () => {
+  mockWithAuth('test-token', () => ({
+    ok: true,
+    status: 200,
+    headers: new Map([['content-type', 'application/json']]),
+    text: async () => JSON.stringify({
+      data: {
+        affected_items: [
+          { id: '001', name: 'web-server', ip: '192.168.1.10', status: 'active', os: { name: 'Ubuntu', version: '22.04' }, version: 'Wazuh v4.9.0', lastKeepAlive: '2024-01-15T12:00:00Z', group: ['default', 'web'] },
+        ],
+        total_affected_items: 1,
+      },
+      error: 0,
+    }),
+  }));
+
+  const handler = await loadHandler(listAgentsPath, {
+    status: 'active',
+  }, defaultDualCtx);
+  const res = await handler();
+
+  assert.equal(res.data.agents.length, 1);
+  assert.equal(res.data.agents[0].id, '001');
+  assert.equal(res.data.agents[0].name, 'web-server');
+  assert.equal(res.data.agents[0].os_name, 'Ubuntu');
+  assert.equal(res.data.agents[0].group, 'default,web');
+  assert.equal(res.data.total, 1);
+});
+
+// ─── JWT Authentication (Manager API) ──────────────────────────────
+
+test('authenticate obtains JWT token via Basic Auth for Manager API', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  _test.clearJwtCache();
+
+  const calls = mockWithAuth('test-jwt-token-123');
+
+  const handler = await loadHandler(listAgentsPath, {}, defaultManagerSecretCtx);
+  await handler();
+
+  // Verify auth call used Basic Auth
+  assert.equal(calls.auth.length, 1);
+  assert.match(calls.auth[0].init.headers['Authorization'], /^Basic /);
+  const decoded = Buffer.from(calls.auth[0].init.headers['Authorization'].slice(6), 'base64').toString();
+  assert.equal(decoded, 'wazuh:wazuh');
+
+  // Verify API call used Bearer token
+  assert.equal(calls.api.length, 1);
+  assert.match(calls.api[0].init.headers['Authorization'], /^Bearer test-jwt-token-123$/);
+});
+
+test('authenticate fails without credentials', async () => {
+  const handler = await loadHandler(listAgentsPath, {}, {
+    bindings: { endpoint: 'http://localhost:19000' },
+  });
+  await assert.rejects(() => handler(), /INVALID_ARGUMENT: username and password are required/);
+});
+
+test('authenticate fails with wrong credentials (HTTP 401)', async () => {
+  mockAuthFail(401, JSON.stringify({ title: 'Unauthorized', detail: 'Invalid credentials' }));
+
+  const handler = await loadHandler(listAgentsPath, {}, {
+    bindings: { endpoint: 'http://localhost:19000' },
+    secret: { username: 'bad', password: 'creds' },
+  });
+  await assert.rejects(() => handler(), /UNAUTHENTICATED: Wazuh authentication failed: invalid credentials \(401\)/);
+});
+
+// ─── HTTP error mapping ──────────────────────────────────────
+
+test('Indexer HTTP 403 maps to PERMISSION_DENIED', async () => {
+  mockIndexerAuthFail(403, 'forbidden');
+
+  const handler = await loadHandler(listAlertsPath, {}, defaultDualCtx);
+  await assert.rejects(() => handler(), /PERMISSION_DENIED: indexer-post forbidden \(403\)/);
+});
+
+test('Indexer HTTP 500 maps to UNAVAILABLE', async () => {
+  mockIndexerAuthFail(500, 'internal server error');
+
+  const handler = await loadHandler(listAlertsPath, {}, defaultDualCtx);
+  await assert.rejects(() => handler(), /UNAVAILABLE: upstream http 500/);
+});
+
+test('Manager API HTTP 422 maps to FAILED_PRECONDITION', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  _test.clearJwtCache();
+  mockAuthOkApiFail('test-token', 422, 'invalid request');
+
+  const handler = await loadHandler(listAgentsPath, {}, defaultManagerSecretCtx);
+  await assert.rejects(() => handler(), /FAILED_PRECONDITION: upstream http 422/);
+});
+
+test('Network failure maps to a redacted UNAVAILABLE error', async () => {
+  setFetch(async () => {
+    throw Object.assign(new Error('connection refused'), { cause: new Error('ECONNREFUSED') });
+  });
+
+  const handler = await loadHandler(listAlertsPath, {}, defaultDualCtx);
+  await assert.rejects(() => handler(), /UNAVAILABLE: upstream request failed/);
+});
+
+test('search fields, pagination validation, and page-size bound are enforced', async () => {
+  let body;
+  mockIndexer(async (_url, init) => {
+    body = JSON.parse(init.body);
+    return { ok: true, status: 200, headers: new Map(), text: async () => '{"hits":{"hits":[],"total":{"value":0}}}' };
+  });
+  const alerts = await loadHandler(listAlertsPath, { search: 'ssh failure' }, defaultDualCtx);
+  await alerts();
+  assert.deepEqual(body.query.bool.must[0], {
+    multi_match: { query: 'ssh failure', fields: ['rule.description', 'full_log', 'agent.name', 'agent.ip'] },
+  });
+
+  const vulnerabilities = await loadHandler(listVulnerabilitiesPath, {
+    agent_id: '001', search: 'CVE package', query: 'vulnerability.severity:high',
+  }, defaultDualCtx);
+  await vulnerabilities();
+  assert.equal(body.query.bool.must.length, 3);
+
+  for (const req of [{ limit: { value: -1 } }, { offset: -2 }, { limit: 1001 }]) {
+    const handler = await loadHandler(listAlertsPath, req, defaultDualCtx);
+    await assert.rejects(() => handler(), /INVALID_ARGUMENT: (limit|offset) must be an integer/);
+  }
+});
+
+test('Indexer credentials are mandatory and Basic Auth supports UTF-8', async () => {
+  const missing = await loadHandler(listAlertsPath, {}, {
+    bindings: { indexerEndpoint: 'http://localhost:19200' },
+  });
+  await assert.rejects(() => missing(), /indexerUsername and indexerPassword are required/);
+
+  let authorization;
+  mockIndexer(async (_url, init) => {
+    authorization = init.headers.Authorization;
+    return { ok: true, status: 200, headers: new Map(), text: async () => '{"hits":{"hits":[],"total":{"value":0}}}' };
+  });
+  const handler = await loadHandler(listAlertsPath, {}, {
+    bindings: { indexerEndpoint: 'http://localhost:19200' },
+    secret: { indexerUsername: '用户', indexerPassword: '密码' },
+  });
+  await handler();
+  assert.equal(Buffer.from(authorization.slice(6), 'base64').toString('utf8'), '用户:密码');
+});
+
+test('JWT cache isolates password rotations and Manager Basic Auth supports UTF-8', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  _test.clearJwtCache();
+  const authHeaders = [];
+  setFetch(async (url, init) => {
+    if (String(url).includes('/authenticate')) {
+      authHeaders.push(init.headers.Authorization);
+      return { ok: true, status: 200, headers: new Map(), text: async () => '{"data":{"token":"token"}}' };
+    }
+    return { ok: true, status: 200, headers: new Map(), text: async () => '{"data":{"affected_items":[]}}' };
+  });
+  for (const password of ['密码一', '密码二']) {
+    const handler = await loadHandler(listAgentsPath, {}, {
+      bindings: { endpoint: 'http://localhost:19000' }, secret: { username: '用户', password },
+    });
+    await handler();
+  }
+  assert.equal(authHeaders.length, 2);
+  assert.equal(Buffer.from(authHeaders[0].slice(6), 'base64').toString('utf8'), '用户:密码一');
+});
+
+test('response reader enforces declared, buffered, and streamed size limits', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  await assert.rejects(() => _test.readResponseText({
+    headers: { get: () => String(5 * 1024 * 1024) },
+  }), /exceeds 4 MiB/);
+  await assert.rejects(() => _test.readResponseText({
+    headers: { get: () => null }, text: async () => 'x'.repeat(5 * 1024 * 1024),
+  }), /exceeds 4 MiB/);
+  const response = new Response('streamed');
+  assert.equal(await _test.readResponseText(response), 'streamed');
+});
+
+test('invalid timeout is rejected and redirects are not followed', async () => {
+  const invalid = await loadHandler(listAlertsPath, {}, {
+    bindings: { indexerEndpoint: 'http://localhost:19200', timeoutMs: 0 },
+    secret: { indexerUsername: 'admin', indexerPassword: 'secret' },
+    limits: { timeoutMs: 0 },
+  });
+  // A zero binding falls through to the default; an excessive value is rejected.
+  assert.equal(typeof invalid, 'function');
+  const { rpcdef } = await import('../src/wazuh-siem.js');
+  assert.throws(() => rpcdef({ config: { timeoutMs: 300001 } }), /timeoutMs must be an integer/);
+
+  let redirect;
+  mockIndexer(async (_url, init) => {
+    redirect = init.redirect;
+    return { ok: true, status: 200, headers: new Map(), text: async () => '{"hits":{"hits":[],"total":{"value":0}}}' };
+  });
+  const handler = await loadHandler(listAlertsPath, {}, defaultDualCtx);
+  await handler();
+  assert.equal(redirect, 'manual');
+});
+
+test('utility edge cases and bounded token cache are covered', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  assert.deepEqual(_test.parseHeaders({ A: 'b' }), { A: 'b' });
+  assert.deepEqual(_test.parseHeaders([]), {});
+  assert.deepEqual(_test.parseHeaders('[]'), {});
+  assert.equal(_test.toPositiveInt(null), null);
+  assert.equal(_test.toPositiveInt(-1), null);
+  assert.equal(_test.toPositiveInt(1.5), null);
+  assert.deepEqual(_test.toValue(true), { boolValue: true });
+  assert.deepEqual(_test.toValue(['x', 2]), { listValue: { values: [{ stringValue: 'x' }, { numberValue: 2 }] } });
+  assert.deepEqual(_test.toValue({ nested: null }), {
+    structValue: { fields: { nested: { stringValue: '' } } },
+  });
+  assert.deepEqual(_test.toValue(1n), { stringValue: '1' });
+  assert.throws(() => _test.paginationValue({ limit: 'bad' }, ['limit'], 10, 'limit', 1000), /INVALID_ARGUMENT/);
+  assert.equal(_test.paginationValue({}, ['limit'], 10, 'limit', 1000), 10);
+  _test.clearJwtCache();
+  for (let index = 0; index < 130; index += 1) {
+    _test.cacheToken(`cache-${index}`, { token: String(index), expiresAt: Date.now() });
+  }
+});
+
+test('authentication rejects malformed success responses without leaking bodies', async () => {
+  for (const [body, expected] of [
+    ['not-json-secret', /authentication response is not valid JSON/],
+    ['{"data":{}}', /no token returned/],
+  ]) {
+    const { _test } = await import('../src/wazuh-siem.js');
+    _test.clearJwtCache();
+    setFetch(async () => ({ ok: true, status: 200, headers: new Map(), text: async () => body }));
+    const handler = await loadHandler(listAgentsPath, {}, defaultManagerSecretCtx);
+    await assert.rejects(() => handler(), expected);
+  }
+
+  const { _test } = await import('../src/wazuh-siem.js');
+  _test.clearJwtCache();
+  mockAuthFail(429, 'rate-limit-secret');
+  const handler = await loadHandler(listAgentsPath, {}, defaultManagerSecretCtx);
+  await assert.rejects(() => handler(), (error) => {
+    assert.match(error.message, /UNAVAILABLE.*http 429/);
+    assert.doesNotMatch(error.message, /rate-limit-secret/);
+    return true;
+  });
+});
+
+test('stream reader cancels oversized bodies', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  let cancelled = false;
+  let released = false;
+  const reader = {
+    read: async () => ({ done: false, value: new Uint8Array(5 * 1024 * 1024) }),
+    cancel: async () => { cancelled = true; },
+    releaseLock: () => { released = true; },
+  };
+  await assert.rejects(() => _test.readResponseText({
+    headers: { get: () => null }, body: { getReader: () => reader },
+  }), /exceeds 4 MiB/);
+  assert.equal(cancelled, true);
+  assert.equal(released, true);
+});
+
+test('mappers and response extractors tolerate sparse upstream payloads', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  assert.deepEqual(_test.extractAffectedItems(null), { items: [], total: 0 });
+  assert.deepEqual(_test.extractAffectedItems({ data: [{ id: 1 }] }), { items: [{ id: 1 }], total: 1 });
+  assert.deepEqual(_test.extractAffectedItems({ data: { answer: 42 } }), {
+    items: [], total: 0, stats: { answer: 42 },
+  });
+  assert.deepEqual(_test.extractOpenSearchHits({}), { items: [], total: 0 });
+  assert.deepEqual(_test.mapAlertRecord({}), {
+    id: '', timestamp: '', rule_description: '', rule_level: 0, rule_groups: '', rule_mitre_id: '',
+    agent_id: '', agent_name: '', agent_ip: '', full_log: '', raw: {},
+  });
+  assert.deepEqual(_test.mapAgentRecord({}), {
+    id: '', name: '', ip: '', status: '', os_name: '', os_version: '', wazuh_version: '', last_keep_alive: '', group: '',
+  });
+  assert.deepEqual(_test.mapVulnerabilityRecord({}), {
+    cve: '', severity: '', package_name: '', package_version: '', title: '', description: '', reference: '', type: '', raw: {},
+  });
+});
+
+test('Manager retries one expired JWT and carries optional filters', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  _test.clearJwtCache();
+  let authCount = 0;
+  let apiCount = 0;
+  let finalUrl;
+  setFetch(async (url) => {
+    if (String(url).includes('/authenticate')) {
+      authCount += 1;
+      return { ok: true, status: 200, headers: new Map(), text: async () => `{"data":{"token":"token-${authCount}"}}` };
+    }
+    apiCount += 1;
+    finalUrl = String(url);
+    if (apiCount === 1) return { ok: false, status: 401, headers: new Map(), text: async () => 'expired-secret' };
+    return { ok: true, status: 200, headers: new Map(), text: async () => '{"data":{"affected_items":[]}}' };
+  });
+  const handler = await loadHandler(listAgentsPath, {
+    status: 'all', search: 'linux', query: 'id=001', limit: 5, offset: 2,
+  }, defaultManagerSecretCtx);
+  await handler();
+  assert.equal(authCount, 2);
+  assert.equal(apiCount, 2);
+  assert.match(finalUrl, /search=linux/);
+  assert.match(finalUrl, /q=id%3D001/);
+  assert.doesNotMatch(finalUrl, /status=/);
+});
+
+test('TLS opt-out installs an undici dispatcher and empty response is accepted', async () => {
+  let dispatcher;
+  setFetch(async (_url, init) => {
+    dispatcher = init.dispatcher;
+    return { ok: true, status: 200, headers: new Map(), text: async () => '' };
+  });
+  const handler = await loadHandler(listAlertsPath, {}, {
+    config: { indexerEndpoint: 'https://localhost:19200', skipTlsVerify: true },
+    secret: { indexerUsername: 'admin', indexerPassword: 'secret' },
+  });
+  const response = await handler();
+  assert.ok(dispatcher);
+  assert.equal(response.data.total, 0);
+  await dispatcher.close();
+});
+
+test('legacy invocation adapter accepts request and context shapes', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  assert.deepEqual(_test.resolveCallContext({}, { request: { a: 1 }, config: { b: 2 } }), {
+    req: { a: 1 },
+    ctx: { request: { a: 1 }, config: { b: 2 }, bindings: {}, secret: {}, limits: {}, meta: {}, metadata: {}, getMetadata: undefined },
+  });
+  assert.deepEqual(_test.resolveCallContext(undefined, undefined, undefined).req, {});
+});
+
+// ─── Indexer Basic Auth failure ──────────────────────────────────
+
+test('Indexer auth failure (HTTP 401) maps to UNAUTHENTICATED', async () => {
+  mockIndexerAuthFail(401, JSON.stringify({ error: { root_cause: [{ type: 'security_exception' }] } }));
+
+  const handler = await loadHandler(listAlertsPath, {}, defaultDualCtx);
+  await assert.rejects(() => handler(), /UNAUTHENTICATED: indexer-post unauthorized \(401\)/);
+});
+
+test('authenticate fails with HTTP 403 maps to PERMISSION_DENIED', async () => {
+  mockAuthFail(403, JSON.stringify({ title: 'Forbidden', detail: 'Access denied' }));
+
+  const handler = await loadHandler(listAgentsPath, {}, {
+    bindings: { endpoint: 'http://localhost:19000' },
+    secret: { username: 'user', password: 'pass' },
+  });
+  await assert.rejects(() => handler(), /PERMISSION_DENIED: Wazuh authentication forbidden \(403\)/);
+});
+
+test('fetch timeout maps to DEADLINE_EXCEEDED', async () => {
+  setFetch(async () => {
+    const err = new Error('The operation was aborted due to timeout');
+    err.name = 'TimeoutError';
+    throw err;
+  });
+
+  const handler = await loadHandler(listAlertsPath, {}, defaultDualCtx);
+  await assert.rejects(() => handler(), /DEADLINE_EXCEEDED: request timeout after/);
+});
+
+test('throwForHttpError does not leak upstream response body in 401/403 errors', async () => {
+  const sensitiveBody = JSON.stringify({ secret_key: 'should-not-appear', internal_ip: '10.0.0.1' });
+  mockIndexerAuthFail(401, sensitiveBody);
+
+  const handler = await loadHandler(listAlertsPath, {}, defaultDualCtx);
+  try {
+    await handler();
+    assert.fail('should have thrown');
+  } catch (err) {
+    const msg = err.message || String(err);
+    assert.match(msg, /UNAUTHENTICATED/);
+    assert.doesNotMatch(msg, /secret_key/);
+    assert.doesNotMatch(msg, /should-not-appear/);
+  }
+});
+
+// ─── SDK handler invocation ──────────────────────────────────
+
+test('SDK handlers accept single context with dual endpoint config', async () => {
+  mockIndexer();
+
+  const { handlers, METHOD_LIST_ALERTS_FULL } = await import('../src/wazuh-siem.js');
+  const res = await handlers[METHOD_LIST_ALERTS_FULL]({
+    config: { endpoint: 'http://localhost:19000', indexerEndpoint: 'http://localhost:19200' },
+    secret: { username: 'wazuh', password: 'wazuh', indexerUsername: 'admin', indexerPassword: 'admin' },
+    request: {},
+    meta: { instance_id: 'inst-sdk', request_id: 'req-sdk' },
+  });
+
+  assert.equal(res.data.alerts.length, 0);
+});
+
+test('SDK handlers accept request plus inner context arguments (Manager API)', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  _test.clearJwtCache();
+  const calls = mockWithAuth('inner-token');
+
+  const registered = _test.registerHandlers({
+    bindings: { endpoint: 'http://base' },
+  });
+
+  await registered[listAgentsPath]({}, {
+    bindings: { endpoint: 'http://inner' },
+    secret: { username: 'inner-wazuh', password: 'inner-pass' },
+    meta: { instanceId: 'inst-camel', requestId: 'req-camel' },
+  });
+
+  // Verify inner context overrides
+  assert.equal(calls.api.length, 1);
+  assert.match(calls.api[0].init.headers['x-engine-instance'], /inst-camel/);
+});
+
+// ─── Review fix verification ──────────────────────────────────
+
+test('JWT token cache persists across rpcdef() calls (module-level Map, not closure)', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  _test.clearJwtCache();
+
+  const calls = mockWithAuth('persistent-token');
+
+  // First call triggers authentication
+  const handler1 = await loadHandler(listAgentsPath, {}, defaultManagerSecretCtx);
+  await handler1();
+  assert.equal(calls.auth.length, 1);
+
+  // Second call reuses cached token — no additional auth request
+  const handler2 = await loadHandler(listAgentsPath, {}, defaultManagerSecretCtx);
+  await handler2();
+  assert.equal(calls.auth.length, 1); // Still 1, cache hit
+  assert.equal(calls.api.length, 2);  // Two API calls total
+});
+
+test('request-level username/password takes priority for Manager JWT auth', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  _test.clearJwtCache();
+
+  const calls = mockWithAuth('req-cred-token');
+
+  const handler = await loadHandler(listAgentsPath, {
+    username: 'override-user',
+    password: 'override-pass',
+  }, defaultManagerSecretCtx);
+  await handler();
+
+  // Auth should use request-level credentials, not secret-level
+  assert.equal(calls.auth.length, 1);
+  assert.match(calls.auth[0].init.headers['Authorization'], /^Basic /);
+  const decoded = Buffer.from(calls.auth[0].init.headers['Authorization'].slice(6), 'base64').toString();
+  assert.equal(decoded, 'override-user:override-pass');
+});
+
+test('timeoutMs reads from bindings (config) before falling back to limits', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  // mergedBindings merges config into bindings, so config.timeoutMs takes priority
+  const bindings = _test.mergedBindings({
+    config: { timeoutMs: 8000 },
+    limits: { timeoutMs: 5000 },
+  });
+  assert.equal(bindings.timeoutMs, 8000); // config wins over limits
+});
+
+test('JWT payload decoded with base64url (not atob) for token expiry parsing', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  _test.clearJwtCache();
+
+  // Create a JWT-like token with base64url characters (- and _)
+  // Header: eyJhbGciOiJIUzI1NiI (standard base64url)
+  // Payload: base64url-encoded JSON with exp field containing base64url chars
+  const header = 'eyJhbGciOiJIUzI1NiI';
+  const payload = Buffer.from(JSON.stringify({ exp: 9999999999 })).toString('base64url');
+  const signature = 'test-sig-_with-base64url_chars';
+  const jwtToken = `${header}.${payload}.${signature}`;
+
+  const calls = mockWithAuth(jwtToken);
+  const handler = await loadHandler(listAgentsPath, {}, defaultManagerSecretCtx);
+  await handler();
+
+  // Verify the auth was successful (no error) — base64url parsing worked
+  assert.equal(calls.auth.length, 1);
+  assert.equal(calls.api.length, 1);
+  assert.match(calls.api[0].init.headers['Authorization'], /^Bearer /);
+});
+
+test('fetch uses AbortSignal.timeout (not invalid timeoutMs option)', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  _test.clearJwtCache();
+
+  let capturedInit;
+  const calls = mockWithAuth('signal-test-token', (url, init) => {
+    capturedInit = init;
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: async () => JSON.stringify({
+        data: { affected_items: [], total_affected_items: 0 },
+        error: 0,
+      }),
+    };
+  });
+
+  const handler = await loadHandler(listAgentsPath, {}, defaultManagerSecretCtx);
+  await handler();
+
+  // Verify API call uses AbortSignal.timeout, not raw timeoutMs property
+  assert.equal(calls.api.length, 1);
+  assert.ok(capturedInit.signal, 'fetch should have signal property from AbortSignal.timeout()');
+  assert.equal(capturedInit.timeoutMs, undefined, 'fetch should NOT have raw timeoutMs option');
+});


### PR DESCRIPTION
Closes #326

# Wazuh SIEM v4.9 adapter

## Scope

- Standard service package: `services/wazuh__siem`
- Manager API with JWT authentication: `ListAgents`
- Wazuh Indexer/OpenSearch with Basic authentication: `ListAlerts`, `GetAlertSummary`, `ListVulnerabilities`, `GetVulnerabilitySummary`
- Repository package registration, root wrapper, and tentacles dispatcher

## Maintainer hardening

This branch was replayed onto the latest `main` and updated to the current service contract. It now isolates JWT cache entries by endpoint and credential digest, bounds cache and upstream response sizes, supports UTF-8 Basic credentials, requires Indexer credentials, validates pagination and timeouts, refuses redirects, implements both `search` fields, maps upstream errors without leaking response bodies, and supports controlled private-CA TLS opt-out.

All actionable MonkeyScan review threads are resolved. Binary screenshots were removed because the current L2 policy forbids binary evidence in service packages.

## Verification

- 47/47 deterministic tests pass
- Coverage: 98.33% line / 88.30% branch / 93.44% function
- Package validation and `npm pack --dry-run` pass
- Go build passes
- OctoBus Connect, native gRPC, and MCP smoke paths pass
- Remote `service-l2-gate` and `validate` pass

The author previously supplied screenshots from a real Wazuh 4.9.2 deployment in the PR history. They showed Manager JWT `ListAgents`, all four Indexer methods through OctoBus, gRPC reflection, and access/stdout traces. Those binaries are intentionally not part of the mergeable tree; no credential or token value is repeated here.

## Endpoint model

| Config | Component | Authentication | RPCs |
|---|---|---|---|
| `endpoint` | Wazuh Manager API | Basic to JWT, then Bearer | `ListAgents` |
| `indexerEndpoint` | Wazuh Indexer | Basic | alert and vulnerability RPCs |
