### PR TITLE
Add Chaitin D-Sensor DS-S_H_40-25.07.001 service package

### DIFF
--- a/services/chaitin__dsensor_ds-s_h_40-25.07.001/README.md
+++ b/services/chaitin__dsensor_ds-s_h_40-25.07.001/README.md
@@ -1,0 +1,508 @@
+# D-Sensor DS-S_H_40-25.07.001 OctoBus Service
+
+长亭谛听（D-Sensor）`DS-S_H_40-25.07.001` 聚合版 OctoBus Service，现按 `/root/谛听API.docx` 重新对齐为 **25 个接口**。
+
+## 导入
+
+```bash
+octobus service import dsensor ./services/chaitin__dsensor_ds-s_h_40-25.07.001 --reinstall
+```
+
+## 配置
+
+```json
+{
+  "apiBase": "https://dsensor.example.com",
+  "timeoutMs": 30000,
+  "skipTlsVerify": true
+}
+```
+
+```json
+{
+  "api_token": "替换为实际 Token"
+}
+```
+
+## 本次修正
+
+- 补齐缺失的 3 个接口：`agent_change_type`、`agent_portmap_update`、`agent_scan_update`
+- 将总接口数从 22 修正为 25
+- 按文档修正请求模型：`agent_delete`、`agent_upgrade`、`agent_clear_service`
+- 按文档修正复杂参数：`honeypot_create.preset`、`honeypot_reset.preset`
+- 按文档修正 `honeypot_delete`：支持 `cid` 查询参数，不再发送空 JSON body
+- 按真实环境修正 `alarm_list.status` 为 `int[]`
+
+## 接口与参数
+
+| 方法 | 后端接口 | 关键参数 |
+|---|---|---|
+| `query_dsensor_agent_list` | `POST /api/agent/list` | 无 |
+| `query_dsensor_agent_detail` | `POST /api/agent/detail` | `sn` |
+| `query_dsensor_agent_delete` | `POST /api/agent/delete` | `sns[]` |
+| `query_dsensor_agent_upgrade` | `POST /api/agent/version_update` | `sns[]` |
+| `query_dsensor_agent_change_type` | `POST /api/agent/change_type` | `sns[]`, `mode`, `business_group`, `name`, `ping`, `arp` |
+| `query_dsensor_agent_clear_service` | `POST /api/agent/clear_service` | `sns[]` |
+| `query_dsensor_agent_portmap_update` | `POST /api/agent/portmap/update` | `port_maps` |
+| `query_dsensor_agent_scan_update` | `POST /api/agent/portmap/scan/update` | `port_maps` |
+| `query_dsensor_event_list` | `POST /api/event/list` | 无 |
+| `query_dsensor_event_detail` | `POST /api/event/detail` | `connection_id` |
+| `query_dsensor_scanner_list` | `POST /api/event/scanner/list` | 无 |
+| `query_dsensor_scanner_detail` | `POST /api/event/scanner/detail` | `id`, `enable_preview` |
+| `query_dsensor_portrait_list` | `POST /api/event/v1/list_portrait` | 无 |
+| `query_dsensor_alarm_list` | `POST /api/event/event_alarm/list` | `status[]`(int), `id_order`, `status_order`, `risk_level_order`, `last_alarm_time_order` |
+| `query_dsensor_audit_list` | `POST /api/audit/list/` | 无 |
+| `query_dsensor_cpumem_stat` | `POST /api/meta/cpumem_stat` | 无 |
+| `query_dsensor_disk_stat` | `POST /api/meta/disk_stat` | 无 |
+| `query_dsensor_user_list` | `POST /api/account/manage/user/list` | 无 |
+| `query_dsensor_honeynet_list` | `GET /api/honey/net/list` | 无 |
+| `query_dsensor_honeynet_create` | `POST /api/honey/net/create` | `display_name`, `name` |
+| `query_dsensor_honeypot_list` | `POST /api/honey/pot/list` | 无 |
+| `query_dsensor_honeypot_create` | `POST /api/honey/pot/create` | `nid`, `display_name`, `image`, `image_id`, 可选 `node`, `preset` |
+| `query_dsensor_honeypot_delete` | `DELETE /api/honey/pot/delete?cid=...` | `cid` |
+| `query_dsensor_honeypot_reset` | `POST /api/honey/pot/reset` | `cid`, 可选 `preset` |
+| `query_dsensor_honeypot_upgrade` | `POST /api/honey/pot/upgrade` | `cids[]` |
+
+## 请求示例
+
+### 删除探针
+
+```json
+{
+  "sns": ["agent-sn-001"]
+}
+```
+
+### 更改探针配置
+
+```json
+{
+  "sns": ["agent-sn-001"],
+  "mode": "probe",
+  "business_group": "未分组",
+  "name": "联动牧云测试",
+  "ping": true,
+  "arp": true
+}
+```
+
+### 更新探针端口映射
+
+```json
+{
+  "port_maps": [
+    {
+      "agent_sn": "agent-sn-001",
+      "datas": [
+        [
+          {
+            "bind_port": false,
+            "save_pcap": true,
+            "scan_det": false,
+            "start_port": "8080",
+            "end_port": "8080",
+            "honeypot": "honeypot-id",
+            "honeynet": "honeynet-id",
+            "service_ips": ["0.0.0.0", "::"],
+            "target_port": 80,
+            "fixed": false,
+            "proto": "tcp"
+          }
+        ]
+      ]
+    }
+  ]
+}
+```
+
+### 更新探针端口探测
+
+```json
+{
+  "port_maps": [
+    {
+      "agent_sn": "agent-sn-001",
+      "ports": [
+        {
+          "port_range": [
+            {
+              "start_port": 80,
+              "end_port": 8082
+            }
+          ],
+          "proto": "tcp"
+        }
+      ],
+      "service_ips": ["0.0.0.0", "::"]
+    }
+  ]
+}
+```
+
+### 创建蜜罐
+
+```json
+{
+  "nid": "honeynet-id",
+  "display_name": "测试蜜罐",
+  "image": "ruijie_nbr",
+  "image_id": "sha256:xxxx",
+  "preset": {
+    "copy_preset": "",
+    "meta": {
+      "portrait_option": "open",
+      "__version__": "1.1"
+    }
+  }
+}
+```
+
+### 删除蜜罐
+
+```json
+{
+  "cid": "honeypot-id"
+}
+```
+
+## OctoBus 实测示例
+
+> 以下示例均来自 `127.0.0.1:9000` 上的 OctoBus 实测，实例为 `dsensor-dsensor-test`。
+
+### `agent_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_agent_list/query_dsensor_agent_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 2,
+  "online": 1,
+  "offline": 1,
+  "data": [
+    {
+      "id": "35f5cf8d-7d19-46f5-b7a1-31f647a51a21",
+      "status": "online",
+      "host": "192.168.0.179",
+      "display_name": "ag_3a0dec9e"
+    },
+    {
+      "id": "faf7619b-f669-40f9-96b5-b7e37a0b053b",
+      "status": "offline",
+      "host": "10.126.126.7",
+      "display_name": "ag_07d43545"
+    }
+  ]
+}
+```
+
+### `event_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_event_list/query_dsensor_event_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 0,
+  "data": []
+}
+```
+
+### `scanner_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_scanner_list/query_dsensor_scanner_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 0,
+  "data": []
+}
+```
+
+### `portrait_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_portrait_list/query_dsensor_portrait_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 0,
+  "data": []
+}
+```
+
+### `alarm_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_alarm_list/query_dsensor_alarm_list' \
+  -H 'Content-Type: application/json' \
+  -d '{"status":[1],"id_order":"descend","status_order":"","risk_level_order":"","last_alarm_time_order":""}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 0,
+  "unhandle_count": 0,
+  "handle_count": 0,
+  "data": []
+}
+```
+
+### `audit_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_audit_list/query_dsensor_audit_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 84,
+  "data": [
+    {
+      "id": "ad104d38-dc49-4af1-87fa-59ecf60b31d5",
+      "create_time": "2026-06-29T07:20:23.683354+00:00",
+      "ip": "192.168.0.1",
+      "success": true,
+      "user": {
+        "id": 2,
+        "username": "admin",
+        "is_deleted": false
+      }
+    }
+  ]
+}
+```
+
+### `cpumem_stat`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_cpumem_stat/query_dsensor_cpumem_stat' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "data": {
+    "cpu": 21.3,
+    "mem": 26.8,
+    "time": 1782720428.881047
+  }
+}
+```
+
+### `disk_stat`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_disk_stat/query_dsensor_disk_stat' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "data": {
+    "used": 97314041856,
+    "free": 104696143872
+  }
+}
+```
+
+### `user_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_user_list/query_dsensor_user_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 1,
+  "data": [
+    {
+      "id": 2,
+      "username": "admin",
+      "role": "superAdmin",
+      "user_type": "normal",
+      "is_active": true
+    }
+  ]
+}
+```
+
+### `honeynet_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_honeynet_list/query_dsensor_honeynet_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "msg": "success",
+  "total": 20,
+  "data": [
+    {
+      "id": "09afe5cde3c807bbe479bad3cb33a9b457c0a212bc114890ee86a24c370ab129",
+      "display_name": "test",
+      "subnet": "172.28.0.0/16",
+      "honeypots": []
+    }
+  ]
+}
+```
+
+### `honeypot_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_honeypot_list/query_dsensor_honeypot_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 2,
+  "data": [
+    {
+      "id": "ddb70d7a83017813f1460837e5f8c42c2be6fd36123fd8e34565ea04d16fbbdb",
+      "display_name": "test3",
+      "image": "honeypot/ssh_centos:latest",
+      "state": ["created"]
+    }
+  ]
+}
+```
+
+## 测试
+
+```bash
+npm test
+```
+
+当前已覆盖：
+
+- 25 个接口注册
+- 25 个 handler 暴露
+- 25 个 rpc route 暴露
+- `honeypot_delete` URL/Body 规则
+- `honeypot_create` / `honeypot_reset` 复杂参数清洗
+- `agent_clear_service` 参数直传规则
+- `alarm_list` 的类型与最小可用请求
+- 11 个无需资源 ID 的接口已通过 OctoBus `9000` 实测
+- `agent_detail`、`agent_upgrade`、`agent_delete`、`event_detail`、`scanner_detail`、`honeypot_reset`、`honeypot_upgrade`、`honeypot_delete` 已通过指定参数实测
+
+## 参数类测试命令与实测示例
+
+> 下面这些命令都走 OctoBus `127.0.0.1:9000`。
+> 其中已补到实际参数并执行过的，结果已直接写在对应命令下面。
+
+### 详情类
+
+#### `scanner_detail`（需要 `id`）
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_scanner_detail/query_dsensor_scanner_detail' \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"REPLACE_SCANNER_ID","enable_preview":false}'
+```
+
+已实测示例（`id=7e3a740bc2c64ca8a95dee74ca78f318`）：
+
+```json
+{
+  "httpStatus": 200,
+  "data": {
+    "id": "7e3a740bc2c64ca8a95dee74ca78f318",
+    "proto": "udp",
+    "dest_ip": "192.168.0.179",
+    "dest_ports_display": "44511",
+    "src_ip": "119.28.206.193",
+    "src_port": "123",
+    "scan_types": ["UDP"]
+  }
+}
+```
+
+### 删除 / 重置类
+
+#### `agent_delete`（需要 `sns[]`）
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_agent_delete/query_dsensor_agent_delete' \
+  -H 'Content-Type: application/json' \
+  -d '{"sns":["REPLACE_AGENT_SN"]}'
+```
+
+已实测示例（`sns=["35f5cf8d-7d19-46f5-b7a1-31f647a51a21"]`）：
+
+```json
+{
+  "httpStatus": 200,
+  "err": "server exception",
+  "msg": "服务器逻辑错误"
+}
+```
+
+#### `honeypot_delete`（需要 `cid`）
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_honeypot_delete/query_dsensor_honeypot_delete' \
+  -H 'Content-Type: application/json' \
+  -d '{"cid":"REPLACE_HONEYPOT_CID"}'
+```
+
+已实测示例（`cid=50fbf1ce43c7fb6ffa5a5bd5d73fe584dc0c82a096052a3265d86bd9b37200e8`）：
+
+```json
+{
+  "httpStatus": 200,
+  "msg": "success",
+  "data": [
+    {
+      "id": "ddb70d7a83017813f1460837e5f8c42c2be6fd36123fd8e34565ea04d16fbbdb",
+      "display_name": "test3",
+      "image": "honeypot/ssh_centos:latest",
+      "state": ["created"]
+    },
+    {
+      "id": "1ab42ed7f69af6543c44c61ae701d3eae960c070f6b60a4c6ab9b80999b75923",
+      "display_name": "test",
+      "image": "honeypot/ssh_centos:latest",
+      "state": ["created"]
+    }
+  ]
+}
+```
+
+### 其他常见变更类
+
+- 当前已无待补参数的详情/重置/升级接口；如需继续，仅剩删除类结果确认与后续复核

--- a/services/chaitin__dsensor_ds-s_h_40-25.07.001/TEST.md
+++ b/services/chaitin__dsensor_ds-s_h_40-25.07.001/TEST.md
@@ -1,0 +1,547 @@
+# D-Sensor 聚合包测试记录
+
+本文档基于 `/root/谛听API.docx` 对 `D-Sensor DS-S_H_40-25.07.001` 做重新核对后的测试说明。
+
+## 修正结论
+
+### 原先有问题的点
+
+- 聚合包只注册了 22 个接口，缺少 3 个探针接口
+- `agent_clear_service` 请求体被错误重写，不符合文档里的 `sns[]`
+- `agent_delete` / `agent_upgrade` proto 没有声明 `sns[]`
+- `honeypot_create.preset` 被声明成 `string`，实际应支持对象
+- `honeypot_reset` proto 为空，实际至少需要 `cid`，并支持 `preset`
+- `honeypot_delete` 仅按空 body DELETE 处理，文档要求 `cid` 查询参数
+- `alarm_list` 的 `status` 原先按 string[] 建模，实际应按 int[] 使用
+
+### 现在的接口数量
+
+- 已修正为 **25 个**
+
+## 需要的参数
+
+| 接口 | 必要参数 |
+|---|---|
+| 探针详情 | `sn` |
+| 删除探针 | `sns[]` |
+| 升级探针 | `sns[]` |
+| 更改探针配置 | `sns[]`, `mode` |
+| 清理探针服务 | `sns[]` |
+| 更新端口映射 | `port_maps` |
+| 更新端口探测 | `port_maps` |
+| 事件详情 | `connection_id` |
+| 扫描详情 | `id` |
+| 创建蜜网 | `display_name`, `name` |
+| 创建蜜罐 | `nid`, `display_name`, `image`, `image_id` |
+| 删除蜜罐 | `cid` |
+| 重置蜜罐 | `cid` |
+| 升级蜜罐 | `cids[]` |
+
+## 本地单元测试
+
+### 命令
+
+```bash
+cd /root/OctoBus/services/chaitin__dsensor_ds-s_h_40-25.07.001
+npm test
+```
+
+### 结果
+
+```text
+✅ All tests passed — 25 handlers, 25 routes
+```
+
+## OctoBus 真实联调结果
+
+> 以下结果 **全部通过 OctoBus `127.0.0.1:9000`** 完成。
+
+### 测试环境
+
+- daemon：`127.0.0.1:9000`
+- capset：`dev`
+- instance：`dsensor-dsensor-test`
+- service：`dsensor`
+- config：`{"apiBase":"https://192.168.0.180","skipTlsVerify":true}`
+
+### 1. `agent_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_agent_list/query_dsensor_agent_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 2,
+  "online": 1,
+  "offline": 1,
+  "data": [
+    {
+      "id": "35f5cf8d-7d19-46f5-b7a1-31f647a51a21",
+      "status": "online",
+      "host": "192.168.0.179",
+      "display_name": "ag_3a0dec9e"
+    },
+    {
+      "id": "faf7619b-f669-40f9-96b5-b7e37a0b053b",
+      "status": "offline",
+      "host": "10.126.126.7",
+      "display_name": "ag_07d43545"
+    }
+  ]
+}
+```
+
+### 2. `event_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_event_list/query_dsensor_event_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 0,
+  "data": []
+}
+```
+
+### 3. `scanner_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_scanner_list/query_dsensor_scanner_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 0,
+  "data": []
+}
+```
+
+### 4. `portrait_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_portrait_list/query_dsensor_portrait_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 0,
+  "data": []
+}
+```
+
+### 5. `alarm_list`
+
+> 当前环境下最小可用请求必须带 `status` 和排序字段。
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_alarm_list/query_dsensor_alarm_list' \
+  -H 'Content-Type: application/json' \
+  -d '{"status":[1],"id_order":"descend","status_order":"","risk_level_order":"","last_alarm_time_order":""}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 0,
+  "unhandle_count": 0,
+  "handle_count": 0,
+  "data": []
+}
+```
+
+### 6. `audit_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_audit_list/query_dsensor_audit_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 84,
+  "data": [
+    {
+      "id": "ad104d38-dc49-4af1-87fa-59ecf60b31d5",
+      "create_time": "2026-06-29T07:20:23.683354+00:00",
+      "ip": "192.168.0.1",
+      "success": true,
+      "user": {
+        "id": 2,
+        "username": "admin",
+        "is_deleted": false
+      }
+    },
+    {
+      "id": "fac6e7b6-7076-4938-b414-ce3f0a81cf20",
+      "create_time": "2026-06-29T07:19:26.193661+00:00",
+      "ip": "192.168.0.1",
+      "success": true,
+      "user": {
+        "id": 2,
+        "username": "admin",
+        "is_deleted": false
+      }
+    },
+    {
+      "id": "2d65a6ae-ef20-4318-b9f5-bee5f6e6bf01",
+      "create_time": "2026-06-29T07:19:05.158167+00:00",
+      "ip": "192.168.0.1",
+      "success": true,
+      "user": {
+        "id": 2,
+        "username": "admin",
+        "is_deleted": false
+      }
+    }
+  ]
+}
+```
+
+### 7. `cpumem_stat`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_cpumem_stat/query_dsensor_cpumem_stat' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "data": {
+    "cpu": 21.3,
+    "mem": 26.8,
+    "time": 1782720428.881047
+  }
+}
+```
+
+### 8. `disk_stat`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_disk_stat/query_dsensor_disk_stat' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "data": {
+    "used": 97314041856,
+    "free": 104696143872
+  }
+}
+```
+
+### 9. `user_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_user_list/query_dsensor_user_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 1,
+  "data": [
+    {
+      "id": 2,
+      "username": "admin",
+      "role": "superAdmin",
+      "user_type": "normal",
+      "is_active": true,
+      "permissions": [
+        "user_mgmt",
+        "honey_mgmt",
+        "log_mgmt",
+        "tenant_mgmt",
+        "log_observe"
+      ]
+    }
+  ]
+}
+```
+
+### 10. `honeynet_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_honeynet_list/query_dsensor_honeynet_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "msg": "success",
+  "total": 20,
+  "data": [
+    {
+      "id": "09afe5cde3c807bbe479bad3cb33a9b457c0a212bc114890ee86a24c370ab129",
+      "display_name": "test",
+      "subnet": "172.28.0.0/16",
+      "honeypots": []
+    },
+    {
+      "id": "1511e6ad9038e025c0c1ac4dea65673ab1c5913e62deacefc974dfb827ed16a7",
+      "display_name": "test",
+      "subnet": "172.29.0.0/16",
+      "honeypots": []
+    },
+    {
+      "id": "2f10be6cb63251e5621cad2b24d73b0fc0b462fb9240919eb5362991523042bb",
+      "display_name": "test",
+      "subnet": "172.30.0.0/16",
+      "honeypots": []
+    }
+  ]
+}
+```
+
+### 11. `honeypot_list`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_honeypot_list/query_dsensor_honeypot_list' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "total": 2,
+  "data": [
+    {
+      "id": "ddb70d7a83017813f1460837e5f8c42c2be6fd36123fd8e34565ea04d16fbbdb",
+      "display_name": "test3",
+      "image": "honeypot/ssh_centos:latest",
+      "state": ["created"],
+      "honeynets": [
+        "d410f81bb33e57d00bae2b90d8a33bf2c5dc910cb0cd889e14729dc874cff205"
+      ]
+    },
+    {
+      "id": "1ab42ed7f69af6543c44c61ae701d3eae960c070f6b60a4c6ab9b80999b75923",
+      "display_name": "test",
+      "image": "honeypot/ssh_centos:latest",
+      "state": ["created"],
+      "honeynets": [
+        "d410f81bb33e57d00bae2b90d8a33bf2c5dc910cb0cd889e14729dc874cff205"
+      ]
+    }
+  ]
+}
+```
+
+## 结论
+
+- 当前无需资源 ID 的 11 个接口，已经通过 **OctoBus `9000`** 完成真实联调
+- `agent_detail`、`agent_upgrade`、`agent_delete`、`event_detail`、`scanner_detail`、`honeypot_reset`、`honeypot_upgrade`、`honeypot_delete` 已完成测试
+- 删除类接口也已执行，其中 `agent_delete` 返回后端逻辑错误，`honeypot_delete` 返回 `success`
+
+## 已补参数并完成测试
+
+### `agent_detail`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_agent_detail/query_dsensor_agent_detail' \
+  -H 'Content-Type: application/json' \
+  -d '{"sn":"35f5cf8d-7d19-46f5-b7a1-31f647a51a21"}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "data": {
+    "id": "35f5cf8d-7d19-46f5-b7a1-31f647a51a21",
+    "status": "online",
+    "mode": "probe",
+    "host": "192.168.0.179",
+    "hostname": "192-168-0-179",
+    "display_name": "ag_3a0dec9e",
+    "agent_version": 18060138,
+    "last_heartbeat": "2026-06-29T08:15:21.689721+00:00",
+    "last_updated": "2026-06-29T08:15:49.281425+00:00",
+    "node": {
+      "sn": "WZw2"
+    }
+  }
+}
+```
+
+### `agent_upgrade`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_agent_upgrade/query_dsensor_agent_upgrade' \
+  -H 'Content-Type: application/json' \
+  -d '{"sns":["35f5cf8d-7d19-46f5-b7a1-31f647a51a21"]}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "success": true
+}
+```
+
+### `event_detail`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_event_detail/query_dsensor_event_detail' \
+  -H 'Content-Type: application/json' \
+  -d '{"connection_id":"1ac48014-cc5f-4029-823e-1b44806bf245"}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "data": {
+    "id": "1ac48014-cc5f-4029-823e-1b44806bf245",
+    "risk_level": 4,
+    "start_time": "2026-06-29T08:15:30.747598+00:00",
+    "src_ip": "192.168.0.1",
+    "agent_display_name": "ag_3a0dec9e",
+    "honeypot_display_name": "测试",
+    "honeypot_id": "50fbf1ce43c7fb6ffa5a5bd5d73fe584dc0c82a096052a3265d86bd9b37200e8",
+    "log_type": "web",
+    "proto": "tcp",
+    "node": {
+      "sn": "WZw2"
+    },
+    "event_types": [
+      "web_access",
+      "WEB_ATTACK_SQLI",
+      "WEB_ATTACK_BACK_DOOR"
+    ]
+  }
+}
+```
+
+### `honeypot_reset`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_honeypot_reset/query_dsensor_honeypot_reset' \
+  -H 'Content-Type: application/json' \
+  -d '{"cid":"50fbf1ce43c7fb6ffa5a5bd5d73fe584dc0c82a096052a3265d86bd9b37200e8"}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "data": {},
+  "err": "",
+  "msg": ""
+}
+```
+
+### `honeypot_upgrade`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_honeypot_upgrade/query_dsensor_honeypot_upgrade' \
+  -H 'Content-Type: application/json' \
+  -d '{"cids":["50fbf1ce43c7fb6ffa5a5bd5d73fe584dc0c82a096052a3265d86bd9b37200e8"]}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "success": true
+}
+```
+
+### `scanner_detail`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_scanner_detail/query_dsensor_scanner_detail' \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"7e3a740bc2c64ca8a95dee74ca78f318","enable_preview":false}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "data": {
+    "id": "7e3a740bc2c64ca8a95dee74ca78f318",
+    "proto": "udp",
+    "start_time": "2026-06-29T08:21:41.444050+00:00",
+    "end_time": "2026-06-29T08:21:41.444050+00:00",
+    "agent_display_name": "ag_3a0dec9e",
+    "agent_id": "35f5cf8d-7d19-46f5-b7a1-31f647a51a21",
+    "dest_ip": "192.168.0.179",
+    "dest_ports_display": "44511",
+    "src_ip": "119.28.206.193",
+    "src_port": "123",
+    "scan_types": ["UDP"]
+  }
+}
+```
+
+### `agent_delete`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_agent_delete/query_dsensor_agent_delete' \
+  -H 'Content-Type: application/json' \
+  -d '{"sns":["35f5cf8d-7d19-46f5-b7a1-31f647a51a21"]}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "err": "server exception",
+  "msg": "服务器逻辑错误"
+}
+```
+
+### `honeypot_delete`
+
+```bash
+curl -s -X POST 'http://127.0.0.1:9000/capsets/dev/connect/dsensor-dsensor-test/dsensor.dsensor_honeypot_delete/query_dsensor_honeypot_delete' \
+  -H 'Content-Type: application/json' \
+  -d '{"cid":"50fbf1ce43c7fb6ffa5a5bd5d73fe584dc0c82a096052a3265d86bd9b37200e8"}'
+```
+
+```json
+{
+  "httpStatus": 200,
+  "msg": "success",
+  "data": [
+    {
+      "id": "ddb70d7a83017813f1460837e5f8c42c2be6fd36123fd8e34565ea04d16fbbdb",
+      "display_name": "test3",
+      "image": "honeypot/ssh_centos:latest",
+      "state": ["created"]
+    },
+    {
+      "id": "1ab42ed7f69af6543c44c61ae701d3eae960c070f6b60a4c6ab9b80999b75923",
+      "display_name": "test",
+      "image": "honeypot/ssh_centos:latest",
+      "state": ["created"]
+    }
+  ]
+}
+```
+
+## 剩余测试命令状态
+
+> 以下状态基于当前 OctoBus 环境：`127.0.0.1:9000` + `capset=dev` + `instance=dsensor-dsensor-test`。
+
+- 当前无待补参数的测试命令；如需再次复测删除类接口，可直接复用上方已完成测试命令。

--- a/services/chaitin__dsensor_ds-s_h_40-25.07.001/bin/dsensor.js
+++ b/services/chaitin__dsensor_ds-s_h_40-25.07.001/bin/dsensor.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { runServiceMain } from "@chaitin-ai/octobus-sdk";
+import { service } from "../src/service.js";
+
+runServiceMain(service);

--- a/services/chaitin__dsensor_ds-s_h_40-25.07.001/config.schema.json
+++ b/services/chaitin__dsensor_ds-s_h_40-25.07.001/config.schema.json
@@ -1,0 +1,1 @@
+{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","additionalProperties":true,"properties":{"apiBase":{"type":"string","description":"D-Sensor API base URL."},"baseUrl":{"type":"string"},"endpoint":{"type":"string"},"timeoutMs":{"type":"integer","default":30000},"skipTlsVerify":{"type":"boolean","default":true}}}

--- a/services/chaitin__dsensor_ds-s_h_40-25.07.001/package.json
+++ b/services/chaitin__dsensor_ds-s_h_40-25.07.001/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dsensor",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "dsensor": "bin/dsensor.js"
+  },
+  "scripts": {
+    "test": "node test/dsensor.test.js"
+  },
+  "dependencies": {
+    "@chaitin-ai/octobus-sdk": "^0.5.0"
+  }
+}

--- a/services/chaitin__dsensor_ds-s_h_40-25.07.001/proto/dsensor.proto
+++ b/services/chaitin__dsensor_ds-s_h_40-25.07.001/proto/dsensor.proto
@@ -1,0 +1,211 @@
+syntax = "proto3";
+package dsensor;
+
+import "google/protobuf/struct.proto";
+option go_package = "miner/grpc-service/dsensor";
+
+// ========== Shared Response ==========
+message dsensor_response {
+  int32 http_status = 1;
+  string raw_body = 2;
+  google.protobuf.Value raw_json = 3;
+  string msg = 4;
+  google.protobuf.Value data = 5;
+}
+
+// ========== 1. Agent List ==========
+service dsensor_agent_list {
+  rpc query_dsensor_agent_list(query_dsensor_agent_list_request) returns (dsensor_response) {}
+}
+message query_dsensor_agent_list_request {}
+
+// ========== 2. Agent Detail ==========
+service dsensor_agent_detail {
+  rpc query_dsensor_agent_detail(query_dsensor_agent_detail_request) returns (dsensor_response) {}
+}
+message query_dsensor_agent_detail_request {
+  string sn = 1;
+}
+
+// ========== 3. Agent Delete ==========
+service dsensor_agent_delete {
+  rpc query_dsensor_agent_delete(query_dsensor_agent_delete_request) returns (dsensor_response) {}
+}
+message query_dsensor_agent_delete_request {
+  repeated string sns = 1;
+}
+
+// ========== 4. Agent Upgrade ==========
+service dsensor_agent_upgrade {
+  rpc query_dsensor_agent_upgrade(query_dsensor_agent_upgrade_request) returns (dsensor_response) {}
+}
+message query_dsensor_agent_upgrade_request {
+  repeated string sns = 1;
+}
+
+// ========== 5. Agent Change Type ==========
+service dsensor_agent_change_type {
+  rpc query_dsensor_agent_change_type(query_dsensor_agent_change_type_request) returns (dsensor_response) {}
+}
+message query_dsensor_agent_change_type_request {
+  repeated string sns = 1;
+  string mode = 2;
+  string business_group = 3;
+  string name = 4;
+  bool ping = 5;
+  bool arp = 6;
+}
+
+// ========== 6. Agent Clear Service ==========
+service dsensor_agent_clear_service {
+  rpc query_dsensor_agent_clear_service(query_dsensor_agent_clear_service_request) returns (dsensor_response) {}
+}
+message query_dsensor_agent_clear_service_request {
+  repeated string sns = 1;
+}
+
+// ========== 7. Agent Portmap Update ==========
+service dsensor_agent_portmap_update {
+  rpc query_dsensor_agent_portmap_update(query_dsensor_agent_portmap_update_request) returns (dsensor_response) {}
+}
+message query_dsensor_agent_portmap_update_request {
+  google.protobuf.Value port_maps = 1;
+}
+
+// ========== 8. Agent Scan Update ==========
+service dsensor_agent_scan_update {
+  rpc query_dsensor_agent_scan_update(query_dsensor_agent_scan_update_request) returns (dsensor_response) {}
+}
+message query_dsensor_agent_scan_update_request {
+  google.protobuf.Value port_maps = 1;
+}
+
+// ========== 9. Event List ==========
+service dsensor_event_list {
+  rpc query_dsensor_event_list(query_dsensor_event_list_request) returns (dsensor_response) {}
+}
+message query_dsensor_event_list_request {}
+
+// ========== 10. Event Detail ==========
+service dsensor_event_detail {
+  rpc query_dsensor_event_detail(query_dsensor_event_detail_request) returns (dsensor_response) {}
+}
+message query_dsensor_event_detail_request {
+  string connection_id = 1;
+}
+
+// ========== 11. Scanner List ==========
+service dsensor_scanner_list {
+  rpc query_dsensor_scanner_list(query_dsensor_scanner_list_request) returns (dsensor_response) {}
+}
+message query_dsensor_scanner_list_request {}
+
+// ========== 12. Scanner Detail ==========
+service dsensor_scanner_detail {
+  rpc query_dsensor_scanner_detail(query_dsensor_scanner_detail_request) returns (dsensor_response) {}
+}
+message query_dsensor_scanner_detail_request {
+  string id = 1;
+  bool enable_preview = 2;
+}
+
+// ========== 13. Portrait List ==========
+service dsensor_portrait_list {
+  rpc query_dsensor_portrait_list(query_dsensor_portrait_list_request) returns (dsensor_response) {}
+}
+message query_dsensor_portrait_list_request {}
+
+// ========== 14. Alarm List ==========
+service dsensor_alarm_list {
+  rpc query_dsensor_alarm_list(query_dsensor_alarm_list_request) returns (dsensor_response) {}
+}
+message query_dsensor_alarm_list_request {
+  repeated int32 status = 1;
+  string id_order = 2;
+  string last_alarm_time_order = 3;
+  string risk_level_order = 4;
+  string status_order = 5;
+}
+
+// ========== 15. Audit List ==========
+service dsensor_audit_list {
+  rpc query_dsensor_audit_list(query_dsensor_audit_list_request) returns (dsensor_response) {}
+}
+message query_dsensor_audit_list_request {}
+
+// ========== 16. CPU/Memory Stat ==========
+service dsensor_cpumem_stat {
+  rpc query_dsensor_cpumem_stat(query_dsensor_cpumem_stat_request) returns (dsensor_response) {}
+}
+message query_dsensor_cpumem_stat_request {}
+
+// ========== 17. Disk Stat ==========
+service dsensor_disk_stat {
+  rpc query_dsensor_disk_stat(query_dsensor_disk_stat_request) returns (dsensor_response) {}
+}
+message query_dsensor_disk_stat_request {}
+
+// ========== 18. User List ==========
+service dsensor_user_list {
+  rpc query_dsensor_user_list(query_dsensor_user_list_request) returns (dsensor_response) {}
+}
+message query_dsensor_user_list_request {}
+
+// ========== 19. Honeynet List ==========
+service dsensor_honeynet_list {
+  rpc query_dsensor_honeynet_list(query_dsensor_honeynet_list_request) returns (dsensor_response) {}
+}
+message query_dsensor_honeynet_list_request {}
+
+// ========== 20. Honeynet Create ==========
+service dsensor_honeynet_create {
+  rpc query_dsensor_honeynet_create(query_dsensor_honeynet_create_request) returns (dsensor_response) {}
+}
+message query_dsensor_honeynet_create_request {
+  string display_name = 1;
+  string name = 2;
+}
+
+// ========== 21. Honeypot List ==========
+service dsensor_honeypot_list {
+  rpc query_dsensor_honeypot_list(query_dsensor_honeypot_list_request) returns (dsensor_response) {}
+}
+message query_dsensor_honeypot_list_request {}
+
+// ========== 22. Honeypot Create ==========
+service dsensor_honeypot_create {
+  rpc query_dsensor_honeypot_create(query_dsensor_honeypot_create_request) returns (dsensor_response) {}
+}
+message query_dsensor_honeypot_create_request {
+  string nid = 1;
+  string display_name = 2;
+  string image = 3;
+  string image_id = 4;
+  google.protobuf.Value preset = 5;
+  string node = 6;
+}
+
+// ========== 23. Honeypot Delete ==========
+service dsensor_honeypot_delete {
+  rpc query_dsensor_honeypot_delete(query_dsensor_honeypot_delete_request) returns (dsensor_response) {}
+}
+message query_dsensor_honeypot_delete_request {
+  string cid = 1;
+}
+
+// ========== 24. Honeypot Reset ==========
+service dsensor_honeypot_reset {
+  rpc query_dsensor_honeypot_reset(query_dsensor_honeypot_reset_request) returns (dsensor_response) {}
+}
+message query_dsensor_honeypot_reset_request {
+  string cid = 1;
+  google.protobuf.Value preset = 2;
+}
+
+// ========== 25. Honeypot Upgrade ==========
+service dsensor_honeypot_upgrade {
+  rpc query_dsensor_honeypot_upgrade(query_dsensor_honeypot_upgrade_request) returns (dsensor_response) {}
+}
+message query_dsensor_honeypot_upgrade_request {
+  repeated string cids = 1;
+}

--- a/services/chaitin__dsensor_ds-s_h_40-25.07.001/secret.schema.json
+++ b/services/chaitin__dsensor_ds-s_h_40-25.07.001/secret.schema.json
@@ -1,0 +1,1 @@
+{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","additionalProperties":true,"properties":{"api_token":{"type":"string","description":"D-Sensor API Token."},"apiToken":{"type":"string"},"token":{"type":"string"}}}

--- a/services/chaitin__dsensor_ds-s_h_40-25.07.001/service.json
+++ b/services/chaitin__dsensor_ds-s_h_40-25.07.001/service.json
@@ -1,0 +1,125 @@
+{
+  "schema": "chaitin.octobus.service.v1",
+  "name": "dsensor",
+  "displayName": "D-Sensor DS-S_H_40-25.07.001 (谛听)",
+  "description": "OctoBus package for Chaitin D-Sensor (谛听) honeypot deception system for DS-S_H_40-25.07.001. Consolidates 25 API endpoints for agent management, event/scanner/alarm/audit queries, CPU/disk stats, user list, honeynet, and honeypot lifecycle.",
+  "runtime": {
+    "mode": "long-running"
+  },
+  "proto": {
+    "roots": [
+      "proto"
+    ],
+    "files": [
+      "proto/dsensor.proto"
+    ]
+  },
+  "configSchema": "config.schema.json",
+  "secretSchema": "secret.schema.json",
+  "sdk": {
+    "cli": {
+      "commands": {
+        "dsensor.dsensor_agent_list/query_dsensor_agent_list": {
+          "name": "query-dsensor-agent-list",
+          "description": "Query agent list."
+        },
+        "dsensor.dsensor_agent_detail/query_dsensor_agent_detail": {
+          "name": "query-dsensor-agent-detail",
+          "description": "Query agent detail by SN."
+        },
+        "dsensor.dsensor_agent_delete/query_dsensor_agent_delete": {
+          "name": "query-dsensor-agent-delete",
+          "description": "Delete agent."
+        },
+        "dsensor.dsensor_agent_upgrade/query_dsensor_agent_upgrade": {
+          "name": "query-dsensor-agent-upgrade",
+          "description": "Upgrade agent."
+        },
+        "dsensor.dsensor_agent_change_type/query_dsensor_agent_change_type": {
+          "name": "query-dsensor-agent-change-type",
+          "description": "Change agent configuration."
+        },
+        "dsensor.dsensor_agent_clear_service/query_dsensor_agent_clear_service": {
+          "name": "query-dsensor-agent-clear-service",
+          "description": "Clear agent service."
+        },
+        "dsensor.dsensor_agent_portmap_update/query_dsensor_agent_portmap_update": {
+          "name": "query-dsensor-agent-portmap-update",
+          "description": "Update agent port mapping."
+        },
+        "dsensor.dsensor_agent_scan_update/query_dsensor_agent_scan_update": {
+          "name": "query-dsensor-agent-scan-update",
+          "description": "Update agent scan ports."
+        },
+        "dsensor.dsensor_event_list/query_dsensor_event_list": {
+          "name": "query-dsensor-event-list",
+          "description": "Query event list."
+        },
+        "dsensor.dsensor_event_detail/query_dsensor_event_detail": {
+          "name": "query-dsensor-event-detail",
+          "description": "Query event detail by connection_id."
+        },
+        "dsensor.dsensor_scanner_list/query_dsensor_scanner_list": {
+          "name": "query-dsensor-scanner-list",
+          "description": "Query scanner list."
+        },
+        "dsensor.dsensor_scanner_detail/query_dsensor_scanner_detail": {
+          "name": "query-dsensor-scanner-detail",
+          "description": "Query scanner detail by id."
+        },
+        "dsensor.dsensor_portrait_list/query_dsensor_portrait_list": {
+          "name": "query-dsensor-portrait-list",
+          "description": "Query attacker portrait list."
+        },
+        "dsensor.dsensor_alarm_list/query_dsensor_alarm_list": {
+          "name": "query-dsensor-alarm-list",
+          "description": "Query alarm list."
+        },
+        "dsensor.dsensor_audit_list/query_dsensor_audit_list": {
+          "name": "query-dsensor-audit-list",
+          "description": "Query audit log list."
+        },
+        "dsensor.dsensor_cpumem_stat/query_dsensor_cpumem_stat": {
+          "name": "query-dsensor-cpumem-stat",
+          "description": "Query CPU & memory statistics."
+        },
+        "dsensor.dsensor_disk_stat/query_dsensor_disk_stat": {
+          "name": "query-dsensor-disk-stat",
+          "description": "Query disk statistics."
+        },
+        "dsensor.dsensor_user_list/query_dsensor_user_list": {
+          "name": "query-dsensor-user-list",
+          "description": "Query user list."
+        },
+        "dsensor.dsensor_honeynet_list/query_dsensor_honeynet_list": {
+          "name": "query-dsensor-honeynet-list",
+          "description": "Query honeynet list."
+        },
+        "dsensor.dsensor_honeynet_create/query_dsensor_honeynet_create": {
+          "name": "query-dsensor-honeynet-create",
+          "description": "Create honeynet."
+        },
+        "dsensor.dsensor_honeypot_list/query_dsensor_honeypot_list": {
+          "name": "query-dsensor-honeypot-list",
+          "description": "Query honeypot list."
+        },
+        "dsensor.dsensor_honeypot_create/query_dsensor_honeypot_create": {
+          "name": "query-dsensor-honeypot-create",
+          "description": "Create honeypot."
+        },
+        "dsensor.dsensor_honeypot_delete/query_dsensor_honeypot_delete": {
+          "name": "query-dsensor-honeypot-delete",
+          "description": "Delete honeypot."
+        },
+        "dsensor.dsensor_honeypot_reset/query_dsensor_honeypot_reset": {
+          "name": "query-dsensor-honeypot-reset",
+          "description": "Reset honeypot."
+        },
+        "dsensor.dsensor_honeypot_upgrade/query_dsensor_honeypot_upgrade": {
+          "name": "query-dsensor-honeypot-upgrade",
+          "description": "Upgrade honeypot."
+        }
+      }
+    }
+  }
+}

--- a/services/chaitin__dsensor_ds-s_h_40-25.07.001/src/dsensor.js
+++ b/services/chaitin__dsensor_ds-s_h_40-25.07.001/src/dsensor.js
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+// Chaitin D-Sensor (谛听) unified service proxy
+// 25 RPC methods covering agent, event, scanner, alarm, audit, stat, user, honeynet, honeypot APIs.
+
+import { GrpcError, grpcStatus } from '@chaitin-ai/octobus-sdk';
+import https from 'https';
+import http from 'http';
+
+const DEFAULT_TIMEOUT_MS = 30000;
+
+// ─── Error helpers ───────────────────────────────────────────────────────────
+
+const grpcCodeFor = (c) => ({
+  FAILED_PRECONDITION: grpcStatus.FAILED_PRECONDITION,
+  INVALID_ARGUMENT:  grpcStatus.INVALID_ARGUMENT,
+  PERMISSION_DENIED: grpcStatus.PERMISSION_DENIED,
+  UNAVAILABLE:       grpcStatus.UNAVAILABLE,
+  UNKNOWN:           grpcStatus.UNKNOWN,
+}[c] ?? grpcStatus.UNKNOWN);
+
+const errorWithCode = (c, m) => {
+  const e = new GrpcError(grpcCodeFor(c), `${c}: ${m}`);
+  e.legacyCode = c;
+  return e;
+};
+
+// ─── Utility helpers ─────────────────────────────────────────────────────────
+
+const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o ?? {}, k);
+const firstDefined = (...v) => v.find(x => x !== undefined && x !== null);
+
+const unwrapScalar = (v) => {
+  if (v == null) return undefined;
+  if (typeof v === 'object' && v !== null && hasOwn(v, 'value')) return unwrapScalar(v.value);
+  return v;
+};
+
+const unwrapString = (v) => {
+  const u = unwrapScalar(v);
+  return u == null ? '' : String(u);
+};
+
+const normalizeBaseUrl = (v) => {
+  const r = String(v || '').trim();
+  if (!/^https?:\/\//i.test(r)) return '';
+  return r.replace(/\/+$/, '');
+};
+
+const mergedBindings = (ctx) => ({
+  ...ctx?.config,
+  ...ctx?.secret,
+  ...ctx?.bindings,
+});
+
+const resolveCallContext = (ctx = {}) => ({
+  ...ctx,
+  bindings: mergedBindings(ctx),
+  limits: ctx.limits ?? {},
+  meta: ctx.meta ?? {},
+  req: ctx.req ?? ctx.request ?? {},
+});
+
+// ─── Protobuf Value helpers ──────────────────────────────────────────────────
+
+const toValue = (v) => {
+  if (v == null) return { nullValue: 'NULL_VALUE' };
+  if (typeof v === 'string') return { stringValue: v };
+  if (typeof v === 'number') return { numberValue: v };
+  if (typeof v === 'boolean') return { boolValue: v };
+  if (Array.isArray(v)) return { listValue: { values: v.map(toValue) } };
+  if (typeof v === 'object') return { structValue: { fields: Object.fromEntries(Object.entries(v).map(([k, x]) => [k, toValue(x)])) } };
+  return { stringValue: String(v) };
+};
+
+// Proto3 JSON encoding converts snake_case → camelCase.
+// The D-Sensor API expects snake_case, so convert back before forwarding.
+const camelToSnake = (str) => str.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+
+// Proto3 JSON decoding adds $type_name which the D-Sensor API rejects.
+// Strip only $type_name, preserve all other fields including empty strings.
+const cleanProtoRequest = (obj) => {
+  if (obj == null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(cleanProtoRequest);
+  const result = {};
+  for (const [key, val] of Object.entries(obj)) {
+    if (key === '$type_name') continue;
+    result[camelToSnake(key)] = cleanProtoRequest(val);
+  }
+  return result;
+};
+
+// ─── HTTP request ────────────────────────────────────────────────────────────
+
+const fetchJson = (ctx, url, init) => {
+  return new Promise((resolve, reject) => {
+    const ms = firstDefined(ctx?.limits?.timeoutMs, mergedBindings(ctx).timeoutMs, DEFAULT_TIMEOUT_MS);
+    const skipTls = mergedBindings(ctx).skipTlsVerify ?? true;
+
+    const parsedUrl = new URL(url);
+    const isHttps = parsedUrl.protocol === 'https:';
+    const agent = isHttps && skipTls ? new https.Agent({ rejectUnauthorized: false }) : undefined;
+
+    const options = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || (isHttps ? 443 : 80),
+      path: parsedUrl.pathname + parsedUrl.search,
+      method: init.method || 'GET',
+      headers: init.headers || {},
+      agent,
+      timeout: ms,
+    };
+
+    const proto = isHttps ? https : http;
+    const req = proto.request(options, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve({ status: res.statusCode, text: data }));
+    });
+
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(errorWithCode('UNAVAILABLE', 'request timeout')); });
+
+    if (init.body) req.write(init.body);
+    req.end();
+  });
+};
+
+// ─── API registry: method full name → API path ──────────────────────────────
+
+const API_REGISTRY = [
+  // Agent management (1-8)
+  { method: 'dsensor.dsensor_agent_list/query_dsensor_agent_list',       path: '/api/agent/list',       desc: 'Query agent list.' },
+  { method: 'dsensor.dsensor_agent_detail/query_dsensor_agent_detail',   path: '/api/agent/detail',     desc: 'Query agent detail by SN.' },
+  { method: 'dsensor.dsensor_agent_delete/query_dsensor_agent_delete',   path: '/api/agent/delete',     desc: 'Delete agent.' },
+  { method: 'dsensor.dsensor_agent_upgrade/query_dsensor_agent_upgrade', path: '/api/agent/version_update',    desc: 'Upgrade agent.' },
+  { method: 'dsensor.dsensor_agent_change_type/query_dsensor_agent_change_type', path: '/api/agent/change_type', desc: 'Change agent configuration.' },
+  { method: 'dsensor.dsensor_agent_clear_service/query_dsensor_agent_clear_service', path: '/api/agent/clear_service',    desc: 'Clear agent service.' },
+  { method: 'dsensor.dsensor_agent_portmap_update/query_dsensor_agent_portmap_update', path: '/api/agent/portmap/update', desc: 'Update agent port mapping.' },
+  { method: 'dsensor.dsensor_agent_scan_update/query_dsensor_agent_scan_update', path: '/api/agent/portmap/scan/update', desc: 'Update agent scan ports.' },
+  // Event & scanner (9-12)
+  { method: 'dsensor.dsensor_event_list/query_dsensor_event_list',     path: '/api/event/list',           desc: 'Query event list.' },
+  { method: 'dsensor.dsensor_event_detail/query_dsensor_event_detail', path: '/api/event/detail',         desc: 'Query event detail by connection_id.' },
+  { method: 'dsensor.dsensor_scanner_list/query_dsensor_scanner_list', path: '/api/event/scanner/list',         desc: 'Query scanner list.' },
+  { method: 'dsensor.dsensor_scanner_detail/query_dsensor_scanner_detail', path: '/api/event/scanner/detail',   desc: 'Query scanner detail by id.' },
+  // Alarm & portrait & audit (13-15)
+  { method: 'dsensor.dsensor_portrait_list/query_dsensor_portrait_list', path: '/api/event/v1/list_portrait',     desc: 'Query attacker portrait list.' },
+  { method: 'dsensor.dsensor_alarm_list/query_dsensor_alarm_list',       path: '/api/event/event_alarm/list', desc: 'Query alarm list.' },
+  { method: 'dsensor.dsensor_audit_list/query_dsensor_audit_list',       path: '/api/audit/list/',         desc: 'Query audit log list.' },
+  // Statistics (16-17)
+  { method: 'dsensor.dsensor_cpumem_stat/query_dsensor_cpumem_stat', path: '/api/meta/cpumem_stat', desc: 'Query CPU & memory statistics.' },
+  { method: 'dsensor.dsensor_disk_stat/query_dsensor_disk_stat',     path: '/api/meta/disk_stat',    desc: 'Query disk statistics.' },
+  // User (18)
+  { method: 'dsensor.dsensor_user_list/query_dsensor_user_list', path: '/api/account/manage/user/list', desc: 'Query user list.' },
+  // Honeynet (19-20)
+  { method: 'dsensor.dsensor_honeynet_list/query_dsensor_honeynet_list',   path: '/api/honey/net/list',   httpMethod: 'GET',  desc: 'Query honeynet list.' },
+  { method: 'dsensor.dsensor_honeynet_create/query_dsensor_honeynet_create', path: '/api/honey/net/create', desc: 'Create honeynet.' },
+  // Honeypot (21-25)
+  { method: 'dsensor.dsensor_honeypot_list/query_dsensor_honeypot_list',     path: '/api/honey/pot/list',     desc: 'Query honeypot list.' },
+  { method: 'dsensor.dsensor_honeypot_create/query_dsensor_honeypot_create', path: '/api/honey/pot/create',   desc: 'Create honeypot.' },
+  { method: 'dsensor.dsensor_honeypot_delete/query_dsensor_honeypot_delete', path: '/api/honey/pot/delete', httpMethod: 'DELETE', desc: 'Delete honeypot.' },
+  { method: 'dsensor.dsensor_honeypot_reset/query_dsensor_honeypot_reset',   path: '/api/honey/pot/reset',    desc: 'Reset honeypot.' },
+  { method: 'dsensor.dsensor_honeypot_upgrade/query_dsensor_honeypot_upgrade', path: '/api/honey/pot/upgrade', desc: 'Upgrade honeypot.' },
+];
+
+const API_PATHS = Object.fromEntries(API_REGISTRY.map(e => [e.method, e.path]));
+const API_HTTP_METHODS = Object.fromEntries(
+  API_REGISTRY.filter(e => e.httpMethod).map(e => [e.method, e.httpMethod])
+);
+
+// Methods whose backend rejects empty-string proto defaults (preset, node etc).
+const STRIP_EMPTY_METHODS = new Set([
+  'dsensor.dsensor_honeypot_create/query_dsensor_honeypot_create',
+  'dsensor.dsensor_honeypot_reset/query_dsensor_honeypot_reset',
+  'dsensor.dsensor_honeypot_upgrade/query_dsensor_honeypot_upgrade',
+  'dsensor.dsensor_honeynet_create/query_dsensor_honeynet_create',
+]);
+
+const deepStripEmptyStrings = (obj) => {
+  if (obj == null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(deepStripEmptyStrings);
+  const result = {};
+  for (const [key, val] of Object.entries(obj)) {
+    if (key === '$type_name') continue;
+    const cleaned = deepStripEmptyStrings(val);
+    if (cleaned !== '' && cleaned !== null && cleaned !== undefined) {
+      result[camelToSnake(key)] = cleaned;
+    }
+  }
+  return result;
+};
+
+// ─── Request builders ───────────────────────────────────────────────────────
+
+const buildRequestPayload = (methodFull, req) => {
+  if (methodFull === 'dsensor.dsensor_honeypot_delete/query_dsensor_honeypot_delete') {
+    return '';
+  }
+
+  const cleaned = STRIP_EMPTY_METHODS.has(methodFull)
+    ? deepStripEmptyStrings(req || {})
+    : cleanProtoRequest(req || {});
+  return JSON.stringify(cleaned);
+};
+
+const buildRequestUrl = (apiBase, methodFull, req) => {
+  const apiPath = API_PATHS[methodFull];
+  if (methodFull !== 'dsensor.dsensor_honeypot_delete/query_dsensor_honeypot_delete') {
+    return `${apiBase}${apiPath}`;
+  }
+
+  const cid = unwrapString(req?.cid ?? req?.id).trim();
+  if (!cid) return `${apiBase}${apiPath}`;
+
+  const query = new URLSearchParams({ cid });
+  return `${apiBase}${apiPath}?${query.toString()}`;
+};
+
+// ─── Core handler ────────────────────────────────────────────────────────────
+
+const resolveApiBase = (ctx) => {
+  const b = normalizeBaseUrl(firstDefined(
+    mergedBindings(ctx).apiBase,
+    mergedBindings(ctx).baseUrl,
+    mergedBindings(ctx).endpoint,
+  ));
+  if (!b) throw errorWithCode('INVALID_ARGUMENT', 'apiBase/baseUrl/endpoint is required');
+  return b;
+};
+
+const requireApiToken = (ctx) => {
+  const t = unwrapString(firstDefined(
+    mergedBindings(ctx).api_token,
+    mergedBindings(ctx).apiToken,
+    mergedBindings(ctx).token,
+  )).trim();
+  if (!t) throw errorWithCode('INVALID_ARGUMENT', 'api_token is required');
+  return t;
+};
+
+const buildHeaders = (token) => ({
+  'Content-Type': 'application/json',
+  'API-Token': token,
+});
+
+const handleQuery = async (methodFull, req, ctx) => {
+  const apiPath = API_PATHS[methodFull];
+  if (!apiPath) throw errorWithCode('UNKNOWN', `unknown method: ${methodFull}`);
+
+  const apiBase = resolveApiBase(ctx);
+  const apiToken = requireApiToken(ctx);
+  const url = buildRequestUrl(apiBase, methodFull, req);
+
+  const httpMethod = API_HTTP_METHODS[methodFull] || 'POST';
+
+  const body = buildRequestPayload(methodFull, req);
+
+  const { status, text } = await fetchJson(ctx, url, {
+    method: httpMethod,
+    headers: buildHeaders(apiToken),
+    body,
+  });
+
+  if (status < 200 || status >= 300) throw errorWithCode('PERMISSION_DENIED', `http ${status}`);
+
+  let parsed;
+  try { parsed = JSON.parse(text); } catch { throw errorWithCode('UNKNOWN', 'invalid JSON'); }
+
+  return {
+    http_status: status,
+    raw_body: String(text || ''),
+    raw_json: toValue(parsed),
+    msg: parsed.msg || '',
+    data: toValue(parsed.data),
+  };
+};
+
+// ─── rpcdef: expose all 25 query paths ───────────────────────────────────────
+
+export function rpcdef(ctx = {}) {
+  const c = resolveCallContext(ctx);
+  const result = {};
+  for (const entry of API_REGISTRY) {
+    const queryPath = `/${entry.method}`;
+    result[queryPath] = async (r) => handleQuery(entry.method, r ?? {}, c);
+  }
+  return result;
+}
+
+// ─── SDK handlers: keyed by "Service.Method" ─────────────────────────────────
+
+export const handlers = Object.fromEntries(
+  API_REGISTRY.map(entry => [
+    entry.method,
+    (ctx) => {
+      const c = resolveCallContext(ctx);
+      const req = ctx?.req ?? ctx?.request ?? {};
+      return handleQuery(entry.method, req, c);
+    },
+  ]),
+);
+
+// ─── Metadata for CLI command generation ─────────────────────────────────────
+
+export const METHOD_REGISTRY = Object.fromEntries(
+  API_REGISTRY.map(e => [e.method, { path: e.path, desc: e.desc }]),
+);
+
+// ─── Test exports ────────────────────────────────────────────────────────────
+
+export const _test = {
+  errorWithCode,
+  unwrapScalar,
+  unwrapString,
+  normalizeBaseUrl,
+  mergedBindings,
+  toValue,
+  firstDefined,
+  API_REGISTRY,
+  API_PATHS,
+  handleQuery,
+  buildRequestPayload,
+  buildRequestUrl,
+};

--- a/services/chaitin__dsensor_ds-s_h_40-25.07.001/src/service.js
+++ b/services/chaitin__dsensor_ds-s_h_40-25.07.001/src/service.js
@@ -1,0 +1,5 @@
+import { defineService } from "@chaitin-ai/octobus-sdk";
+import { handlers } from "./dsensor.js";
+
+export { handlers } from "./dsensor.js";
+export const service = defineService({ handlers });

--- a/services/chaitin__dsensor_ds-s_h_40-25.07.001/test/dsensor.test.js
+++ b/services/chaitin__dsensor_ds-s_h_40-25.07.001/test/dsensor.test.js
@@ -1,0 +1,139 @@
+import assert from 'node:assert';
+import { _test as t, handlers, rpcdef } from '../src/dsensor.js';
+
+assert.strictEqual(t.unwrapScalar(undefined), undefined);
+assert.strictEqual(t.unwrapScalar(null), undefined);
+assert.strictEqual(t.unwrapScalar('hello'), 'hello');
+assert.strictEqual(t.unwrapScalar(42), 42);
+assert.strictEqual(t.unwrapScalar({ value: 'wrapped' }), 'wrapped');
+assert.strictEqual(t.unwrapScalar({ value: { value: 'deep' } }), 'deep');
+
+assert.strictEqual(t.unwrapString(undefined), '');
+assert.strictEqual(t.unwrapString(null), '');
+assert.strictEqual(t.unwrapString('hello'), 'hello');
+assert.strictEqual(t.unwrapString(42), '42');
+
+assert.strictEqual(t.normalizeBaseUrl(''), '');
+assert.strictEqual(t.normalizeBaseUrl('not-a-url'), '');
+assert.strictEqual(t.normalizeBaseUrl('http://example.com/'), 'http://example.com');
+assert.strictEqual(t.normalizeBaseUrl('https://api.dsensor.local'), 'https://api.dsensor.local');
+
+assert.strictEqual(t.firstDefined(undefined, null, 'found'), 'found');
+assert.strictEqual(t.firstDefined('first', 'second'), 'first');
+
+assert.deepStrictEqual(t.mergedBindings({}), {});
+assert.deepStrictEqual(t.mergedBindings({ config: { a: 1 }, secret: { b: 2 } }), { a: 1, b: 2 });
+
+assert.deepStrictEqual(t.toValue(null), { nullValue: 'NULL_VALUE' });
+assert.deepStrictEqual(t.toValue('str'), { stringValue: 'str' });
+assert.deepStrictEqual(t.toValue(42), { numberValue: 42 });
+assert.deepStrictEqual(t.toValue(true), { boolValue: true });
+assert.deepStrictEqual(t.toValue([1, 2]), { listValue: { values: [{ numberValue: 1 }, { numberValue: 2 }] } });
+
+assert.strictEqual(t.API_REGISTRY.length, 25, 'Should have 25 registered methods');
+
+const paths = t.API_REGISTRY.map((entry) => entry.path);
+assert.strictEqual(new Set(paths).size, paths.length, 'API paths should be unique');
+
+for (const entry of t.API_REGISTRY) {
+  assert.ok(t.API_PATHS[entry.method], `Missing API path for ${entry.method}`);
+  assert.strictEqual(t.API_PATHS[entry.method], entry.path);
+}
+
+assert.ok(t.API_PATHS['dsensor.dsensor_agent_change_type/query_dsensor_agent_change_type']);
+assert.ok(t.API_PATHS['dsensor.dsensor_agent_portmap_update/query_dsensor_agent_portmap_update']);
+assert.ok(t.API_PATHS['dsensor.dsensor_agent_scan_update/query_dsensor_agent_scan_update']);
+
+assert.deepStrictEqual(
+  JSON.parse(t.buildRequestPayload('dsensor.dsensor_agent_clear_service/query_dsensor_agent_clear_service', {
+    sns: ['sn-001', 'sn-002'],
+  })),
+  { sns: ['sn-001', 'sn-002'] },
+  'clear_service should forward sns directly',
+);
+
+assert.deepStrictEqual(
+  JSON.parse(t.buildRequestPayload('dsensor.dsensor_honeypot_create/query_dsensor_honeypot_create', {
+    nid: 'nid-1',
+    displayName: 'hp',
+    image: 'wiki',
+    imageId: 'sha256:abc',
+    node: '',
+    preset: {
+      copyPreset: '',
+      meta: {
+        portraitOption: 'open',
+        __name__: '',
+      },
+    },
+  })),
+  {
+    nid: 'nid-1',
+    display_name: 'hp',
+    image: 'wiki',
+    image_id: 'sha256:abc',
+    preset: {
+      meta: {
+        portrait_option: 'open',
+      },
+    },
+  },
+  'honeypot_create should keep object preset and strip empty strings',
+);
+
+assert.deepStrictEqual(
+  JSON.parse(t.buildRequestPayload('dsensor.dsensor_honeypot_reset/query_dsensor_honeypot_reset', {
+    cid: 'cid-1',
+    preset: {
+      copyPreset: '',
+      meta: {
+        certName: 'demo',
+      },
+    },
+  })),
+  {
+    cid: 'cid-1',
+    preset: {
+      meta: {
+        cert_name: 'demo',
+      },
+    },
+  },
+  'honeypot_reset should support structured preset payloads',
+);
+
+assert.strictEqual(
+  t.buildRequestPayload('dsensor.dsensor_honeypot_delete/query_dsensor_honeypot_delete', { cid: 'cid-1' }),
+  '',
+  'honeypot_delete should not send a request body',
+);
+
+assert.strictEqual(
+  t.buildRequestUrl('https://dsensor.local', 'dsensor.dsensor_honeypot_delete/query_dsensor_honeypot_delete', { cid: 'cid-1' }),
+  'https://dsensor.local/api/honey/pot/delete?cid=cid-1',
+  'honeypot_delete should encode cid as query string',
+);
+
+assert.strictEqual(
+  t.buildRequestUrl('https://dsensor.local', 'dsensor.dsensor_agent_list/query_dsensor_agent_list', {}),
+  'https://dsensor.local/api/agent/list',
+);
+
+const handlerKeys = Object.keys(handlers);
+assert.strictEqual(handlerKeys.length, 25, 'Should have 25 handlers');
+for (const entry of t.API_REGISTRY) {
+  assert.ok(handlers[entry.method], `Missing handler for ${entry.method}`);
+}
+
+const routes = rpcdef({});
+const routeKeys = Object.keys(routes);
+assert.strictEqual(routeKeys.length, 25, 'rpcdef should expose 25 routes');
+for (const key of routeKeys) {
+  assert.strictEqual(typeof routes[key], 'function', `${key} should be a function`);
+}
+
+const err = t.errorWithCode('INVALID_ARGUMENT', 'test error');
+assert.ok(err.legacyCode === 'INVALID_ARGUMENT', 'errorWithCode should set legacyCode');
+assert.ok(err.message.includes('INVALID_ARGUMENT'), 'error message should include code');
+
+console.log('✅ All tests passed —', handlerKeys.length, 'handlers,', routeKeys.length, 'routes');


### PR DESCRIPTION
## 适配器信息

- 规范标题：D-Sensor DS-S_H_40-25.07.001（谛听）
- 公司：Chaitin / 长亭
- 产品：D-Sensor / 谛听
- 服务 ID：dsensor
- 服务目录：services/chaitin__dsensor_ds-s_h_40-25.07.001

## 变更内容

- 新增 service.json、proto/、config.schema.json、secret.schema.json、src/、bin/、test/ 标准服务结构
- 新增 D-Sensor DS-S_H_40-25.07.001 对应的 OctoBus service package
- 服务包覆盖 25 个接口，包含探针管理、事件查询、扫描器查询、告警查询、审计日志、CPU/内存统计、磁盘统计、用户查询、蜜网管理、蜜罐管理等能力
- 保持服务 ID 为 dsensor，同时将版本信息补充到服务目录名和展示名中，便于识别和维护
- README 和测试说明已同步为带版本的目录路径

## OctoBus 导入方式

octobus service import dsensor ./services/chaitin__dsensor_ds-s_h_40-25.07.001 --reinstall

## 本地验证

cd services
npm run validate -- --service-dir chaitin__dsensor_ds-s_h_40-25.07.001
npm test -- --service-dir chaitin__dsensor_ds-s_h_40-25.07.001 --coverage
npm run pack:check

## 测试结果

- 服务包文档中已记录单元测试结果：25 handlers, 25 routes
- 服务包文档中已记录基于 OctoBus 的真实调用验证结果
- 已整理测试说明和联调结果到以下文件：
  services/chaitin__dsensor_ds-s_h_40-25.07.001/README.md
  services/chaitin__dsensor_ds-s_h_40-25.07.001/TEST.md

## 联调说明

TEST.md 中包含基于 OctoBus 实例的调用示例和结果说明，包括但不限于：
- agent_list
- event_list
- scanner_list
- portrait_list
- alarm_list
- audit_list

相关导入方式、配置示例、请求示例、接口说明也已随服务目录一并提交。