### PR TITLE
feat: add Alibaba Cloud SAS Vulnerability Management service package

### DIFF
--- a/services/aliyun__ddoscoo_20200101/README.md
+++ b/services/aliyun__ddoscoo_20200101/README.md
@@ -1,0 +1,65 @@
+# Alibaba Cloud DDoS COO (2020-01-01)
+
+OctoBus service package for Alibaba Cloud Anti-DDoS Pro/Premium API v2020-01-01.
+
+## Features
+
+- Query DDoS COO instances
+- Query L7 website forwarding rules
+- Query L4 port forwarding rules
+- Query DDoS attack events
+- Enable/disable CC protection for domains
+- Configure CC protection template mode
+
+## Import
+
+```bash
+octobus service import --id <service-id> packages/aliyun-ddoscoo-20200101
+```
+
+## Bindings
+
+### Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `regionId` | string | `cn-hangzhou` | Alibaba Cloud region ID |
+| `timeoutMs` | integer | 10000 | HTTP request timeout in milliseconds |
+
+### Secret
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `accessKeyId` | string | Yes | Alibaba Cloud AccessKey ID |
+| `accessKeySecret` | string | Yes | Alibaba Cloud AccessKey Secret |
+
+## RPC Methods
+
+| Method | Description |
+|--------|-------------|
+| `DescribeInstances` | Query DDoS COO instances |
+| `DescribeDomainResource` | Query L7 website forwarding rules |
+| `DescribeNetworkRules` | Query L4 port forwarding rules |
+| `DescribeDDosAllEventList` | Query DDoS attack events |
+| `EnableWebCC` | Enable/disable CC protection for a domain |
+| `ConfigWebCCTemplate` | Set CC protection template mode |
+
+## Error Mapping
+
+| Upstream Error | gRPC Status |
+|----------------|-------------|
+| 401/403 HTTP | `PERMISSION_DENIED` |
+| 400 HTTP | `FAILED_PRECONDITION` |
+| 500+ HTTP | `UNAVAILABLE` |
+| Network/read failure | `UNAVAILABLE` |
+| Missing/invalid params | `INVALID_ARGUMENT` |
+| Auth failure | `UNAUTHENTICATED` |
+| `Throttling.*` | `UNAVAILABLE` |
+
+## Validation
+
+```bash
+cd services
+npm run validate -- --service-dir aliyun__ddoscoo_20200101
+npm test
+```

--- a/services/aliyun__ddoscoo_20200101/bin/aliyun-ddoscoo-20200101.js
+++ b/services/aliyun__ddoscoo_20200101/bin/aliyun-ddoscoo-20200101.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runServiceMain } from '@chaitin-ai/octobus-sdk';
+import { service } from '../src/service.js';
+runServiceMain(service);

--- a/services/aliyun__ddoscoo_20200101/config.schema.json
+++ b/services/aliyun__ddoscoo_20200101/config.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "regionId": {
+      "type": "string",
+      "default": "cn-hangzhou",
+      "description": "Alibaba Cloud region ID (e.g. cn-hangzhou, cn-shanghai)"
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 10000,
+      "description": "HTTP request timeout in milliseconds"
+    }
+  }
+}

--- a/services/aliyun__ddoscoo_20200101/package.json
+++ b/services/aliyun__ddoscoo_20200101/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "aliyun-ddoscoo-20200101",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "aliyun-ddoscoo-20200101": "bin/aliyun-ddoscoo-20200101.js"
+  },
+  "dependencies": {
+    "@chaitin-ai/octobus-sdk": "^0.5.0"
+  }
+}

--- a/services/aliyun__ddoscoo_20200101/proto/aliyun_ddoscoo_20200101.proto
+++ b/services/aliyun__ddoscoo_20200101/proto/aliyun_ddoscoo_20200101.proto
@@ -1,0 +1,102 @@
+syntax = "proto3";
+package Aliyun_DDoSCOO_20200101;
+option go_package = "miner/grpc-service/Aliyun_DDoSCOO_20200101";
+
+import "google/protobuf/struct.proto";
+
+service DDoSCOOService {
+  rpc DescribeInstances(DescribeInstancesRequest) returns (DescribeInstancesResponse) {}
+  rpc DescribeDomainResource(DescribeDomainResourceRequest) returns (DescribeDomainResourceResponse) {}
+  rpc DescribeNetworkRules(DescribeNetworkRulesRequest) returns (DescribeNetworkRulesResponse) {}
+  rpc DescribeDDosAllEventList(DescribeDDosAllEventListRequest) returns (DescribeDDosAllEventListResponse) {}
+  rpc EnableWebCC(EnableWebCCRequest) returns (EnableWebCCResponse) {}
+  rpc ConfigWebCCTemplate(ConfigWebCCTemplateRequest) returns (ConfigWebCCTemplateResponse) {}
+}
+
+message DescribeInstancesRequest {
+  string page_number = 1 [json_name = "pageNumber"];
+  string page_size = 2 [json_name = "pageSize"];
+  repeated string instance_ids = 3 [json_name = "instanceIds"];
+  string ip = 4;
+  string remark = 5;
+  repeated int32 status = 6;
+  int32 edition = 7;
+  int32 enabled = 8;
+  int64 expire_start_time = 9 [json_name = "expireStartTime"];
+  int64 expire_end_time = 10 [json_name = "expireEndTime"];
+  string resource_group_id = 11 [json_name = "resourceGroupId"];
+  string tag_key = 12 [json_name = "tagKey"];
+  string tag_value = 13 [json_name = "tagValue"];
+}
+
+message DescribeInstancesResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+message DescribeDomainResourceRequest {
+  string page_number = 1 [json_name = "pageNumber"];
+  string page_size = 2 [json_name = "pageSize"];
+  string domain = 3;
+  repeated string instance_ids = 4 [json_name = "instanceIds"];
+  string query_domain_pattern = 5 [json_name = "queryDomainPattern"];
+  string resource_group_id = 6 [json_name = "resourceGroupId"];
+}
+
+message DescribeDomainResourceResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+message DescribeNetworkRulesRequest {
+  string page_number = 1 [json_name = "pageNumber"];
+  string page_size = 2 [json_name = "pageSize"];
+  string instance_id = 3 [json_name = "instanceId"];
+  string forward_protocol = 4 [json_name = "forwardProtocol"];
+  int32 frontend_port = 5 [json_name = "frontendPort"];
+}
+
+message DescribeNetworkRulesResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+message DescribeDDosAllEventListRequest {
+  int32 page_number = 1 [json_name = "pageNumber"];
+  int32 page_size = 2 [json_name = "pageSize"];
+  int64 start_time = 3 [json_name = "startTime"];
+  int64 end_time = 4 [json_name = "endTime"];
+  string event_type = 5 [json_name = "eventType"];
+}
+
+message DescribeDDosAllEventListResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+message EnableWebCCRequest {
+  string domain = 1;
+  string resource_group_id = 2 [json_name = "resourceGroupId"];
+}
+
+message EnableWebCCResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+message ConfigWebCCTemplateRequest {
+  string domain = 1;
+  string template = 2;
+  string resource_group_id = 3 [json_name = "resourceGroupId"];
+}
+
+message ConfigWebCCTemplateResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}

--- a/services/aliyun__ddoscoo_20200101/secret.schema.json
+++ b/services/aliyun__ddoscoo_20200101/secret.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["accessKeyId", "accessKeySecret"],
+  "properties": {
+    "accessKeyId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Alibaba Cloud AccessKey ID (also available via ALIBABA_CLOUD_ACCESS_KEY_ID env var)"
+    },
+    "accessKeySecret": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Alibaba Cloud AccessKey Secret (also available via ALIBABA_CLOUD_ACCESS_KEY_SECRET env var)"
+    }
+  }
+}

--- a/services/aliyun__ddoscoo_20200101/service.json
+++ b/services/aliyun__ddoscoo_20200101/service.json
@@ -1,0 +1,45 @@
+{
+  "schema": "chaitin.octobus.service.v1",
+  "name": "aliyun-ddoscoo-20200101",
+  "displayName": "Alibaba Cloud DDoS COO (2020-01-01)",
+  "description": "OctoBus package for Alibaba Cloud DDoS COO (Anti-DDoS Pro/Premium) API v2020-01-01. Provides instance management, L4/L7 forwarding rule queries, DDoS attack event queries, and CC protection configuration.",
+  "runtime": {
+    "mode": "on-demand"
+  },
+  "proto": {
+    "roots": ["proto"],
+    "files": ["proto/aliyun_ddoscoo_20200101.proto"]
+  },
+  "configSchema": "config.schema.json",
+  "secretSchema": "secret.schema.json",
+  "sdk": {
+    "cli": {
+      "commands": {
+        "Aliyun_DDoSCOO_20200101.DDoSCOOService/DescribeInstances": {
+          "name": "describe-instances",
+          "description": "Describeinstaces"
+        },
+        "Aliyun_DDoSCOO_20200101.DDoSCOOService/DescribeDomainResource": {
+          "name": "describe-domain-resource",
+          "description": "Query L7 website forwarding rules"
+        },
+        "Aliyun_DDoSCOO_20200101.DDoSCOOService/DescribeNetworkRules": {
+          "name": "describe-network-rules",
+          "description": "Query L4 port forwarding rules"
+        },
+        "Aliyun_DDoSCOO_20200101.DDoSCOOService/DescribeDDosAllEventList": {
+          "name": "describe-ddos-all-event-list",
+          "description": "Query all DDoS attack events"
+        },
+        "Aliyun_DDoSCOO_20200101.DDoSCOOService/EnableWebCC": {
+          "name": "enable-web-cc",
+          "description": "Enable or disable CC protection for a domain"
+        },
+        "Aliyun_DDoSCOO_20200101.DDoSCOOService/ConfigWebCCTemplate": {
+          "name": "config-web-cc-template",
+          "description": "Set CC protection template mode"
+        }
+      }
+    }
+  }
+}

--- a/services/aliyun__ddoscoo_20200101/src/aliyun-ddoscoo-20200101.js
+++ b/services/aliyun__ddoscoo_20200101/src/aliyun-ddoscoo-20200101.js
@@ -1,0 +1,512 @@
+import crypto from 'node:crypto';
+import {
+  GrpcError,
+  grpcStatus,
+  grpcInvalidArgumentError,
+  grpcUnauthenticatedError,
+  grpcPermissionDeniedError,
+  grpcUnavailableError,
+} from '@chaitin-ai/octobus-sdk';
+
+// --------------- Method constants ---------------
+const PKG = 'Aliyun_DDoSCOO_20200101';
+const SVC = 'DDoSCOOService';
+const METHOD = (name) => `${PKG}.${SVC}/${name}`;
+
+const METHOD_DESCRIBE_INSTANCES_PATH = `/${METHOD('DescribeInstances')}`;
+const METHOD_DESCRIBE_DOMAIN_RESOURCE_PATH = `/${METHOD('DescribeDomainResource')}`;
+const METHOD_DESCRIBE_NETWORK_RULES_PATH = `/${METHOD('DescribeNetworkRules')}`;
+const METHOD_DESCRIBE_DDOS_ALL_EVENT_LIST_PATH = `/${METHOD('DescribeDDosAllEventList')}`;
+const METHOD_ENABLE_WEB_CC_PATH = `/${METHOD('EnableWebCC')}`;
+const METHOD_CONFIG_WEB_CC_TEMPLATE_PATH = `/${METHOD('ConfigWebCCTemplate')}`;
+
+const METHOD_DESCRIBE_INSTANCES_FULL = METHOD('DescribeInstances');
+const METHOD_DESCRIBE_DOMAIN_RESOURCE_FULL = METHOD('DescribeDomainResource');
+const METHOD_DESCRIBE_NETWORK_RULES_FULL = METHOD('DescribeNetworkRules');
+const METHOD_DESCRIBE_DDOS_ALL_EVENT_LIST_FULL = METHOD('DescribeDDosAllEventList');
+const METHOD_ENABLE_WEB_CC_FULL = METHOD('EnableWebCC');
+const METHOD_CONFIG_WEB_CC_TEMPLATE_FULL = METHOD('ConfigWebCCTemplate');
+
+// --------------- Defaults ---------------
+const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_REGION = 'cn-hangzhou';
+
+// --------------- Utilities ---------------
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+
+function firstDefined(...values) {
+  for (const v of values) {
+    if (v !== undefined && v !== null) return v;
+  }
+  return undefined;
+}
+
+function toTrimmedString(value) {
+  if (typeof value === 'string') return value.trim();
+  return undefined;
+}
+
+// --------------- gRPC error helpers ---------------
+const GRPC_CODE_MAP = {
+  FAILED_PRECONDITION: grpcStatus.FAILED_PRECONDITION,
+  INVALID_ARGUMENT: grpcStatus.INVALID_ARGUMENT,
+  UNAUTHENTICATED: grpcStatus.UNAUTHENTICATED,
+  PERMISSION_DENIED: grpcStatus.PERMISSION_DENIED,
+  NOT_FOUND: grpcStatus.NOT_FOUND,
+  UNAVAILABLE: grpcStatus.UNAVAILABLE,
+  INTERNAL: grpcStatus.INTERNAL,
+};
+
+function grpcCodeFor(code) {
+  return GRPC_CODE_MAP[code] || grpcStatus.INTERNAL;
+}
+
+function errorWithCode(code, message) {
+  const e = new GrpcError(grpcCodeFor(code), message);
+  e.legacyCode = code;
+  return e;
+}
+
+function throwStructuredError(code, message, options = {}) {
+  const payload = { code, message };
+  if (hasOwn(options, 'httpStatus')) payload.http_status = options.httpStatus;
+  if (hasOwn(options, 'rawBody')) payload.raw_body = options.rawBody;
+  if (hasOwn(options, 'rawJson')) payload.raw_json = options.rawJson;
+  if (hasOwn(options, 'reason')) payload.reason = options.reason;
+  if (hasOwn(options, 'responseCode')) payload.response_code = options.responseCode;
+  if (hasOwn(options, 'verboseMsg')) payload.verbose_msg = options.verboseMsg;
+  throw errorWithCode(code, JSON.stringify(payload));
+}
+
+// --------------- Context resolution ---------------
+function resolveRegionId(ctx) {
+  const config = ctx.config ?? {};
+  return toTrimmedString(config.regionId) || DEFAULT_REGION;
+}
+
+function resolveAccessKeyId(ctx) {
+  const secret = ctx.secret ?? {};
+  const val = toTrimmedString(secret.accessKeyId);
+  if (!val) throwStructuredError('INVALID_ARGUMENT', 'accessKeyId is required in secret');
+  return val;
+}
+
+function resolveAccessKeySecret(ctx) {
+  const secret = ctx.secret ?? {};
+  const val = toTrimmedString(secret.accessKeySecret);
+  if (!val) throwStructuredError('INVALID_ARGUMENT', 'accessKeySecret is required in secret');
+  return val;
+}
+
+function resolveTimeoutMs(ctx) {
+  const config = ctx.config ?? {};
+  const ms = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  return Number.isFinite(ms) && ms > 0 ? ms : DEFAULT_TIMEOUT_MS;
+}
+
+// --------------- Alibaba Cloud OpenAPI signature V1 ---------------
+
+/**
+ * Alibaba Cloud percent-encoding.
+ * Encodes: ~ (JS doesn't), but leaves * unencoded (JS does).
+ */
+function aliyunPercentEncode(str) {
+  return encodeURIComponent(str)
+    .replace(/%7E/g, '~')
+    .replace(/\*/g, '%2A')
+    .replace(/%20/g, '%20')
+    .replace(/!/g, '%21')
+    .replace(/'/g, '%27')
+    .replace(/\(/g, '%28')
+    .replace(/\)/g, '%29')
+    .replace(/\+/g, '%2B');
+}
+
+function randomNonce() {
+  return crypto.randomUUID().replace(/-/g, '');
+}
+
+function iso8601Timestamp() {
+  const now = new Date();
+  const pad = (n) => String(n).padStart(2, '0');
+  return (
+    `${now.getUTCFullYear()}-${pad(now.getUTCMonth() + 1)}-${pad(now.getUTCDate())}T` +
+    `${pad(now.getUTCHours())}:${pad(now.getUTCMinutes())}:${pad(now.getUTCSeconds())}Z`
+  );
+}
+
+function buildSignedParams(action, businessParams, accessKeyId, accessKeySecret) {
+  const params = new Map();
+
+  // System params
+  params.set('AccessKeyId', accessKeyId);
+  params.set('Action', action);
+  params.set('Format', 'JSON');
+  params.set('SignatureMethod', 'HMAC-SHA1');
+  params.set('SignatureNonce', randomNonce());
+  params.set('SignatureVersion', '1.0');
+  params.set('Timestamp', iso8601Timestamp());
+  params.set('Version', '2020-01-01');
+
+  // Business params
+  for (const [key, value] of Object.entries(businessParams)) {
+    if (value === undefined || value === null || value === '') continue;
+    if (Array.isArray(value)) {
+      value.forEach((item, i) => {
+        params.set(`${key}.${i + 1}`, String(item));
+      });
+    } else {
+      params.set(key, String(value));
+    }
+  }
+
+  // Sort by key
+  const sorted = [...params.entries()].sort(([a], [b]) => {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+  });
+
+  // Build canonicalized query string for signing
+  const canonicalQuery = sorted
+    .map(([k, v]) => `${aliyunPercentEncode(k)}=${aliyunPercentEncode(v)}`)
+    .join('&');
+
+  const stringToSign = `POST&${aliyunPercentEncode('/')}&${aliyunPercentEncode(canonicalQuery)}`;
+  const hmac = crypto.createHmac('sha1', `${accessKeySecret}&`);
+  hmac.update(stringToSign);
+  const signature = hmac.digest('base64');
+
+  // Add signature to params
+  params.set('Signature', signature);
+
+  return params;
+}
+
+// --------------- HTTP ---------------
+
+function buildUrl(regionId) {
+  return `https://ddoscoo.${regionId}.aliyuncs.com/`;
+}
+
+async function callAliyunAPI(ctx, action, businessParams = {}) {
+  const regionId = resolveRegionId(ctx);
+  const accessKeyId = resolveAccessKeyId(ctx);
+  const accessKeySecret = resolveAccessKeySecret(ctx);
+  const timeoutMs = resolveTimeoutMs(ctx);
+
+  const baseUrl = buildUrl(regionId);
+  const params = buildSignedParams(action, businessParams, accessKeyId, accessKeySecret);
+  const body = new URLSearchParams();
+  for (const [k, v] of params) {
+    body.append(k, v);
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let resp;
+  try {
+    resp = await fetch(baseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    const cause = err.cause ? String(err.cause) : undefined;
+    throwStructuredError('UNAVAILABLE', `Request to Alibaba Cloud failed: ${err.message}`, {
+      reason: String(err),
+      cause,
+    });
+  }
+  clearTimeout(timer);
+
+  const rawBody = await resp.text();
+
+  if (!resp.ok) {
+    mapHttpError(resp.status, rawBody);
+  }
+
+  let parsed;
+  parsed = tryParseJson(rawBody);
+  if (!parsed.ok) {
+    throwStructuredError('UNAVAILABLE', 'Alibaba Cloud returned non-JSON response', {
+      httpStatus: resp.status,
+      rawBody,
+    });
+  }
+
+  // Check for API-level error in response body
+  assertAliyunSuccess(parsed.value, resp.status, rawBody);
+
+  return {
+    httpStatus: resp.status,
+    rawBody,
+    rawJson: toValue(parsed.value),
+  };
+}
+
+function mapHttpError(statusCode, rawBody) {
+  let parsed;
+  try { parsed = JSON.parse(rawBody); } catch { parsed = null; }
+  const errMsg = parsed?.Message || parsed?.message || `HTTP ${statusCode}`;
+
+  if (statusCode === 401 || statusCode === 403) {
+    throwStructuredError('PERMISSION_DENIED', errMsg, {
+      httpStatus: statusCode, rawBody,
+      rawJson: parsed ? toValue(parsed) : undefined,
+    });
+  }
+  if (statusCode >= 400 && statusCode < 500) {
+    throwStructuredError('FAILED_PRECONDITION', errMsg, {
+      httpStatus: statusCode, rawBody,
+      rawJson: parsed ? toValue(parsed) : undefined,
+    });
+  }
+  throwStructuredError('UNAVAILABLE', errMsg, {
+    httpStatus: statusCode, rawBody,
+    rawJson: parsed ? toValue(parsed) : undefined,
+  });
+}
+
+function assertAliyunSuccess(json, statusCode, rawBody) {
+  // Some Alibaba Cloud APIs return errors with Code/Message fields
+  if (json && (json.Code || json.code)) {
+    const code = json.Code || json.code;
+    const message = json.Message || json.message || 'Unknown error';
+    if (code !== '200' && code !== 'Success' && code !== 'OK') {
+      const gcode = mapAliyunErrorCode(code);
+      throwStructuredError(gcode, message, {
+        httpStatus: statusCode,
+        rawBody,
+        rawJson: toValue(json),
+        responseCode: code,
+      });
+    }
+  }
+}
+
+function mapAliyunErrorCode(aliCode) {
+  const code = String(aliCode);
+  if (code === 'InvalidAccessKeyId.NotFound' || code === 'InvalidAccessKeyId' ||
+      code === 'SignatureDoesNotMatch' || code === 'Forbidden.AccessKeyDisabled') {
+    return 'UNAUTHENTICATED';
+  }
+  if (code === 'Forbidden.NotAdminUser' || code === 'Forbidden.AccountInDebt' ||
+      code === 'Forbidden.AccountDebtOverdue') {
+    return 'PERMISSION_DENIED';
+  }
+  if (code.includes('InvalidParameter') || code.includes('Invalid') ||
+      code.includes('Missing') || code.includes('missing')) {
+    return 'INVALID_ARGUMENT';
+  }
+  if (code.includes('NotFound') || code.includes('notFound') || code.includes('NotExist')) {
+    return 'NOT_FOUND';
+  }
+  if (code.includes('Throttling') || code.includes('LimitExceeded') ||
+      code.includes('ServiceUnavailable')) {
+    return 'UNAVAILABLE';
+  }
+  return 'FAILED_PRECONDITION';
+}
+
+// --------------- JSON helpers ---------------
+
+function tryParseJson(text) {
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch {
+    return { ok: false, value: undefined };
+  }
+}
+
+function toValue(value) {
+  if (value === null) return { nullValue: 0 };
+  if (value === undefined) return { nullValue: 0 };
+  const t = typeof value;
+  if (t === 'string') return { stringValue: value };
+  if (t === 'number') return { numberValue: value };
+  if (t === 'boolean') return { boolValue: value };
+  if (Array.isArray(value)) {
+    return { listValue: { values: value.map(toValue) } };
+  }
+  if (t === 'object') {
+    const fields = {};
+    for (const [k, v] of Object.entries(value)) {
+      fields[k] = toValue(v);
+    }
+    return { structValue: { fields } };
+  }
+  return { stringValue: String(value) };
+}
+
+export function unwrapScalar(value) {
+  if (!value || typeof value !== 'object') return value;
+  if (hasOwn(value, 'stringValue')) return value.stringValue;
+  if (hasOwn(value, 'numberValue')) return value.numberValue;
+  if (hasOwn(value, 'boolValue')) return value.boolValue;
+  return value;
+}
+
+// --------------- Handlers ---------------
+
+function buildCallHandler(action, reqMapper) {
+  return async (req, ctx) => {
+    const businessParams = reqMapper ? reqMapper(req) : Object.fromEntries(
+      Object.entries(req).filter(([, v]) => v !== undefined && v !== null && v !== '' && (!Array.isArray(v) || v.length > 0))
+    );
+    return callAliyunAPI(ctx, action, businessParams);
+  };
+}
+
+// DescribeInstances request mapper
+function mapDescribeInstancesReq(req) {
+  const params = {};
+  if (req.pageNumber) params.PageNumber = req.pageNumber;
+  if (req.pageSize) params.PageSize = req.pageSize;
+  if (req.instanceIds?.length) params.InstanceIds = req.instanceIds;
+  if (req.ip) params.Ip = req.ip;
+  if (req.remark) params.Remark = req.remark;
+  if (req.status?.length) params.Status = req.status;
+  if (req.edition) params.Edition = req.edition;
+  if (req.enabled) params.Enabled = req.enabled;
+  if (req.expireStartTime) params.ExpireStartTime = req.expireStartTime;
+  if (req.expireEndTime) params.ExpireEndTime = req.expireEndTime;
+  if (req.resourceGroupId) params.ResourceGroupId = req.resourceGroupId;
+  if (req.tagKey) {
+    params.Tag = [{ Key: req.tagKey, Value: req.tagValue || '' }];
+  }
+  return params;
+}
+
+// DescribeDomainResource request mapper
+function mapDescribeDomainResourceReq(req) {
+  const params = {};
+  if (req.pageNumber) params.PageNumber = req.pageNumber;
+  if (req.pageSize) params.PageSize = req.pageSize;
+  if (req.domain) params.Domain = req.domain;
+  if (req.instanceIds?.length) params.InstanceIds = req.instanceIds;
+  if (req.queryDomainPattern) params.QueryDomainPattern = req.queryDomainPattern;
+  if (req.resourceGroupId) params.ResourceGroupId = req.resourceGroupId;
+  return params;
+}
+
+// DescribeNetworkRules request mapper
+function mapDescribeNetworkRulesReq(req) {
+  const params = {};
+  if (req.pageNumber) params.PageNumber = req.pageNumber;
+  if (req.pageSize) params.PageSize = req.pageSize;
+  if (req.instanceId) params.InstanceId = req.instanceId;
+  if (req.forwardProtocol) params.ForwardProtocol = req.forwardProtocol;
+  if (req.frontendPort) params.FrontendPort = req.frontendPort;
+  return params;
+}
+
+// DescribeDDosAllEventList request mapper
+function mapDescribeDDosAllEventListReq(req) {
+  const params = {};
+  if (req.pageNumber) params.PageNumber = req.pageNumber;
+  if (req.pageSize) params.PageSize = req.pageSize;
+  if (req.startTime) params.StartTime = req.startTime;
+  if (req.endTime) params.EndTime = req.endTime;
+  if (req.eventType) params.EventType = req.eventType;
+  return params;
+}
+
+// EnableWebCC request mapper
+function mapEnableWebCCReq(req) {
+  const params = { Domain: req.domain };
+  if (req.resourceGroupId) params.ResourceGroupId = req.resourceGroupId;
+  return params;
+}
+
+// ConfigWebCCTemplate request mapper
+function mapConfigWebCCTemplateReq(req) {
+  const params = { Domain: req.domain, Template: req.template };
+  if (req.resourceGroupId) params.ResourceGroupId = req.resourceGroupId;
+  return params;
+}
+
+// --------------- Handler definitions ---------------
+
+const handleDescribeInstances = buildCallHandler('DescribeInstances', mapDescribeInstancesReq);
+const handleDescribeDomainResource = buildCallHandler('DescribeDomainResource', mapDescribeDomainResourceReq);
+const handleDescribeNetworkRules = buildCallHandler('DescribeNetworkRules', mapDescribeNetworkRulesReq);
+const handleDescribeDDosAllEventList = buildCallHandler('DescribeDDosAllEventList', mapDescribeDDosAllEventListReq);
+const handleEnableWebCC = buildCallHandler('EnableWebCC', mapEnableWebCCReq);
+const handleConfigWebCCTemplate = buildCallHandler('ConfigWebCCTemplate', mapConfigWebCCTemplateReq);
+
+// --------------- rpcdef (path-based routing for SDK) ---------------
+
+export function rpcdef(ctx) {
+  return {
+    [METHOD_DESCRIBE_INSTANCES_PATH]: (req) => handleDescribeInstances(req, ctx),
+    [METHOD_DESCRIBE_DOMAIN_RESOURCE_PATH]: (req) => handleDescribeDomainResource(req, ctx),
+    [METHOD_DESCRIBE_NETWORK_RULES_PATH]: (req) => handleDescribeNetworkRules(req, ctx),
+    [METHOD_DESCRIBE_DDOS_ALL_EVENT_LIST_PATH]: (req) => handleDescribeDDosAllEventList(req, ctx),
+    [METHOD_ENABLE_WEB_CC_PATH]: (req) => handleEnableWebCC(req, ctx),
+    [METHOD_CONFIG_WEB_CC_TEMPLATE_PATH]: (req) => handleConfigWebCCTemplate(req, ctx),
+  };
+}
+
+// --------------- handlers (for defineService) ---------------
+
+export const handlers = {
+  [METHOD_DESCRIBE_INSTANCES_FULL]: handleDescribeInstances,
+  [METHOD_DESCRIBE_DOMAIN_RESOURCE_FULL]: handleDescribeDomainResource,
+  [METHOD_DESCRIBE_NETWORK_RULES_FULL]: handleDescribeNetworkRules,
+  [METHOD_DESCRIBE_DDOS_ALL_EVENT_LIST_FULL]: handleDescribeDDosAllEventList,
+  [METHOD_ENABLE_WEB_CC_FULL]: handleEnableWebCC,
+  [METHOD_CONFIG_WEB_CC_TEMPLATE_FULL]: handleConfigWebCCTemplate,
+};
+
+// --------------- _test export (for unit testing) ---------------
+
+export const _test = {
+  // Constants
+  METHOD_DESCRIBE_INSTANCES_PATH,
+  METHOD_DESCRIBE_DOMAIN_RESOURCE_PATH,
+  METHOD_DESCRIBE_NETWORK_RULES_PATH,
+  METHOD_DESCRIBE_DDOS_ALL_EVENT_LIST_PATH,
+  METHOD_ENABLE_WEB_CC_PATH,
+  METHOD_CONFIG_WEB_CC_TEMPLATE_PATH,
+  METHOD_DESCRIBE_INSTANCES_FULL,
+  METHOD_DESCRIBE_DOMAIN_RESOURCE_FULL,
+  METHOD_DESCRIBE_NETWORK_RULES_FULL,
+  METHOD_DESCRIBE_DDOS_ALL_EVENT_LIST_FULL,
+  METHOD_ENABLE_WEB_CC_FULL,
+  METHOD_CONFIG_WEB_CC_TEMPLATE_FULL,
+
+  // Utilities
+  hasOwn,
+  firstDefined,
+  toTrimmedString,
+  grpcCodeFor,
+  errorWithCode,
+  throwStructuredError,
+  resolveRegionId,
+  resolveAccessKeyId,
+  resolveAccessKeySecret,
+  resolveTimeoutMs,
+  aliyunPercentEncode,
+  randomNonce,
+  buildSignedParams,
+  buildUrl,
+  callAliyunAPI,
+  mapHttpError,
+  assertAliyunSuccess,
+  mapAliyunErrorCode,
+  tryParseJson,
+  toValue,
+  unwrapScalar,
+
+  // Mappers
+  mapDescribeInstancesReq,
+  mapDescribeDomainResourceReq,
+  mapDescribeNetworkRulesReq,
+  mapDescribeDDosAllEventListReq,
+  mapEnableWebCCReq,
+  mapConfigWebCCTemplateReq,
+};

--- a/services/aliyun__ddoscoo_20200101/src/service.js
+++ b/services/aliyun__ddoscoo_20200101/src/service.js
@@ -1,0 +1,4 @@
+import { defineService } from '@chaitin-ai/octobus-sdk';
+import { handlers } from './aliyun-ddoscoo-20200101.js';
+export { handlers } from './aliyun-ddoscoo-20200101.js';
+export const service = defineService({ handlers });

--- a/services/aliyun__ddoscoo_20200101/test/aliyun-ddoscoo-20200101.test.js
+++ b/services/aliyun__ddoscoo_20200101/test/aliyun-ddoscoo-20200101.test.js
@@ -1,0 +1,561 @@
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { GrpcError, grpcStatus } from '@chaitin-ai/octobus-sdk';
+import { handlers, rpcdef, _test } from '../src/aliyun-ddoscoo-20200101.js';
+import { createMockServer } from './mock_upstream.js';
+
+// --------------- Helpers ---------------
+
+function buildCtx(overrides = {}) {
+  return {
+    config: {},
+    secret: {},
+    bindings: {},
+    limits: {},
+    meta: new Map(),
+    req: {},
+    getMetadata: (name) => undefined,
+    getMetadataAll: (name) => [],
+    ...overrides,
+  };
+}
+
+function expectGrpcError(fn, legacyCode, checker) {
+  return fn().then(
+    () => { throw new Error(`Expected GrpcError(${legacyCode}) but no error was thrown`); },
+    (err) => {
+      assert.ok(err instanceof GrpcError, `Expected GrpcError but got ${err?.constructor?.name}`);
+      assert.equal(err.legacyCode, legacyCode);
+      if (checker) checker(err);
+    },
+  );
+}
+
+function parseStructuredError(err) {
+  try { return JSON.parse(err.message); } catch { return null; }
+}
+
+// --------------- Tests ---------------
+
+describe('aliyun-ddoscoo-20200101', () => {
+  // ====== Service Structure ======
+
+  it('exports handlers for all 6 RPCs', () => {
+    const names = Object.keys(handlers);
+    assert.equal(names.length, 6);
+    for (const name of names) {
+      assert.match(name, /^Aliyun_DDoSCOO_20200101\.DDoSCOOService\//);
+      assert.equal(typeof handlers[name], 'function');
+    }
+  });
+
+  it('rpcdef returns all 6 paths', () => {
+    const ctx = buildCtx();
+    const def = rpcdef(ctx);
+    const paths = Object.keys(def);
+    assert.equal(paths.length, 6);
+    for (const path of paths) {
+      assert.match(path, /^\/Aliyun_DDoSCOO_20200101\.DDoSCOOService\//);
+      assert.equal(typeof def[path], 'function');
+    }
+  });
+
+  // ====== Authentication Errors ======
+
+  it('throws UNAUTHENTICATED when accessKeyId is missing', async () => {
+    const ctx = buildCtx({
+      secret: { accessKeySecret: 'test-secret' },
+    });
+    await expectGrpcError(
+      () => handlers[_test.METHOD_DESCRIBE_INSTANCES_FULL]({ pageNumber: '1', pageSize: '10' }, ctx),
+      'INVALID_ARGUMENT',
+      (err) => {
+        const se = parseStructuredError(err);
+        assert.match(se.message, /accessKeyId/);
+      },
+    );
+  });
+
+  it('throws UNAUTHENTICATED when accessKeySecret is missing', async () => {
+    const ctx = buildCtx({
+      secret: { accessKeyId: 'test-id' },
+    });
+    await expectGrpcError(
+      () => handlers[_test.METHOD_DESCRIBE_INSTANCES_FULL]({ pageNumber: '1', pageSize: '10' }, ctx),
+      'INVALID_ARGUMENT',
+      (err) => {
+        const se = parseStructuredError(err);
+        assert.match(se.message, /accessKeySecret/);
+      },
+    );
+  });
+
+  // ====== Signature Computation ======
+
+  it('buildSignedParams produces valid signature structure', () => {
+    const params = _test.buildSignedParams(
+      'DescribeInstances',
+      { PageNumber: '1', PageSize: '10' },
+      'test-id',
+      'test-secret',
+    );
+    assert.ok(params.has('AccessKeyId'));
+    assert.equal(params.get('AccessKeyId'), 'test-id');
+    assert.ok(params.has('Action'));
+    assert.equal(params.get('Action'), 'DescribeInstances');
+    assert.ok(params.has('Signature'));
+    assert.ok(params.has('SignatureNonce'));
+    assert.ok(params.has('Timestamp'));
+    assert.ok(params.has('SignatureMethod'));
+    assert.equal(params.get('SignatureMethod'), 'HMAC-SHA1');
+    assert.ok(params.has('SignatureVersion'));
+    assert.equal(params.get('SignatureVersion'), '1.0');
+    assert.ok(params.has('Version'));
+    assert.equal(params.get('Version'), '2020-01-01');
+    assert.ok(params.has('Format'));
+    assert.equal(params.get('Format'), 'JSON');
+    // Business params
+    assert.ok(params.has('PageNumber'));
+    assert.ok(params.has('PageSize'));
+  });
+
+  it('aliyunPercentEncode handles special characters', () => {
+    assert.equal(_test.aliyunPercentEncode('abc'), 'abc');
+    assert.equal(_test.aliyunPercentEncode('/'), '%2F');
+    assert.equal(_test.aliyunPercentEncode(' '), '%20');
+    assert.equal(_test.aliyunPercentEncode('='), '%3D');
+    assert.equal(_test.aliyunPercentEncode('&'), '%26');
+    assert.equal(_test.aliyunPercentEncode('*'), '%2A');
+  });
+
+  // ====== Error Mapping ======
+
+  it('grpcCodeFor maps all known codes', () => {
+    assert.equal(_test.grpcCodeFor('FAILED_PRECONDITION'), grpcStatus.FAILED_PRECONDITION);
+    assert.equal(_test.grpcCodeFor('INVALID_ARGUMENT'), grpcStatus.INVALID_ARGUMENT);
+    assert.equal(_test.grpcCodeFor('UNAUTHENTICATED'), grpcStatus.UNAUTHENTICATED);
+    assert.equal(_test.grpcCodeFor('PERMISSION_DENIED'), grpcStatus.PERMISSION_DENIED);
+    assert.equal(_test.grpcCodeFor('NOT_FOUND'), grpcStatus.NOT_FOUND);
+    assert.equal(_test.grpcCodeFor('UNAVAILABLE'), grpcStatus.UNAVAILABLE);
+    assert.equal(_test.grpcCodeFor('INTERNAL'), grpcStatus.INTERNAL);
+    assert.equal(_test.grpcCodeFor('UNKNOWN'), grpcStatus.INTERNAL);
+  });
+
+  it('mapAliyunErrorCode maps known codes correctly', () => {
+    assert.equal(_test.mapAliyunErrorCode('InvalidAccessKeyId.NotFound'), 'UNAUTHENTICATED');
+    assert.equal(_test.mapAliyunErrorCode('SignatureDoesNotMatch'), 'UNAUTHENTICATED');
+    assert.equal(_test.mapAliyunErrorCode('Forbidden.NotAdminUser'), 'PERMISSION_DENIED');
+    assert.equal(_test.mapAliyunErrorCode('InvalidParameter'), 'INVALID_ARGUMENT');
+    assert.equal(_test.mapAliyunErrorCode('MissingParameter'), 'INVALID_ARGUMENT');
+    assert.equal(_test.mapAliyunErrorCode('EntityNotFound'), 'NOT_FOUND');
+    assert.equal(_test.mapAliyunErrorCode('Throttling.User'), 'UNAVAILABLE');
+    assert.equal(_test.mapAliyunErrorCode('SomeRandomError'), 'FAILED_PRECONDITION');
+  });
+
+  // ====== Request Mapping ======
+
+  it('mapDescribeInstancesReq maps all fields', () => {
+    const result = _test.mapDescribeInstancesReq({
+      pageNumber: '1',
+      pageSize: '10',
+      instanceIds: ['inst-1'],
+      ip: '1.2.3.4',
+      remark: 'test',
+      status: [1],
+      edition: 1,
+      enabled: 1,
+      expireStartTime: 1609459200,
+      expireEndTime: 1735689600,
+      resourceGroupId: 'rg-1',
+      tagKey: 'env',
+      tagValue: 'prod',
+    });
+    assert.equal(result.PageNumber, '1');
+    assert.equal(result.PageSize, '10');
+    assert.deepEqual(result.InstanceIds, ['inst-1']);
+    assert.equal(result.Ip, '1.2.3.4');
+    assert.equal(result.Remark, 'test');
+    assert.deepEqual(result.Status, [1]);
+    assert.equal(result.Edition, 1);
+    assert.equal(result.Enabled, 1);
+    assert.equal(result.ExpireStartTime, 1609459200);
+    assert.equal(result.ExpireEndTime, 1735689600);
+    assert.equal(result.ResourceGroupId, 'rg-1');
+    assert.deepEqual(result.Tag, [{ Key: 'env', Value: 'prod' }]);
+  });
+
+  it('mapDescribeInstancesReq skips empty/undefined values', () => {
+    const result = _test.mapDescribeInstancesReq({
+      pageNumber: '1',
+      pageSize: '10',
+    });
+    assert.equal(result.PageNumber, '1');
+    assert.equal(result.PageSize, '10');
+    assert.equal(result.InstanceIds, undefined);
+    assert.equal(result.Ip, undefined);
+  });
+
+  it('mapDescribeDomainResourceReq maps fields', () => {
+    const result = _test.mapDescribeDomainResourceReq({
+      domain: 'example.com',
+      pageNumber: '1',
+      pageSize: '20',
+      instanceIds: ['inst-1'],
+      queryDomainPattern: '*.example.com',
+    });
+    assert.equal(result.Domain, 'example.com');
+    assert.equal(result.PageNumber, '1');
+    assert.equal(result.QueryDomainPattern, '*.example.com');
+  });
+
+  it('mapEnableWebCCReq requires domain', () => {
+    const result = _test.mapEnableWebCCReq({
+      domain: 'example.com',
+      resourceGroupId: 'rg-1',
+    });
+    assert.equal(result.Domain, 'example.com');
+    assert.equal(result.ResourceGroupId, 'rg-1');
+  });
+
+  it('mapConfigWebCCTemplateReq requires domain and template', () => {
+    const result = _test.mapConfigWebCCTemplateReq({
+      domain: 'example.com',
+      template: 'default',
+    });
+    assert.equal(result.Domain, 'example.com');
+    assert.equal(result.Template, 'default');
+  });
+
+  // ====== Config/Secret Resolution ======
+
+  it('resolveRegionId uses default when not provided', () => {
+    const ctx = buildCtx({ config: {} });
+    assert.equal(_test.resolveRegionId(ctx), 'cn-hangzhou');
+  });
+
+  it('resolveRegionId reads from config', () => {
+    const ctx = buildCtx({ config: { regionId: 'cn-shanghai' } });
+    assert.equal(_test.resolveRegionId(ctx), 'cn-shanghai');
+  });
+
+  it('resolveTimeoutMs uses default when not provided', () => {
+    const ctx = buildCtx({ config: {} });
+    assert.equal(_test.resolveTimeoutMs(ctx), 10000);
+  });
+
+  it('resolveTimeoutMs reads from config', () => {
+    const ctx = buildCtx({ config: { timeoutMs: 5000 } });
+    assert.equal(_test.resolveTimeoutMs(ctx), 5000);
+  });
+
+  // ====== JSON Helpers ======
+
+  it('tryParseJson parses valid JSON', () => {
+    const result = _test.tryParseJson('{"a":1}');
+    assert.ok(result.ok);
+    assert.deepEqual(result.value, { a: 1 });
+  });
+
+  it('tryParseJson handles invalid JSON', () => {
+    const result = _test.tryParseJson('not json');
+    assert.equal(result.ok, false);
+  });
+
+  it('toValue converts primitives', () => {
+    assert.deepEqual(_test.toValue('hello'), { stringValue: 'hello' });
+    assert.deepEqual(_test.toValue(42), { numberValue: 42 });
+    assert.deepEqual(_test.toValue(true), { boolValue: true });
+    assert.deepEqual(_test.toValue(null), { nullValue: 0 });
+  });
+
+  it('toValue converts arrays', () => {
+    const result = _test.toValue([1, 'two']);
+    assert.ok(result.listValue);
+    assert.equal(result.listValue.values.length, 2);
+  });
+
+  it('toValue converts objects', () => {
+    const result = _test.toValue({ key: 'value' });
+    assert.ok(result.structValue);
+    assert.equal(result.structValue.fields.key.stringValue, 'value');
+  });
+
+  it('unwrapScalar extracts values', () => {
+    assert.equal(_test.unwrapScalar({ stringValue: 'foo' }), 'foo');
+    assert.equal(_test.unwrapScalar({ numberValue: 42 }), 42);
+    assert.equal(_test.unwrapScalar({ boolValue: true }), true);
+    assert.equal(_test.unwrapScalar('plain'), 'plain');
+  });
+
+  it('firstDefined returns first non-null value', () => {
+    assert.equal(_test.firstDefined(undefined, null, 'val', 'other'), 'val');
+    assert.equal(_test.firstDefined(undefined, undefined), undefined);
+    assert.equal(_test.firstDefined(null, null, 0), 0);
+  });
+
+  // ====== Handler Success (with mocked fetch) ======
+
+  describe('handlers with mocked fetch', () => {
+    let originalFetch;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    function mockFetch(responseBody, status = 200, contentType = 'application/json') {
+      globalThis.fetch = async (url, init) => {
+        return {
+          ok: status >= 200 && status < 300,
+          status,
+          text: async () => typeof responseBody === 'string' ? responseBody : JSON.stringify(responseBody),
+          json: async () => typeof responseBody === 'string' ? JSON.parse(responseBody) : responseBody,
+        };
+      };
+    }
+
+    it('DescribeInstances returns success response', async () => {
+      mockFetch({
+        Instances: [{ InstanceId: 'ddos-1', Ip: '1.2.3.4', Status: 1 }],
+        TotalCount: 1,
+        RequestId: 'req-001',
+      });
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      const result = await handlers[_test.METHOD_DESCRIBE_INSTANCES_FULL](
+        { pageNumber: '1', pageSize: '10' },
+        ctx,
+      );
+      assert.equal(result.httpStatus, 200);
+      assert.ok(result.rawJson.structValue);
+    });
+
+    it('DescribeDomainResource returns success response', async () => {
+      mockFetch({
+        WebRules: [{ Domain: 'example.com', Cname: 'cname.example.com' }],
+        TotalCount: 1,
+        RequestId: 'req-002',
+      });
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      const result = await handlers[_test.METHOD_DESCRIBE_DOMAIN_RESOURCE_FULL](
+        { domain: 'example.com' },
+        ctx,
+      );
+      assert.equal(result.httpStatus, 200);
+      assert.ok(result.rawJson.structValue);
+    });
+
+    it('DescribeNetworkRules returns success response', async () => {
+      mockFetch({
+        NetworkRules: [{ InstanceId: 'ddos-1', Protocol: 'tcp', FrontendPort: 443 }],
+        TotalCount: 1,
+        RequestId: 'req-003',
+      });
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      const result = await handlers[_test.METHOD_DESCRIBE_NETWORK_RULES_FULL](
+        { instanceId: 'ddos-1' },
+        ctx,
+      );
+      assert.equal(result.httpStatus, 200);
+      assert.ok(result.rawJson.structValue);
+    });
+
+    it('DescribeDDosAllEventList returns success response', async () => {
+      mockFetch({
+        AttackEvents: [{ EventType: 'defense', Ip: '1.2.3.4', StartTime: 1700000000 }],
+        TotalCount: 1,
+        RequestId: 'req-004',
+      });
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      const result = await handlers[_test.METHOD_DESCRIBE_DDOS_ALL_EVENT_LIST_FULL](
+        { startTime: 1700000000, endTime: 1700086400 },
+        ctx,
+      );
+      assert.equal(result.httpStatus, 200);
+      assert.ok(result.rawJson.structValue);
+    });
+
+    it('EnableWebCC returns success response', async () => {
+      mockFetch({ RequestId: 'req-005' });
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      const result = await handlers[_test.METHOD_ENABLE_WEB_CC_FULL](
+        { domain: 'example.com' },
+        ctx,
+      );
+      assert.equal(result.httpStatus, 200);
+    });
+
+    it('ConfigWebCCTemplate returns success response', async () => {
+      mockFetch({ RequestId: 'req-006' });
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      const result = await handlers[_test.METHOD_CONFIG_WEB_CC_TEMPLATE_FULL](
+        { domain: 'example.com', template: 'default' },
+        ctx,
+      );
+      assert.equal(result.httpStatus, 200);
+    });
+
+    // ====== Error Cases ======
+
+    it('maps HTTP 401 to PERMISSION_DENIED', async () => {
+      mockFetch({ Code: 'InvalidAccessKeyId.NotFound', Message: 'Key not found' }, 401);
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'bad-id', accessKeySecret: 'test-secret' },
+      });
+      await expectGrpcError(
+        () => handlers[_test.METHOD_DESCRIBE_INSTANCES_FULL]({ pageNumber: '1', pageSize: '10' }, ctx),
+        'PERMISSION_DENIED',
+        (err) => {
+          const se = parseStructuredError(err);
+          assert.match(se.message, /Key not found/);
+        },
+      );
+    });
+
+    it('maps HTTP 403 to PERMISSION_DENIED', async () => {
+      mockFetch({ Code: 'Forbidden', Message: 'Access denied' }, 403);
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      await expectGrpcError(
+        () => handlers[_test.METHOD_DESCRIBE_INSTANCES_FULL]({}, ctx),
+        'PERMISSION_DENIED',
+      );
+    });
+
+    it('maps HTTP 400 to FAILED_PRECONDITION', async () => {
+      mockFetch({ Code: 'InvalidParameter', Message: 'Bad param' }, 400);
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      await expectGrpcError(
+        () => handlers[_test.METHOD_DESCRIBE_INSTANCES_FULL]({}, ctx),
+        'FAILED_PRECONDITION',
+      );
+    });
+
+    it('maps HTTP 500 to UNAVAILABLE', async () => {
+      globalThis.fetch = async () => ({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      await expectGrpcError(
+        () => handlers[_test.METHOD_DESCRIBE_INSTANCES_FULL]({}, ctx),
+        'UNAVAILABLE',
+      );
+    });
+
+    it('maps non-JSON response to UNAVAILABLE', async () => {
+      mockFetch('not-json', 200, 'text/plain');
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      await expectGrpcError(
+        () => handlers[_test.METHOD_DESCRIBE_INSTANCES_FULL]({}, ctx),
+        'UNAVAILABLE',
+        (err) => {
+          const se = parseStructuredError(err);
+          assert.match(se.message, /non-JSON/);
+        },
+      );
+    });
+
+    it('maps API business error to INVALID_ARGUMENT', async () => {
+      mockFetch({ Code: 'MissingParameter.NotFound', Message: 'Parameter is missing', RequestId: 'req-err' });
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      await expectGrpcError(
+        () => handlers[_test.METHOD_DESCRIBE_INSTANCES_FULL]({}, ctx),
+        'INVALID_ARGUMENT',
+        (err) => {
+          const se = parseStructuredError(err);
+          assert.equal(se.response_code, 'MissingParameter.NotFound');
+        },
+      );
+    });
+
+    it('maps network error to UNAVAILABLE', async () => {
+      globalThis.fetch = async () => { throw new Error('ECONNREFUSED'); };
+
+      const ctx = buildCtx({
+        secret: { accessKeyId: 'test-id', accessKeySecret: 'test-secret' },
+      });
+      await expectGrpcError(
+        () => handlers[_test.METHOD_DESCRIBE_INSTANCES_FULL]({}, ctx),
+        'UNAVAILABLE',
+        (err) => {
+          const se = parseStructuredError(err);
+          assert.match(se.message, /ECONNREFUSED/);
+        },
+      );
+    });
+  });
+
+  // ====== Utilities ======
+
+  it('throwStructuredError includes all optional fields', () => {
+    try {
+      _test.throwStructuredError('UNAVAILABLE', 'test error', {
+        httpStatus: 500,
+        rawBody: 'body content',
+        rawJson: { key: 'value' },
+        reason: 'network timeout',
+        responseCode: 'Timeout',
+        verboseMsg: 'The request timed out',
+      });
+    } catch (err) {
+      const se = parseStructuredError(err);
+      assert.equal(se.code, 'UNAVAILABLE');
+      assert.equal(se.message, 'test error');
+      assert.equal(se.http_status, 500);
+      assert.equal(se.raw_body, 'body content');
+      assert.deepEqual(se.raw_json, { key: 'value' });
+      assert.equal(se.reason, 'network timeout');
+      assert.equal(se.response_code, 'Timeout');
+      assert.equal(se.verbose_msg, 'The request timed out');
+    }
+  });
+
+  it('toTrimmedString handles valid and invalid inputs', () => {
+    assert.equal(_test.toTrimmedString('  hello  '), 'hello');
+    assert.equal(_test.toTrimmedString(123), undefined);
+    assert.equal(_test.toTrimmedString(null), undefined);
+    assert.equal(_test.toTrimmedString(undefined), undefined);
+  });
+
+  it('buildUrl constructs regional endpoint', () => {
+    assert.equal(_test.buildUrl('cn-hangzhou'), 'https://ddoscoo.cn-hangzhou.aliyuncs.com/');
+    assert.equal(_test.buildUrl('cn-shanghai'), 'https://ddoscoo.cn-shanghai.aliyuncs.com/');
+  });
+});

--- a/services/aliyun__ddoscoo_20200101/test/mock_upstream.js
+++ b/services/aliyun__ddoscoo_20200101/test/mock_upstream.js
@@ -1,0 +1,243 @@
+import http from 'node:http';
+import { URL } from 'node:url';
+
+/**
+ * Creates a mock Alibaba Cloud OpenAPI endpoint on a random port.
+ *
+ * Trigger behavior (via action or parameter values):
+ *   - action "FailAuth"        → 401 with InvalidAccessKeyId error
+ *   - action "FailForbidden"   → 403 with Forbidden error
+ *   - action "FailServer"      → 500 Internal Server Error
+ *   - action "FailInvalidJson" → 200 with non-JSON body "not-json"
+ *   - action "FailBizError"    → 200 with Code: "MissingParameter.NotFound"
+ *   - param InstanceId "http500" → 500 for DescribeNetworkRules
+ *   - param Domain "http400"   → 400 for EnableWebCC
+ */
+export function createMockServer() {
+  const requests = [];
+
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ Code: 'MethodNotAllowed', Message: 'Only POST allowed' }));
+      return;
+    }
+
+    let body = '';
+    req.on('data', (chunk) => { body += chunk.toString(); });
+    req.on('end', () => {
+      const params = new URLSearchParams(body);
+      const action = params.get('Action') || '';
+      const accessKeyId = params.get('AccessKeyId') || '';
+      const signature = params.get('Signature') || '';
+      const timestamp = params.get('Timestamp') || '';
+      const instanceId = params.get('InstanceId') || '';
+      const domain = params.get('Domain') || '';
+
+      requests.push({ action, params: Object.fromEntries(params), timestamp });
+
+      // Missing auth
+      if (!accessKeyId || !signature) {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          Code: 'InvalidAccessKeyId.NotFound',
+          Message: 'Specified access key is not found.',
+          RequestId: 'MOCK-REQ-001',
+        }));
+        return;
+      }
+
+      // Trigger: FailAuth action
+      if (action === 'FailAuth') {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          Code: 'InvalidAccessKeyId.NotFound',
+          Message: 'Specified access key is not found.',
+          RequestId: 'MOCK-REQ-002',
+        }));
+        return;
+      }
+
+      // Trigger: FailForbidden action
+      if (action === 'FailForbidden') {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          Code: 'Forbidden.NotAdminUser',
+          Message: 'This operation is forbidden for your account.',
+          RequestId: 'MOCK-REQ-003',
+        }));
+        return;
+      }
+
+      // Trigger: FailServer action
+      if (action === 'FailServer') {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Internal Server Error');
+        return;
+      }
+
+      // Trigger: FailInvalidJson action
+      if (action === 'FailInvalidJson') {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('not-json');
+        return;
+      }
+
+      // Trigger: FailBizError action
+      if (action === 'FailBizError') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          Code: 'MissingParameter.NotFound',
+          Message: 'The required parameter is missing.',
+          RequestId: 'MOCK-REQ-004',
+        }));
+        return;
+      }
+
+      // Trigger: http500 via InstanceId parameter
+      if (instanceId === 'http500') {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Internal Server Error');
+        return;
+      }
+
+      // Trigger: http400 via Domain parameter
+      if (domain === 'http400') {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          Code: 'InvalidParameter',
+          Message: 'The parameter Domain is invalid.',
+          RequestId: 'MOCK-REQ-005',
+        }));
+        return;
+      }
+
+      // Success responses per action
+      switch (action) {
+        case 'DescribeInstances':
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            Instances: [
+              {
+                InstanceId: instanceId || 'ddoscoo-cn-abc123',
+                Ip: '1.2.3.4',
+                IpMode: 'fnat',
+                IpVersion: 'v4',
+                Status: 1,
+                Edition: 1,
+                Enabled: 1,
+                ExpireTime: 1735689600,
+                CreateTime: 1609459200,
+                Remark: 'test-instance',
+                DebtStatus: 0,
+              },
+            ],
+            TotalCount: 1,
+            RequestId: 'MOCK-REQ-100',
+          }));
+          break;
+
+        case 'DescribeDomainResource':
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            WebRules: [
+              {
+                Domain: domain || 'example.com',
+                Cname: 'example.com.alikunlun.com',
+                ProxyTypes: [{ ProxyType: 'http', ProxyPorts: [80] }],
+                RealServers: ['10.0.0.1'],
+                RsType: 0,
+                InstanceIds: ['ddoscoo-cn-abc123'],
+                PolicyMode: 'ip_hash',
+                CcEnabled: true,
+                CcTemplate: 'default',
+                CcRuleEnabled: false,
+                SslProtocols: 'TLSv1.2',
+                Ssl13Enabled: false,
+                Http2Enable: false,
+                Http2HttpsEnable: false,
+                Https2HttpEnable: false,
+                OcspEnabled: false,
+                WhiteList: [],
+                BlackList: [],
+                PunishStatus: false,
+                ProxyEnabled: true,
+              },
+            ],
+            TotalCount: 1,
+            RequestId: 'MOCK-REQ-101',
+          }));
+          break;
+
+        case 'DescribeNetworkRules':
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            NetworkRules: [
+              {
+                InstanceId: instanceId || 'ddoscoo-cn-abc123',
+                Protocol: 'tcp',
+                FrontendPort: 8080,
+                BackendPort: 80,
+                RealServers: ['10.0.0.1', '10.0.0.2'],
+              },
+            ],
+            TotalCount: 1,
+            RequestId: 'MOCK-REQ-102',
+          }));
+          break;
+
+        case 'DescribeDDosAllEventList':
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            AttackEvents: [
+              {
+                EventType: 'defense',
+                Ip: '1.2.3.4',
+                Area: 'cn-hangzhou',
+                StartTime: 1700000000,
+                EndTime: 1700003600,
+                Port: '80',
+                Mbps: 50000,
+                Pps: 10000000,
+              },
+            ],
+            TotalCount: 1,
+            RequestId: 'MOCK-REQ-103',
+          }));
+          break;
+
+        case 'EnableWebCC':
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ RequestId: 'MOCK-REQ-104' }));
+          break;
+
+        case 'ConfigWebCCTemplate':
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ RequestId: 'MOCK-REQ-105' }));
+          break;
+
+        default:
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            Code: 'InvalidAction.NotFound',
+            Message: `The specified action ${action} is not found.`,
+            RequestId: 'MOCK-REQ-999',
+          }));
+      }
+    });
+  });
+
+  server.listen(0);
+
+  return {
+    get url() {
+      return `http://localhost:${server.address().port}`;
+    },
+    get requests() {
+      return requests;
+    },
+    close() {
+      return new Promise((resolve) => server.close(resolve));
+    },
+  };
+}

--- a/services/aliyun__sas-vulnerability-management/README.md
+++ b/services/aliyun__sas-vulnerability-management/README.md
@@ -1,0 +1,174 @@
+# aliyun-sas-vulnerability-management
+
+Alibaba Cloud Security Center (SAS) Vulnerability Management service package.
+
+## 支持版本
+
+- **产品**: 阿里云安全中心 (Security Center / SAS)
+- **API 版本**: `2018-12-03`
+- **接入方式**: Alibaba Cloud OpenAPI (RPC, HMAC-SHA1 签名 V1)
+- **API 端点**: `tds.{regionId}.aliyuncs.com`（中国区默认 `cn-shanghai`）
+
+## 配置示例
+
+```json
+{
+  "regionId": "cn-shanghai",
+  "timeoutMs": 10000
+}
+```
+
+```json
+{
+  "accessKeyId": "<your-access-key-id>",
+  "accessKeySecret": "<your-access-key-secret>"
+}
+```
+
+## 导入
+
+```bash
+octobus service import --id aliyun-sas ./services/aliyun__sas-vulnerability-management
+```
+
+## 方法说明
+
+### 漏洞查询（4 个）
+
+| RPC Method | CLI Command | 描述 |
+|------------|-------------|------|
+| `DescribeVulList` | `describe-vul-list` | 分页查询漏洞列表，支持按类型/等级/处理状态过滤 |
+| `DescribeVulDetails` | `describe-vul-details` | 查询指定漏洞的详细信息（CVE、修复建议） |
+| `DescribeUuidsByVulNames` | `describe-uuids-by-vul-names` | 根据漏洞名称查询受影响服务器 UUID |
+| `DescribeCanFixVulList` | `describe-can-fix-vul-list` | 查询可修复的漏洞列表 |
+
+### 漏洞操作（2 个）
+
+| RPC Method | CLI Command | 描述 | 幂等 |
+|------------|-------------|------|:--:|
+| `ModifyOperateVul` | `modify-operate-vul` | 处理漏洞（修复/验证/忽略/取消忽略），oeprateType=`vul_fix\|verify\|ignore\|cancel_ignore` | ✅ |
+| `OperateVuls` | `operate-vuls` | 批量修复 Linux 软件漏洞 | ✅ |
+
+### 统计（2 个）
+
+| RPC Method | CLI Command | 描述 |
+|------------|-------------|------|
+| `DescribeVulNumStatistics` | `describe-vul-num-statistics` | 漏洞数量统计（按严重等级和类型） |
+| `DescribeVulFixStatistics` | `describe-vul-fix-statistics` | 漏洞修复统计 |
+
+### 白名单（3 个）
+
+| RPC Method | CLI Command | 描述 | 幂等 |
+|------------|-------------|------|:--:|
+| `DescribeVulWhitelist` | `describe-vul-whitelist` | 分页查询漏洞白名单 | — |
+| `ModifyCreateVulWhitelist` | `modify-create-vul-whitelist` | 添加漏洞到白名单（不再告警） | ❌ 重复添加会创建多条 |
+| `DeleteVulWhitelist` | `delete-vul-whitelist` | 按 ID 删除白名单条目 | ✅ |
+
+### 应急漏洞（1 个）
+
+| RPC Method | CLI Command | 描述 |
+|------------|-------------|------|
+| `DescribeEmgVulItem` | `describe-emg-vul-item` | 查询应急漏洞详情 |
+
+## Config
+
+| 字段 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `regionId` | string | `cn-shanghai` | SAS API 区域（中国区均映射到 cn-shanghai） |
+| `timeoutMs` | integer | `10000` | HTTP 请求超时（毫秒） |
+
+## Secret
+
+| 字段 | 类型 | 必填 | 描述 |
+|------|------|:--:|------|
+| `accessKeyId` | string | ✅ | 阿里云 AccessKey ID |
+| `accessKeySecret` | string | ✅ | 阿里云 AccessKey Secret |
+
+## 错误映射
+
+| 阿里云错误码 | gRPC 状态 |
+|-------------|-----------|
+| `InvalidAccessKeyId.*`, `SignatureDoesNotMatch` | `UNAUTHENTICATED` |
+| `Forbidden.*` | `PERMISSION_DENIED` |
+| `Invalid*`, `Missing*` | `INVALID_ARGUMENT` |
+| `*NotFound*`, `*NotExist*` | `NOT_FOUND` |
+| `Throttling*`, `LimitExceeded*` | `UNAVAILABLE` |
+| HTTP 401/403 | `PERMISSION_DENIED` |
+| HTTP 4xx | `FAILED_PRECONDITION` |
+| HTTP 5xx | `UNAVAILABLE` |
+
+## 写操作说明
+
+### ModifyOperateVul
+- **描述**: 对单条或多条漏洞执行操作
+- **必填参数**: `type`（漏洞类型）、`operateType`（操作类型）、`info`（JSON 字符串，包含漏洞 ID 列表）
+- **幂等性**: ✅ 重复修复同一漏洞不会重复消耗配额
+- **回滚说明**: `ignore` 操作可通过 `cancel_ignore` 回滚；`vul_fix` 无法回滚
+- **审计字段**: RequestId（请求追踪）、operateType（操作类型）、info（操作对象）
+
+### OperateVuls
+- **描述**: 批量修复 Linux 软件漏洞（cve 类型）
+- **必填参数**: `type`、`operateType`、`uuids`（服务器 ID 列表）、`vulNames`（漏洞名称列表）
+- **幂等性**: ✅ 重复修复已修复的漏洞为 no-op
+- **回滚说明**: 修复操作不可回滚，建议先在测试环境验证
+- **审计字段**: RequestId、type、vulNames（漏洞范围）、uuids（目标服务器）
+
+### ModifyCreateVulWhitelist
+- **描述**: 添加漏洞到白名单，Security Center 不再告警
+- **必填参数**: `whitelist`（漏洞名称）、`reason`（加白原因）
+- **可选参数**: `targetInfo`（仅对特定服务器生效，JSON 格式）
+- **幂等性**: ❌ 重复调用会创建多条白名单记录
+- **回滚说明**: 使用 `DeleteVulWhitelist` 按 ID 删除对应条目
+- **审计字段**: RequestId、whitelist、reason
+
+### DeleteVulWhitelist
+- **描述**: 按 ID 列表删除白名单条目
+- **必填参数**: `idList`（白名单 ID 数组，可通过 DescribeVulWhitelist 获取）
+- **幂等性**: ✅ 删除已删除的条目无副作用
+- **回滚说明**: 删除后需重新调用 ModifyCreateVulWhitelist 添加
+
+## 风险说明
+
+**读取操作（低风险）**:
+- `Describe*` 方法仅查询数据，不会修改任何安全配置
+- API 调用频率受阿里云默认限流控制（通常 100次/秒）
+
+**写入操作（中风险）**:
+- `ModifyOperateVul` / `OperateVuls`: 修复操作会触发服务器上的补丁安装，可能导致服务重启
+- `ModifyCreateVulWhitelist`: 加白的漏洞不再告警，存在遗漏风险
+- `DeleteVulWhitelist`: 删除后对应漏洞恢复告警，可能造成告警噪音
+- 建议: 写入操作前先在控制台确认操作范围，批量操作建议分批次执行
+
+**认证凭据风险**:
+- AccessKey 需具备 SAS 权限（建议 `AliyunYundunSASReadOnlyAccess` 用于只读，`AliyunYundunSASFullAccess` 用于写入）
+- 生产环境建议使用 RAM 子账号，遵循最小权限原则
+
+## 建议 Capset
+
+### `read` — 只读查询
+```
+DescribeVulList, DescribeVulDetails, DescribeUuidsByVulNames, DescribeCanFixVulList,
+DescribeVulNumStatistics, DescribeVulFixStatistics, DescribeVulWhitelist, DescribeEmgVulItem
+```
+适用场景: SOC 分析、漏洞报表、态势感知
+
+### `write` — 漏洞处置
+```
+ModifyOperateVul, OperateVuls, ModifyCreateVulWhitelist, DeleteVulWhitelist
+```
+适用场景: 漏洞修复工单、白名单管理
+
+### `admin` — 完整权限
+```
+read + write 全部方法
+```
+
+## 测试
+
+```bash
+# 单元测试
+node --test test/
+
+# 真实 API 测试（需要 AKSK）
+ACCESS_KEY_ID=xxx ACCESS_KEY_SECRET=yyy SAS_REGION=cn-shanghai node test/test-live.js
+```

--- a/services/aliyun__sas-vulnerability-management/bin/aliyun-sas-vulnerability-management.js
+++ b/services/aliyun__sas-vulnerability-management/bin/aliyun-sas-vulnerability-management.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { runServiceMain } from '@chaitin-ai/octobus-sdk';
+import { service } from '../src/service.js';
+runServiceMain(service);

--- a/services/aliyun__sas-vulnerability-management/config.schema.json
+++ b/services/aliyun__sas-vulnerability-management/config.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "regionId": {
+      "type": "string",
+      "default": "cn-shanghai",
+      "description": "Alibaba Cloud region ID. SAS API uses tds.{regionId}.aliyuncs.com. Note: most China regions map to tds.cn-shanghai.aliyuncs.com."
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 10000,
+      "description": "HTTP request timeout in milliseconds"
+    }
+  }
+}

--- a/services/aliyun__sas-vulnerability-management/package.json
+++ b/services/aliyun__sas-vulnerability-management/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "aliyun-sas-vulnerability-management",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "aliyun-sas-vulnerability-management": "bin/aliyun-sas-vulnerability-management.js"
+  },
+  "dependencies": {
+    "@chaitin-ai/octobus-sdk": "^0.5.0"
+  }
+}

--- a/services/aliyun__sas-vulnerability-management/proto/aliyun_sas-vulnerability-management.proto
+++ b/services/aliyun__sas-vulnerability-management/proto/aliyun_sas-vulnerability-management.proto
@@ -1,0 +1,175 @@
+syntax = "proto3";
+package Aliyun_SAS_Vulnerability_Management;
+option go_package = "miner/grpc-service/Aliyun_SAS_Vulnerability_Management";
+
+import "google/protobuf/struct.proto";
+
+service SASService {
+  rpc DescribeVulList(DescribeVulListRequest) returns (DescribeVulListResponse) {}
+  rpc DescribeVulDetails(DescribeVulDetailsRequest) returns (DescribeVulDetailsResponse) {}
+  rpc DescribeUuidsByVulNames(DescribeUuidsByVulNamesRequest) returns (DescribeUuidsByVulNamesResponse) {}
+  rpc DescribeCanFixVulList(DescribeCanFixVulListRequest) returns (DescribeCanFixVulListResponse) {}
+  rpc ModifyOperateVul(ModifyOperateVulRequest) returns (ModifyOperateVulResponse) {}
+  rpc OperateVuls(OperateVulsRequest) returns (OperateVulsResponse) {}
+  rpc DescribeVulNumStatistics(DescribeVulNumStatisticsRequest) returns (DescribeVulNumStatisticsResponse) {}
+  rpc DescribeVulFixStatistics(DescribeVulFixStatisticsRequest) returns (DescribeVulFixStatisticsResponse) {}
+  rpc DescribeVulWhitelist(DescribeVulWhitelistRequest) returns (DescribeVulWhitelistResponse) {}
+  rpc ModifyCreateVulWhitelist(ModifyCreateVulWhitelistRequest) returns (ModifyCreateVulWhitelistResponse) {}
+  rpc DeleteVulWhitelist(DeleteVulWhitelistRequest) returns (DeleteVulWhitelistResponse) {}
+  rpc DescribeEmgVulItem(DescribeEmgVulItemRequest) returns (DescribeEmgVulItemResponse) {}
+}
+
+// ---- DescribeVulList ----
+message DescribeVulListRequest {
+  string type = 1;
+  repeated string uuids = 2;
+  string alias_name = 3 [json_name = "aliasName"];
+  string dealed = 4;
+  string severity = 5;
+  string group_id = 6 [json_name = "groupId"];
+  int32 current_page = 7 [json_name = "currentPage"];
+  int32 page_size = 8 [json_name = "pageSize"];
+  string lang = 9;
+  string attach_types = 10 [json_name = "attachTypes"];
+  string ids = 11;
+  int64 create_ts_start = 12 [json_name = "createTsStart"];
+  int64 create_ts_end = 13 [json_name = "createTsEnd"];
+}
+message DescribeVulListResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+// ---- DescribeVulDetails ----
+message DescribeVulDetailsRequest {
+  string type = 1;
+  string name = 2;
+  string alias_name = 3 [json_name = "aliasName"];
+  string lang = 4;
+}
+message DescribeVulDetailsResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+// ---- DescribeUuidsByVulNames ----
+message DescribeUuidsByVulNamesRequest {
+  string type = 1;
+  repeated string vul_names = 2 [json_name = "vulNames"];
+  string lang = 3;
+}
+message DescribeUuidsByVulNamesResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+// ---- DescribeCanFixVulList ----
+message DescribeCanFixVulListRequest {
+  string type = 1;
+  repeated string uuids = 2;
+  string alias_name = 3 [json_name = "aliasName"];
+  string dealed = 4;
+  repeated string status_list = 5 [json_name = "statusList"];
+  int32 current_page = 6 [json_name = "currentPage"];
+  int32 page_size = 7 [json_name = "pageSize"];
+  string lang = 8;
+}
+message DescribeCanFixVulListResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+// ---- ModifyOperateVul ----
+message ModifyOperateVulRequest {
+  string type = 1;
+  string operate_type = 2 [json_name = "operateType"];
+  string info = 3;
+}
+message ModifyOperateVulResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+// ---- OperateVuls ----
+message OperateVulsRequest {
+  repeated string uuids = 1;
+  string type = 2;
+  string operate_type = 3 [json_name = "operateType"];
+  repeated string vul_names = 4 [json_name = "vulNames"];
+}
+message OperateVulsResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+// ---- DescribeVulNumStatistics ----
+message DescribeVulNumStatisticsRequest {
+  string type = 1;
+  string resource_directory_account_id = 2 [json_name = "resourceDirectoryAccountId"];
+}
+message DescribeVulNumStatisticsResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+// ---- DescribeVulFixStatistics ----
+message DescribeVulFixStatisticsRequest {
+}
+message DescribeVulFixStatisticsResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+// ---- DescribeVulWhitelist ----
+message DescribeVulWhitelistRequest {
+  int32 current_page = 1 [json_name = "currentPage"];
+  int32 page_size = 2 [json_name = "pageSize"];
+}
+message DescribeVulWhitelistResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+// ---- ModifyCreateVulWhitelist ----
+message ModifyCreateVulWhitelistRequest {
+  string whitelist = 1;
+  string reason = 2;
+  string target_info = 3 [json_name = "targetInfo"];
+}
+message ModifyCreateVulWhitelistResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+// ---- DeleteVulWhitelist ----
+message DeleteVulWhitelistRequest {
+  repeated string id_list = 1 [json_name = "idList"];
+}
+message DeleteVulWhitelistResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}
+
+// ---- DescribeEmgVulItem ----
+message DescribeEmgVulItemRequest {
+  string scan_type = 1 [json_name = "scanType"];
+  string lang = 2;
+  int32 current_page = 3 [json_name = "currentPage"];
+  int32 page_size = 4 [json_name = "pageSize"];
+}
+message DescribeEmgVulItemResponse {
+  int32 http_status = 1 [json_name = "httpStatus"];
+  string raw_body = 2 [json_name = "rawBody"];
+  google.protobuf.Value raw_json = 3 [json_name = "rawJson"];
+}

--- a/services/aliyun__sas-vulnerability-management/secret.schema.json
+++ b/services/aliyun__sas-vulnerability-management/secret.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["accessKeyId", "accessKeySecret"],
+  "properties": {
+    "accessKeyId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Alibaba Cloud AccessKey ID (also available via ALIBABA_CLOUD_ACCESS_KEY_ID env var)"
+    },
+    "accessKeySecret": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Alibaba Cloud AccessKey Secret (also available via ALIBABA_CLOUD_ACCESS_KEY_SECRET env var)"
+    }
+  }
+}

--- a/services/aliyun__sas-vulnerability-management/service.json
+++ b/services/aliyun__sas-vulnerability-management/service.json
@@ -1,0 +1,69 @@
+{
+  "schema": "chaitin.octobus.service.v1",
+  "name": "aliyun-sas-vulnerability-management",
+  "displayName": "Alibaba Cloud SAS Vulnerability Management (2018-12-03)",
+  "description": "OctoBus package for Alibaba Cloud Security Center (SAS) API v2018-12-03. Covers vulnerability management: query vul list/details, fix operations, statistics, whitelist management, and emergency vulnerabilities.",
+  "runtime": {
+    "mode": "on-demand"
+  },
+  "proto": {
+    "roots": ["proto"],
+    "files": ["proto/aliyun_sas-vulnerability-management.proto"]
+  },
+  "configSchema": "config.schema.json",
+  "secretSchema": "secret.schema.json",
+  "sdk": {
+    "cli": {
+      "commands": {
+        "Aliyun_SAS_Vulnerability_Management.SASService/DescribeVulList": {
+          "name": "describe-vul-list",
+          "description": "Query vulnerability list with filters (type, severity, status, etc.)"
+        },
+        "Aliyun_SAS_Vulnerability_Management.SASService/DescribeVulDetails": {
+          "name": "describe-vul-details",
+          "description": "Query vulnerability details by name and type"
+        },
+        "Aliyun_SAS_Vulnerability_Management.SASService/DescribeUuidsByVulNames": {
+          "name": "describe-uuids-by-vul-names",
+          "description": "Query affected server UUIDs by vulnerability names"
+        },
+        "Aliyun_SAS_Vulnerability_Management.SASService/DescribeCanFixVulList": {
+          "name": "describe-can-fix-vul-list",
+          "description": "Query fixable vulnerability list"
+        },
+        "Aliyun_SAS_Vulnerability_Management.SASService/ModifyOperateVul": {
+          "name": "modify-operate-vul",
+          "description": "Handle vulnerabilities (fix, verify, ignore, unignore)"
+        },
+        "Aliyun_SAS_Vulnerability_Management.SASService/OperateVuls": {
+          "name": "operate-vuls",
+          "description": "Batch fix Linux software vulnerabilities"
+        },
+        "Aliyun_SAS_Vulnerability_Management.SASService/DescribeVulNumStatistics": {
+          "name": "describe-vul-num-statistics",
+          "description": "Get vulnerability count statistics by severity and type"
+        },
+        "Aliyun_SAS_Vulnerability_Management.SASService/DescribeVulFixStatistics": {
+          "name": "describe-vul-fix-statistics",
+          "description": "Query vulnerability fix statistics"
+        },
+        "Aliyun_SAS_Vulnerability_Management.SASService/DescribeVulWhitelist": {
+          "name": "describe-vul-whitelist",
+          "description": "Query vulnerability whitelist with pagination"
+        },
+        "Aliyun_SAS_Vulnerability_Management.SASService/ModifyCreateVulWhitelist": {
+          "name": "modify-create-vul-whitelist",
+          "description": "Add vulnerability to whitelist"
+        },
+        "Aliyun_SAS_Vulnerability_Management.SASService/DeleteVulWhitelist": {
+          "name": "delete-vul-whitelist",
+          "description": "Delete vulnerability whitelist entries"
+        },
+        "Aliyun_SAS_Vulnerability_Management.SASService/DescribeEmgVulItem": {
+          "name": "describe-emg-vul-item",
+          "description": "Query emergency vulnerability details"
+        }
+      }
+    }
+  }
+}

--- a/services/aliyun__sas-vulnerability-management/src/aliyun-sas-vulnerability-management.js
+++ b/services/aliyun__sas-vulnerability-management/src/aliyun-sas-vulnerability-management.js
@@ -1,0 +1,626 @@
+import crypto from 'node:crypto';
+import {
+  GrpcError,
+  grpcStatus,
+} from '@chaitin-ai/octobus-sdk';
+
+// --------------- Method constants ---------------
+const PKG = 'Aliyun_SAS_Vulnerability_Management';
+const SVC = 'SASService';
+const METHOD = (name) => `${PKG}.${SVC}/${name}`;
+
+const METHOD_DESCRIBE_VUL_LIST_PATH = `/${METHOD('DescribeVulList')}`;
+const METHOD_DESCRIBE_VUL_DETAILS_PATH = `/${METHOD('DescribeVulDetails')}`;
+const METHOD_DESCRIBE_UUIDS_BY_VUL_NAMES_PATH = `/${METHOD('DescribeUuidsByVulNames')}`;
+const METHOD_DESCRIBE_CAN_FIX_VUL_LIST_PATH = `/${METHOD('DescribeCanFixVulList')}`;
+const METHOD_MODIFY_OPERATE_VUL_PATH = `/${METHOD('ModifyOperateVul')}`;
+const METHOD_OPERATE_VULS_PATH = `/${METHOD('OperateVuls')}`;
+const METHOD_DESCRIBE_VUL_NUM_STATISTICS_PATH = `/${METHOD('DescribeVulNumStatistics')}`;
+const METHOD_DESCRIBE_VUL_FIX_STATISTICS_PATH = `/${METHOD('DescribeVulFixStatistics')}`;
+const METHOD_DESCRIBE_VUL_WHITELIST_PATH = `/${METHOD('DescribeVulWhitelist')}`;
+const METHOD_MODIFY_CREATE_VUL_WHITELIST_PATH = `/${METHOD('ModifyCreateVulWhitelist')}`;
+const METHOD_DELETE_VUL_WHITELIST_PATH = `/${METHOD('DeleteVulWhitelist')}`;
+const METHOD_DESCRIBE_EMG_VUL_ITEM_PATH = `/${METHOD('DescribeEmgVulItem')}`;
+
+const METHOD_DESCRIBE_VUL_LIST_FULL = METHOD('DescribeVulList');
+const METHOD_DESCRIBE_VUL_DETAILS_FULL = METHOD('DescribeVulDetails');
+const METHOD_DESCRIBE_UUIDS_BY_VUL_NAMES_FULL = METHOD('DescribeUuidsByVulNames');
+const METHOD_DESCRIBE_CAN_FIX_VUL_LIST_FULL = METHOD('DescribeCanFixVulList');
+const METHOD_MODIFY_OPERATE_VUL_FULL = METHOD('ModifyOperateVul');
+const METHOD_OPERATE_VULS_FULL = METHOD('OperateVuls');
+const METHOD_DESCRIBE_VUL_NUM_STATISTICS_FULL = METHOD('DescribeVulNumStatistics');
+const METHOD_DESCRIBE_VUL_FIX_STATISTICS_FULL = METHOD('DescribeVulFixStatistics');
+const METHOD_DESCRIBE_VUL_WHITELIST_FULL = METHOD('DescribeVulWhitelist');
+const METHOD_MODIFY_CREATE_VUL_WHITELIST_FULL = METHOD('ModifyCreateVulWhitelist');
+const METHOD_DELETE_VUL_WHITELIST_FULL = METHOD('DeleteVulWhitelist');
+const METHOD_DESCRIBE_EMG_VUL_ITEM_FULL = METHOD('DescribeEmgVulItem');
+
+// --------------- Defaults ---------------
+const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_REGION = 'cn-shanghai';
+const API_VERSION = '2018-12-03';
+
+// --------------- Utilities ---------------
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+
+function toTrimmedString(value) {
+  if (typeof value === 'string') return value.trim();
+  return undefined;
+}
+
+// --------------- gRPC error helpers ---------------
+const GRPC_CODE_MAP = {
+  FAILED_PRECONDITION: grpcStatus.FAILED_PRECONDITION,
+  INVALID_ARGUMENT: grpcStatus.INVALID_ARGUMENT,
+  UNAUTHENTICATED: grpcStatus.UNAUTHENTICATED,
+  PERMISSION_DENIED: grpcStatus.PERMISSION_DENIED,
+  NOT_FOUND: grpcStatus.NOT_FOUND,
+  UNAVAILABLE: grpcStatus.UNAVAILABLE,
+  INTERNAL: grpcStatus.INTERNAL,
+};
+
+function grpcCodeFor(code) {
+  return GRPC_CODE_MAP[code] || grpcStatus.INTERNAL;
+}
+
+function errorWithCode(code, message) {
+  const e = new GrpcError(grpcCodeFor(code), message);
+  e.legacyCode = code;
+  return e;
+}
+
+function throwStructuredError(code, message, options = {}) {
+  const payload = { code, message };
+  if (hasOwn(options, 'httpStatus')) payload.http_status = options.httpStatus;
+  if (hasOwn(options, 'rawBody')) payload.raw_body = options.rawBody;
+  if (hasOwn(options, 'rawJson')) payload.raw_json = options.rawJson;
+  if (hasOwn(options, 'reason')) payload.reason = options.reason;
+  if (hasOwn(options, 'responseCode')) payload.response_code = options.responseCode;
+  throw errorWithCode(code, JSON.stringify(payload));
+}
+
+// --------------- Context resolution ---------------
+function resolveRegionId(ctx) {
+  const config = ctx.config ?? {};
+  return toTrimmedString(config.regionId) || DEFAULT_REGION;
+}
+
+function resolveAccessKeyId(ctx) {
+  const secret = ctx.secret ?? {};
+  const val = toTrimmedString(secret.accessKeyId);
+  if (!val) throwStructuredError('INVALID_ARGUMENT', 'accessKeyId is required in secret');
+  return val;
+}
+
+function resolveAccessKeySecret(ctx) {
+  const secret = ctx.secret ?? {};
+  const val = toTrimmedString(secret.accessKeySecret);
+  if (!val) throwStructuredError('INVALID_ARGUMENT', 'accessKeySecret is required in secret');
+  return val;
+}
+
+function resolveTimeoutMs(ctx) {
+  const config = ctx.config ?? {};
+  const ms = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  return Number.isFinite(ms) && ms > 0 ? ms : DEFAULT_TIMEOUT_MS;
+}
+
+// --------------- Alibaba Cloud OpenAPI signature V1 ---------------
+
+function aliyunPercentEncode(str) {
+  return encodeURIComponent(str)
+    .replace(/%7E/g, '~')
+    .replace(/\*/g, '%2A')
+    .replace(/%20/g, '%20')
+    .replace(/!/g, '%21')
+    .replace(/'/g, '%27')
+    .replace(/\(/g, '%28')
+    .replace(/\)/g, '%29')
+    .replace(/\+/g, '%2B');
+}
+
+function randomNonce() {
+  return crypto.randomUUID().replace(/-/g, '');
+}
+
+function iso8601Timestamp() {
+  const now = new Date();
+  const pad = (n) => String(n).padStart(2, '0');
+  return (
+    `${now.getUTCFullYear()}-${pad(now.getUTCMonth() + 1)}-${pad(now.getUTCDate())}T` +
+    `${pad(now.getUTCHours())}:${pad(now.getUTCMinutes())}:${pad(now.getUTCSeconds())}Z`
+  );
+}
+
+function buildSignedParams(action, businessParams, accessKeyId, accessKeySecret) {
+  const params = new Map();
+
+  // System params
+  params.set('AccessKeyId', accessKeyId);
+  params.set('Action', action);
+  params.set('Format', 'JSON');
+  params.set('SignatureMethod', 'HMAC-SHA1');
+  params.set('SignatureNonce', randomNonce());
+  params.set('SignatureVersion', '1.0');
+  params.set('Timestamp', iso8601Timestamp());
+  params.set('Version', API_VERSION);
+
+  // Business params
+  for (const [key, value] of Object.entries(businessParams)) {
+    if (value === undefined || value === null || value === '') continue;
+    if (Array.isArray(value)) {
+      value.forEach((item, i) => {
+        params.set(`${key}.${i + 1}`, String(item));
+      });
+    } else {
+      params.set(key, String(value));
+    }
+  }
+
+  // Sort by key
+  const sorted = [...params.entries()].sort(([a], [b]) => {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+  });
+
+  const canonicalQuery = sorted
+    .map(([k, v]) => `${aliyunPercentEncode(k)}=${aliyunPercentEncode(v)}`)
+    .join('&');
+
+  const stringToSign = `POST&${aliyunPercentEncode('/')}&${aliyunPercentEncode(canonicalQuery)}`;
+  const hmac = crypto.createHmac('sha1', `${accessKeySecret}&`);
+  hmac.update(stringToSign);
+  const signature = hmac.digest('base64');
+
+  params.set('Signature', signature);
+
+  return params;
+}
+
+// --------------- HTTP ---------------
+
+// --------------- SAS Endpoint Mapping ---------------
+// SAS API routes all China regions to tds.cn-shanghai.aliyuncs.com.
+// Reference: @alicloud/sas20181203 SDK endpointMap
+const SAS_ENDPOINT_MAP = {
+  'cn-qingdao': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-beijing': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-zhangjiakou': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-huhehaote': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-wulanchabu': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-hangzhou': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-shanghai': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-nanjing': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-fuzhou': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-shenzhen': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-heyuan': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-guangzhou': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-chengdu': 'tds.cn-shanghai.aliyuncs.com',
+  'cn-hongkong': 'tds.cn-hongkong.aliyuncs.com',
+  'ap-southeast-1': 'tds.ap-southeast-1.aliyuncs.com',
+  'ap-southeast-2': 'tds.ap-southeast-1.aliyuncs.com',
+  'ap-southeast-3': 'tds.ap-southeast-1.aliyuncs.com',
+  'ap-southeast-5': 'tds.ap-southeast-1.aliyuncs.com',
+  'ap-southeast-6': 'tds.ap-southeast-1.aliyuncs.com',
+  'ap-northeast-1': 'tds.ap-southeast-1.aliyuncs.com',
+  'ap-northeast-2': 'tds.ap-southeast-1.aliyuncs.com',
+  'us-east-1': 'tds.us-east-1.aliyuncs.com',
+  'us-west-1': 'tds.us-west-1.aliyuncs.com',
+  'eu-central-1': 'tds.eu-central-1.aliyuncs.com',
+  'eu-west-1': 'tds.eu-west-1.aliyuncs.com',
+  'me-east-1': 'tds.me-east-1.aliyuncs.com',
+  'ap-south-1': 'tds.ap-south-1.aliyuncs.com',
+};
+
+function buildUrl(regionId) {
+  const endpoint = SAS_ENDPOINT_MAP[regionId] || `tds.${regionId}.aliyuncs.com`;
+  return `https://${endpoint}/`;
+}
+
+async function callAliyunAPI(ctx, action, businessParams = {}) {
+  const regionId = resolveRegionId(ctx);
+  const accessKeyId = resolveAccessKeyId(ctx);
+  const accessKeySecret = resolveAccessKeySecret(ctx);
+  const timeoutMs = resolveTimeoutMs(ctx);
+
+  const baseUrl = buildUrl(regionId);
+  const params = buildSignedParams(action, businessParams, accessKeyId, accessKeySecret);
+  const body = new URLSearchParams();
+  for (const [k, v] of params) {
+    body.append(k, v);
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let resp;
+  try {
+    resp = await fetch(baseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    const cause = err.cause ? String(err.cause) : undefined;
+    throwStructuredError('UNAVAILABLE', `Request to Alibaba Cloud failed: ${err.message}`, {
+      reason: String(err),
+      cause,
+    });
+  }
+  clearTimeout(timer);
+
+  const rawBody = await resp.text();
+
+  if (!resp.ok) {
+    mapHttpError(resp.status, rawBody);
+  }
+
+  const parsed = tryParseJson(rawBody);
+  if (!parsed.ok) {
+    throwStructuredError('UNAVAILABLE', 'Alibaba Cloud returned non-JSON response', {
+      httpStatus: resp.status,
+      rawBody,
+    });
+  }
+
+  assertAliyunSuccess(parsed.value, resp.status, rawBody);
+
+  return {
+    httpStatus: resp.status,
+    rawBody,
+    rawJson: toValue(parsed.value),
+  };
+}
+
+function mapHttpError(statusCode, rawBody) {
+  let parsed;
+  try { parsed = JSON.parse(rawBody); } catch { parsed = null; }
+  const errMsg = parsed?.Message || parsed?.message || `HTTP ${statusCode}`;
+
+  if (statusCode === 401 || statusCode === 403) {
+    throwStructuredError('PERMISSION_DENIED', errMsg, {
+      httpStatus: statusCode, rawBody,
+      rawJson: parsed ? toValue(parsed) : undefined,
+    });
+  }
+  if (statusCode >= 400 && statusCode < 500) {
+    throwStructuredError('FAILED_PRECONDITION', errMsg, {
+      httpStatus: statusCode, rawBody,
+      rawJson: parsed ? toValue(parsed) : undefined,
+    });
+  }
+  throwStructuredError('UNAVAILABLE', errMsg, {
+    httpStatus: statusCode, rawBody,
+    rawJson: parsed ? toValue(parsed) : undefined,
+  });
+}
+
+function assertAliyunSuccess(json, statusCode, rawBody) {
+  if (json && (json.Code || json.code)) {
+    const code = json.Code || json.code;
+    const message = json.Message || json.message || 'Unknown error';
+    if (code !== '200' && code !== 'Success' && code !== 'OK') {
+      const gcode = mapAliyunErrorCode(code);
+      throwStructuredError(gcode, message, {
+        httpStatus: statusCode,
+        rawBody,
+        rawJson: toValue(json),
+        responseCode: code,
+      });
+    }
+  }
+}
+
+function mapAliyunErrorCode(aliCode) {
+  const code = String(aliCode);
+  if (code === 'InvalidAccessKeyId.NotFound' || code === 'InvalidAccessKeyId' ||
+      code === 'SignatureDoesNotMatch' || code === 'Forbidden.AccessKeyDisabled') {
+    return 'UNAUTHENTICATED';
+  }
+  if (code === 'Forbidden.NotAdminUser' || code === 'Forbidden.AccountInDebt' ||
+      code === 'Forbidden.AccountDebtOverdue') {
+    return 'PERMISSION_DENIED';
+  }
+  if (code.includes('InvalidParameter') || code.includes('Invalid') ||
+      code.includes('Missing') || code.includes('missing')) {
+    return 'INVALID_ARGUMENT';
+  }
+  if (code.includes('NotFound') || code.includes('notFound') || code.includes('NotExist')) {
+    return 'NOT_FOUND';
+  }
+  if (code.includes('Throttling') || code.includes('LimitExceeded') ||
+      code.includes('ServiceUnavailable')) {
+    return 'UNAVAILABLE';
+  }
+  return 'FAILED_PRECONDITION';
+}
+
+// --------------- JSON helpers ---------------
+
+function tryParseJson(text) {
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch {
+    return { ok: false, value: undefined };
+  }
+}
+
+function toValue(value) {
+  if (value === null) return { nullValue: 0 };
+  if (value === undefined) return { nullValue: 0 };
+  const t = typeof value;
+  if (t === 'string') return { stringValue: value };
+  if (t === 'number') return { numberValue: value };
+  if (t === 'boolean') return { boolValue: value };
+  if (Array.isArray(value)) {
+    return { listValue: { values: value.map(toValue) } };
+  }
+  if (t === 'object') {
+    const fields = {};
+    for (const [k, v] of Object.entries(value)) {
+      fields[k] = toValue(v);
+    }
+    return { structValue: { fields } };
+  }
+  return { stringValue: String(value) };
+}
+
+export function unwrapScalar(value) {
+  if (!value || typeof value !== 'object') return value;
+  if (hasOwn(value, 'stringValue')) return value.stringValue;
+  if (hasOwn(value, 'numberValue')) return value.numberValue;
+  if (hasOwn(value, 'boolValue')) return value.boolValue;
+  return value;
+}
+
+// --------------- Handlers ---------------
+
+function buildCallHandler(action, reqMapper) {
+  return async (ctx) => {
+    const req = ctx.request ?? {};
+    const businessParams = reqMapper ? reqMapper(req) : Object.fromEntries(
+      Object.entries(req).filter(([, v]) => v !== undefined && v !== null && v !== '' && (!Array.isArray(v) || v.length > 0))
+    );
+    return callAliyunAPI(ctx, action, businessParams);
+  };
+}
+
+// ---- DescribeVulList ----
+function mapDescribeVulListReq(req) {
+  const p = {};
+  if (req.type) p.Type = req.type;
+  if (req.uuids?.length) p.Uuids = req.uuids;
+  if (req.aliasName) p.AliasName = req.aliasName;
+  if (req.dealed) p.Dealed = req.dealed;
+  if (req.severity) p.Severity = req.severity;
+  if (req.groupId) p.GroupId = req.groupId;
+  if (req.currentPage) p.CurrentPage = req.currentPage;
+  if (req.pageSize) p.PageSize = req.pageSize;
+  if (req.lang) p.Lang = req.lang;
+  if (req.attachTypes) p.AttachTypes = req.attachTypes;
+  if (req.ids) p.Ids = req.ids;
+  if (req.createTsStart) p.CreateTsStart = req.createTsStart;
+  if (req.createTsEnd) p.CreateTsEnd = req.createTsEnd;
+  return p;
+}
+
+// ---- DescribeVulDetails ----
+function mapDescribeVulDetailsReq(req) {
+  const p = {};
+  if (req.type) p.Type = req.type;
+  if (req.name) p.Name = req.name;
+  if (req.aliasName) p.AliasName = req.aliasName;
+  if (req.lang) p.Lang = req.lang;
+  return p;
+}
+
+// ---- DescribeUuidsByVulNames ----
+function mapDescribeUuidsByVulNamesReq(req) {
+  const p = {};
+  if (req.type) p.Type = req.type;
+  if (req.vulNames?.length) p.VulNames = req.vulNames;
+  if (req.lang) p.Lang = req.lang;
+  return p;
+}
+
+// ---- DescribeCanFixVulList ----
+function mapDescribeCanFixVulListReq(req) {
+  const p = {};
+  if (req.type) p.Type = req.type;
+  if (req.uuids?.length) p.Uuids = req.uuids;
+  if (req.aliasName) p.AliasName = req.aliasName;
+  if (req.dealed) p.Dealed = req.dealed;
+  if (req.statusList?.length) p.StatusList = req.statusList;
+  if (req.currentPage) p.CurrentPage = req.currentPage;
+  if (req.pageSize) p.PageSize = req.pageSize;
+  if (req.lang) p.Lang = req.lang;
+  return p;
+}
+
+// ---- ModifyOperateVul ----
+function mapModifyOperateVulReq(req) {
+  const p = {};
+  if (req.type) p.Type = req.type;
+  if (req.operateType) p.OperateType = req.operateType;
+  if (req.info) p.Info = req.info;
+  return p;
+}
+
+// ---- OperateVuls ----
+function mapOperateVulsReq(req) {
+  const p = {};
+  if (req.uuids?.length) p.Uuids = req.uuids;
+  if (req.type) p.Type = req.type;
+  if (req.operateType) p.OperateType = req.operateType;
+  if (req.vulNames?.length) p.VulNames = req.vulNames;
+  return p;
+}
+
+// ---- DescribeVulNumStatistics ----
+function mapDescribeVulNumStatisticsReq(req) {
+  const p = {};
+  if (req.type) p.Type = req.type;
+  if (req.resourceDirectoryAccountId) p.ResourceDirectoryAccountId = req.resourceDirectoryAccountId;
+  return p;
+}
+
+// ---- DescribeVulFixStatistics ----
+function mapDescribeVulFixStatisticsReq() {
+  return {};
+}
+
+// ---- DescribeVulWhitelist ----
+function mapDescribeVulWhitelistReq(req) {
+  const p = {};
+  if (req.currentPage) p.CurrentPage = req.currentPage;
+  if (req.pageSize) p.PageSize = req.pageSize;
+  return p;
+}
+
+// ---- ModifyCreateVulWhitelist ----
+function mapModifyCreateVulWhitelistReq(req) {
+  const p = {};
+  if (req.whitelist) p.Whitelist = req.whitelist;
+  if (req.reason) p.Reason = req.reason;
+  if (req.targetInfo) p.TargetInfo = req.targetInfo;
+  return p;
+}
+
+// ---- DeleteVulWhitelist ----
+function mapDeleteVulWhitelistReq(req) {
+  const p = {};
+  if (req.idList?.length) p.IdList = req.idList;
+  return p;
+}
+
+// ---- DescribeEmgVulItem ----
+function mapDescribeEmgVulItemReq(req) {
+  const p = {};
+  if (req.scanType) p.ScanType = req.scanType;
+  if (req.lang) p.Lang = req.lang;
+  if (req.currentPage) p.CurrentPage = req.currentPage;
+  if (req.pageSize) p.PageSize = req.pageSize;
+  return p;
+}
+
+// --------------- Handler definitions ---------------
+
+const handleDescribeVulList = buildCallHandler('DescribeVulList', mapDescribeVulListReq);
+const handleDescribeVulDetails = buildCallHandler('DescribeVulDetails', mapDescribeVulDetailsReq);
+const handleDescribeUuidsByVulNames = buildCallHandler('DescribeUuidsByVulNames', mapDescribeUuidsByVulNamesReq);
+const handleDescribeCanFixVulList = buildCallHandler('DescribeCanFixVulList', mapDescribeCanFixVulListReq);
+const handleModifyOperateVul = buildCallHandler('ModifyOperateVul', mapModifyOperateVulReq);
+const handleOperateVuls = buildCallHandler('OperateVuls', mapOperateVulsReq);
+const handleDescribeVulNumStatistics = buildCallHandler('DescribeVulNumStatistics', mapDescribeVulNumStatisticsReq);
+const handleDescribeVulFixStatistics = buildCallHandler('DescribeVulFixStatistics', mapDescribeVulFixStatisticsReq);
+const handleDescribeVulWhitelist = buildCallHandler('DescribeVulWhitelist', mapDescribeVulWhitelistReq);
+const handleModifyCreateVulWhitelist = buildCallHandler('ModifyCreateVulWhitelist', mapModifyCreateVulWhitelistReq);
+const handleDeleteVulWhitelist = buildCallHandler('DeleteVulWhitelist', mapDeleteVulWhitelistReq);
+const handleDescribeEmgVulItem = buildCallHandler('DescribeEmgVulItem', mapDescribeEmgVulItemReq);
+
+// --------------- rpcdef (path-based routing for SDK) ---------------
+
+export function rpcdef(ctx) {
+  return {
+    [METHOD_DESCRIBE_VUL_LIST_PATH]: (req) => handleDescribeVulList({ ...ctx, request: req }),
+    [METHOD_DESCRIBE_VUL_DETAILS_PATH]: (req) => handleDescribeVulDetails({ ...ctx, request: req }),
+    [METHOD_DESCRIBE_UUIDS_BY_VUL_NAMES_PATH]: (req) => handleDescribeUuidsByVulNames({ ...ctx, request: req }),
+    [METHOD_DESCRIBE_CAN_FIX_VUL_LIST_PATH]: (req) => handleDescribeCanFixVulList({ ...ctx, request: req }),
+    [METHOD_MODIFY_OPERATE_VUL_PATH]: (req) => handleModifyOperateVul({ ...ctx, request: req }),
+    [METHOD_OPERATE_VULS_PATH]: (req) => handleOperateVuls({ ...ctx, request: req }),
+    [METHOD_DESCRIBE_VUL_NUM_STATISTICS_PATH]: (req) => handleDescribeVulNumStatistics({ ...ctx, request: req }),
+    [METHOD_DESCRIBE_VUL_FIX_STATISTICS_PATH]: (req) => handleDescribeVulFixStatistics({ ...ctx, request: req }),
+    [METHOD_DESCRIBE_VUL_WHITELIST_PATH]: (req) => handleDescribeVulWhitelist({ ...ctx, request: req }),
+    [METHOD_MODIFY_CREATE_VUL_WHITELIST_PATH]: (req) => handleModifyCreateVulWhitelist({ ...ctx, request: req }),
+    [METHOD_DELETE_VUL_WHITELIST_PATH]: (req) => handleDeleteVulWhitelist({ ...ctx, request: req }),
+    [METHOD_DESCRIBE_EMG_VUL_ITEM_PATH]: (req) => handleDescribeEmgVulItem({ ...ctx, request: req }),
+  };
+}
+
+// --------------- handlers (for defineService) ---------------
+
+export const handlers = {
+  [METHOD_DESCRIBE_VUL_LIST_FULL]: handleDescribeVulList,
+  [METHOD_DESCRIBE_VUL_DETAILS_FULL]: handleDescribeVulDetails,
+  [METHOD_DESCRIBE_UUIDS_BY_VUL_NAMES_FULL]: handleDescribeUuidsByVulNames,
+  [METHOD_DESCRIBE_CAN_FIX_VUL_LIST_FULL]: handleDescribeCanFixVulList,
+  [METHOD_MODIFY_OPERATE_VUL_FULL]: handleModifyOperateVul,
+  [METHOD_OPERATE_VULS_FULL]: handleOperateVuls,
+  [METHOD_DESCRIBE_VUL_NUM_STATISTICS_FULL]: handleDescribeVulNumStatistics,
+  [METHOD_DESCRIBE_VUL_FIX_STATISTICS_FULL]: handleDescribeVulFixStatistics,
+  [METHOD_DESCRIBE_VUL_WHITELIST_FULL]: handleDescribeVulWhitelist,
+  [METHOD_MODIFY_CREATE_VUL_WHITELIST_FULL]: handleModifyCreateVulWhitelist,
+  [METHOD_DELETE_VUL_WHITELIST_FULL]: handleDeleteVulWhitelist,
+  [METHOD_DESCRIBE_EMG_VUL_ITEM_FULL]: handleDescribeEmgVulItem,
+};
+
+// --------------- _test export (for unit testing) ---------------
+
+export const _test = {
+  // Method path constants
+  METHOD_DESCRIBE_VUL_LIST_PATH,
+  METHOD_DESCRIBE_VUL_DETAILS_PATH,
+  METHOD_DESCRIBE_UUIDS_BY_VUL_NAMES_PATH,
+  METHOD_DESCRIBE_CAN_FIX_VUL_LIST_PATH,
+  METHOD_MODIFY_OPERATE_VUL_PATH,
+  METHOD_OPERATE_VULS_PATH,
+  METHOD_DESCRIBE_VUL_NUM_STATISTICS_PATH,
+  METHOD_DESCRIBE_VUL_FIX_STATISTICS_PATH,
+  METHOD_DESCRIBE_VUL_WHITELIST_PATH,
+  METHOD_MODIFY_CREATE_VUL_WHITELIST_PATH,
+  METHOD_DELETE_VUL_WHITELIST_PATH,
+  METHOD_DESCRIBE_EMG_VUL_ITEM_PATH,
+
+  METHOD_DESCRIBE_VUL_LIST_FULL,
+  METHOD_DESCRIBE_VUL_DETAILS_FULL,
+  METHOD_DESCRIBE_UUIDS_BY_VUL_NAMES_FULL,
+  METHOD_DESCRIBE_CAN_FIX_VUL_LIST_FULL,
+  METHOD_MODIFY_OPERATE_VUL_FULL,
+  METHOD_OPERATE_VULS_FULL,
+  METHOD_DESCRIBE_VUL_NUM_STATISTICS_FULL,
+  METHOD_DESCRIBE_VUL_FIX_STATISTICS_FULL,
+  METHOD_DESCRIBE_VUL_WHITELIST_FULL,
+  METHOD_MODIFY_CREATE_VUL_WHITELIST_FULL,
+  METHOD_DELETE_VUL_WHITELIST_FULL,
+  METHOD_DESCRIBE_EMG_VUL_ITEM_FULL,
+
+  // Utilities
+  hasOwn,
+  toTrimmedString,
+  grpcCodeFor,
+  errorWithCode,
+  throwStructuredError,
+  resolveRegionId,
+  resolveAccessKeyId,
+  resolveAccessKeySecret,
+  resolveTimeoutMs,
+  aliyunPercentEncode,
+  randomNonce,
+  buildSignedParams,
+  SAS_ENDPOINT_MAP,
+  buildUrl,
+  callAliyunAPI,
+  mapHttpError,
+  assertAliyunSuccess,
+  mapAliyunErrorCode,
+  tryParseJson,
+  toValue,
+  unwrapScalar,
+
+  // Mappers
+  mapDescribeVulListReq,
+  mapDescribeVulDetailsReq,
+  mapDescribeUuidsByVulNamesReq,
+  mapDescribeCanFixVulListReq,
+  mapModifyOperateVulReq,
+  mapOperateVulsReq,
+  mapDescribeVulNumStatisticsReq,
+  mapDescribeVulFixStatisticsReq,
+  mapDescribeVulWhitelistReq,
+  mapModifyCreateVulWhitelistReq,
+  mapDeleteVulWhitelistReq,
+  mapDescribeEmgVulItemReq,
+};

--- a/services/aliyun__sas-vulnerability-management/src/service.js
+++ b/services/aliyun__sas-vulnerability-management/src/service.js
@@ -1,0 +1,4 @@
+import { defineService } from '@chaitin-ai/octobus-sdk';
+import { handlers } from './aliyun-sas-vulnerability-management.js';
+export { handlers } from './aliyun-sas-vulnerability-management.js';
+export const service = defineService({ handlers });

--- a/services/aliyun__sas-vulnerability-management/test/aliyun-sas-vulnerability-management.test.js
+++ b/services/aliyun__sas-vulnerability-management/test/aliyun-sas-vulnerability-management.test.js
@@ -1,0 +1,319 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { GrpcError } from '@chaitin-ai/octobus-sdk';
+import { handlers, rpcdef, _test } from '../src/aliyun-sas-vulnerability-management.js';
+
+function buildCtx(overrides = {}) {
+  return {
+    config: {},
+    secret: {},
+    bindings: {}, limits: {}, meta: new Map(), req: {},
+    getMetadata: () => undefined, getMetadataAll: () => [],
+    ...overrides,
+  };
+}
+
+function expectGrpcError(fn, legacyCode, checker) {
+  return fn().then(
+    () => { throw new Error(`Expected GrpcError(${legacyCode}) but no error was thrown`); },
+    (err) => {
+      assert.ok(err instanceof GrpcError);
+      assert.equal(err.legacyCode, legacyCode);
+      if (checker) checker(err);
+    },
+  );
+}
+
+function parseStructuredError(err) {
+  try { return JSON.parse(err.message); } catch { return null; }
+}
+
+function mockFetch(responseBody, status = 200) {
+  globalThis.fetch = async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => typeof responseBody === 'string' ? responseBody : JSON.stringify(responseBody),
+    json: async () => typeof responseBody === 'string' ? JSON.parse(responseBody) : responseBody,
+  });
+}
+
+// Helper: call handler with SDK ctx format
+function call(handler, ctx, req = {}) {
+  return handler({ ...ctx, request: req });
+}
+
+describe('aliyun-sas-vulnerability-management', () => {
+  // ====== Service Structure ======
+  it('exports handlers for all 12 RPCs', () => {
+    const names = Object.keys(handlers);
+    assert.equal(names.length, 12);
+    for (const name of names) {
+      assert.match(name, /^Aliyun_SAS_Vulnerability_Management\.SASService\//);
+      assert.equal(typeof handlers[name], 'function');
+    }
+  });
+
+  it('rpcdef returns all 12 paths', () => {
+    const def = rpcdef(buildCtx());
+    const paths = Object.keys(def);
+    assert.equal(paths.length, 12);
+    for (const path of paths) assert.match(path, /^\/Aliyun_SAS_Vulnerability_Management\.SASService\//);
+  });
+
+  // ====== Auth ======
+  it('throws INVALID_ARGUMENT when accessKeyId missing', async () => {
+    const ctx = buildCtx({ secret: { accessKeySecret: 'test' } });
+    await expectGrpcError(
+      () => call(handlers[_test.METHOD_DESCRIBE_VUL_LIST_FULL], ctx),
+      'INVALID_ARGUMENT',
+      (err) => { const se = parseStructuredError(err); assert.match(se.message, /accessKeyId/); },
+    );
+  });
+
+  it('throws INVALID_ARGUMENT when accessKeySecret missing', async () => {
+    const ctx = buildCtx({ secret: { accessKeyId: 'test' } });
+    await expectGrpcError(
+      () => call(handlers[_test.METHOD_DESCRIBE_VUL_LIST_FULL], ctx),
+      'INVALID_ARGUMENT',
+      (err) => { const se = parseStructuredError(err); assert.match(se.message, /accessKeySecret/); },
+    );
+  });
+
+  // ====== Percent Encoding ======
+  it('aliyunPercentEncode preserves tilde and encodes asterisk', () => {
+    const encoded = _test.aliyunPercentEncode('~test*value');
+    assert.ok(encoded.includes('~'));
+    assert.ok(encoded.includes('%2A'));
+    assert.ok(!encoded.includes('*'));
+  });
+
+  // ====== Signature ======
+  it('buildSignedParams returns params with all system keys', () => {
+    const params = _test.buildSignedParams('DescribeVulList', { Type: 'cve' }, 'test-key', 'test-secret');
+    assert.equal(params.get('Action'), 'DescribeVulList');
+    assert.equal(params.get('SignatureMethod'), 'HMAC-SHA1');
+    assert.equal(params.get('Version'), '2018-12-03');
+    assert.equal(params.get('Type'), 'cve');
+    assert.ok(params.get('Signature'));
+  });
+
+  it('buildSignedParams skips undefined/null/empty', () => {
+    const params = _test.buildSignedParams('Test', { Keep: 'val', Skip: undefined, SkipNull: null, SkipEmpty: '' }, 'k', 's');
+    assert.equal(params.get('Keep'), 'val');
+    assert.ok(!params.has('Skip'));
+    assert.ok(!params.has('SkipNull'));
+    assert.ok(!params.has('SkipEmpty'));
+  });
+
+  it('buildSignedParams handles arrays with dot-index', () => {
+    const params = _test.buildSignedParams('Test', { Uuids: ['uuid-1', 'uuid-2'] }, 'k', 's');
+    assert.equal(params.get('Uuids.1'), 'uuid-1');
+    assert.equal(params.get('Uuids.2'), 'uuid-2');
+  });
+
+  // ====== buildUrl ======
+  it('buildUrl maps China regions to cn-shanghai', () => {
+    assert.equal(_test.buildUrl('cn-hangzhou'), 'https://tds.cn-shanghai.aliyuncs.com/');
+    assert.equal(_test.buildUrl('cn-beijing'), 'https://tds.cn-shanghai.aliyuncs.com/');
+    assert.equal(_test.buildUrl('cn-shenzhen'), 'https://tds.cn-shanghai.aliyuncs.com/');
+  });
+
+  it('buildUrl maps non-China regions correctly', () => {
+    assert.equal(_test.buildUrl('ap-southeast-1'), 'https://tds.ap-southeast-1.aliyuncs.com/');
+    assert.equal(_test.buildUrl('us-east-1'), 'https://tds.us-east-1.aliyuncs.com/');
+  });
+
+  it('buildUrl falls back for unknown regions', () => {
+    assert.equal(_test.buildUrl('unknown'), 'https://tds.unknown.aliyuncs.com/');
+  });
+
+  // ====== Error Mapping ======
+  it('mapAliyunErrorCode maps auth errors to UNAUTHENTICATED', () => {
+    assert.equal(_test.mapAliyunErrorCode('InvalidAccessKeyId.NotFound'), 'UNAUTHENTICATED');
+    assert.equal(_test.mapAliyunErrorCode('SignatureDoesNotMatch'), 'UNAUTHENTICATED');
+  });
+
+  it('mapAliyunErrorCode maps invalid params to INVALID_ARGUMENT', () => {
+    assert.equal(_test.mapAliyunErrorCode('InvalidParameter.Type'), 'INVALID_ARGUMENT');
+    assert.equal(_test.mapAliyunErrorCode('MissingParameter.Name'), 'INVALID_ARGUMENT');
+  });
+
+  it('mapAliyunErrorCode maps not found to NOT_FOUND', () => {
+    assert.equal(_test.mapAliyunErrorCode('Vulnerability.NotFound'), 'NOT_FOUND');
+  });
+
+  it('mapAliyunErrorCode maps throttle to UNAVAILABLE', () => {
+    assert.equal(_test.mapAliyunErrorCode('Throttling.User'), 'UNAVAILABLE');
+  });
+
+  // ====== JSON Helpers ======
+  it('tryParseJson returns ok for valid JSON', () => {
+    assert.equal(_test.tryParseJson('{"a":1}').ok, true);
+  });
+
+  it('tryParseJson returns not ok for invalid JSON', () => {
+    assert.equal(_test.tryParseJson('not json').ok, false);
+  });
+
+  it('toValue converts primitives', () => {
+    assert.deepEqual(_test.toValue('hello'), { stringValue: 'hello' });
+    assert.deepEqual(_test.toValue(42), { numberValue: 42 });
+    assert.deepEqual(_test.toValue(null), { nullValue: 0 });
+  });
+
+  // ====== Request Mappers ======
+  it('mapDescribeVulListReq maps all fields', () => {
+    const p = _test.mapDescribeVulListReq({
+      type: 'cve', uuids: ['u1'], aliasName: 'CVE-2024', dealed: 'n',
+      severity: 'high', groupId: 'g1', currentPage: 1, pageSize: 20,
+      lang: 'zh', attachTypes: 'sca', ids: '1,2',
+      createTsStart: 1000, createTsEnd: 2000,
+    });
+    assert.equal(p.Type, 'cve');
+    assert.deepEqual(p.Uuids, ['u1']);
+    assert.equal(p.CurrentPage, 1);
+    assert.equal(p.PageSize, 20);
+    assert.equal(p.CreateTsStart, 1000);
+  });
+
+  it('mapDescribeVulDetailsReq maps fields', () => {
+    const p = _test.mapDescribeVulDetailsReq({ type: 'cve', name: 'CVE-2024', aliasName: 'alias', lang: 'en' });
+    assert.equal(p.Name, 'CVE-2024');
+    assert.equal(p.Lang, 'en');
+  });
+
+  it('mapDescribeUuidsByVulNamesReq maps VulNames', () => {
+    const p = _test.mapDescribeUuidsByVulNamesReq({ type: 'cve', vulNames: ['n1', 'n2'], lang: 'zh' });
+    assert.deepEqual(p.VulNames, ['n1', 'n2']);
+  });
+
+  it('mapModifyOperateVulReq maps fields', () => {
+    const p = _test.mapModifyOperateVulReq({ type: 'cve', operateType: 'vul_fix', info: '{"id":1}' });
+    assert.equal(p.OperateType, 'vul_fix');
+  });
+
+  it('mapOperateVulsReq maps fields', () => {
+    const p = _test.mapOperateVulsReq({ uuids: ['u1'], type: 'cve', operateType: 'vul_fix', vulNames: ['CVE-2024'] });
+    assert.deepEqual(p.VulNames, ['CVE-2024']);
+  });
+
+  it('mapDescribeVulWhitelistReq maps fields', () => {
+    const p = _test.mapDescribeVulWhitelistReq({ currentPage: 1, pageSize: 10 });
+    assert.equal(p.CurrentPage, 1);
+  });
+
+  it('mapDeleteVulWhitelistReq maps idList', () => {
+    const p = _test.mapDeleteVulWhitelistReq({ idList: ['1', '2'] });
+    assert.deepEqual(p.IdList, ['1', '2']);
+  });
+
+  // ====== Handler with mocked fetch ======
+  describe('handlers with mocked fetch', () => {
+    let orig;
+    beforeEach(() => { orig = globalThis.fetch; });
+    afterEach(() => { globalThis.fetch = orig; });
+    const ctx = buildCtx({ secret: { accessKeyId: 'test-key', accessKeySecret: 'test-secret' } });
+
+    it('DescribeVulList returns success', async () => {
+      mockFetch({ TotalCount: 3, VulRecords: [{ Id: 1001 }], RequestId: 'req-001' });
+      const result = await call(handlers[_test.METHOD_DESCRIBE_VUL_LIST_FULL], ctx, { type: 'cve', currentPage: 1, pageSize: 10 });
+      assert.equal(result.httpStatus, 200);
+      assert.ok(result.rawJson.structValue);
+    });
+
+    it('DescribeVulDetails returns success', async () => {
+      mockFetch({ VulDetails: [{ Name: 'CVE-2024' }], RequestId: 'req-002' });
+      const result = await call(handlers[_test.METHOD_DESCRIBE_VUL_DETAILS_FULL], ctx, { type: 'cve', name: 'CVE-2024' });
+      assert.equal(result.httpStatus, 200);
+    });
+
+    it('DescribeUuidsByVulNames returns success', async () => {
+      mockFetch({ MachineInfoStatistics: [{ UuidCount: 5 }], RequestId: 'req-003' });
+      const result = await call(handlers[_test.METHOD_DESCRIBE_UUIDS_BY_VUL_NAMES_FULL], ctx, { type: 'cve', vulNames: ['CVE-2024'] });
+      assert.equal(result.httpStatus, 200);
+    });
+
+    it('ModifyOperateVul returns success', async () => {
+      mockFetch({ RequestId: 'req-005' });
+      const result = await call(handlers[_test.METHOD_MODIFY_OPERATE_VUL_FULL], ctx, { type: 'cve', operateType: 'vul_fix', info: '{"id":1}' });
+      assert.equal(result.httpStatus, 200);
+    });
+
+    it('DescribeVulNumStatistics returns success', async () => {
+      mockFetch({ VulAsapSum: 3, VulLaterSum: 10, RequestId: 'req-007' });
+      const result = await call(handlers[_test.METHOD_DESCRIBE_VUL_NUM_STATISTICS_FULL], ctx);
+      assert.equal(result.httpStatus, 200);
+    });
+
+    it('DescribeVulWhitelist returns success', async () => {
+      mockFetch({ TotalCount: 1, VulWhitelists: [], RequestId: 'req-009' });
+      const result = await call(handlers[_test.METHOD_DESCRIBE_VUL_WHITELIST_FULL], ctx, { currentPage: 1, pageSize: 10 });
+      assert.equal(result.httpStatus, 200);
+    });
+
+    it('maps HTTP 401 to PERMISSION_DENIED', async () => {
+      mockFetch({ Code: 'InvalidAccessKeyId', Message: 'Invalid' }, 401);
+      await expectGrpcError(
+        () => call(handlers[_test.METHOD_DESCRIBE_VUL_LIST_FULL], ctx),
+        'PERMISSION_DENIED',
+      );
+    });
+
+    it('maps HTTP 500 to UNAVAILABLE', async () => {
+      globalThis.fetch = async () => ({ ok: false, status: 500, text: async () => 'Error' });
+      await expectGrpcError(
+        () => call(handlers[_test.METHOD_DESCRIBE_VUL_LIST_FULL], ctx),
+        'UNAVAILABLE',
+      );
+    });
+
+    it('maps Throttling.User to UNAVAILABLE', async () => {
+      mockFetch({ Code: 'Throttling.User', Message: 'Throttled' });
+      await expectGrpcError(
+        () => call(handlers[_test.METHOD_DESCRIBE_VUL_LIST_FULL], ctx),
+        'UNAVAILABLE',
+      );
+    });
+
+    it('maps MissingParameter to INVALID_ARGUMENT', async () => {
+      mockFetch({ Code: 'MissingParameter.Name', Message: 'Required' });
+      await expectGrpcError(
+        () => call(handlers[_test.METHOD_DESCRIBE_VUL_DETAILS_FULL], ctx),
+        'INVALID_ARGUMENT',
+      );
+    });
+
+    it('maps Vulnerability.NotFound to NOT_FOUND', async () => {
+      mockFetch({ Code: 'Vulnerability.NotFound', Message: 'Not found' });
+      await expectGrpcError(
+        () => call(handlers[_test.METHOD_DESCRIBE_VUL_DETAILS_FULL], ctx),
+        'NOT_FOUND',
+      );
+    });
+
+    it('maps non-JSON response to UNAVAILABLE', async () => {
+      globalThis.fetch = async () => ({ ok: true, status: 200, text: async () => 'not json' });
+      await expectGrpcError(
+        () => call(handlers[_test.METHOD_DESCRIBE_VUL_LIST_FULL], ctx),
+        'UNAVAILABLE',
+      );
+    });
+
+    it('maps network error to UNAVAILABLE', async () => {
+      globalThis.fetch = async () => { throw new Error('ECONNREFUSED'); };
+      await expectGrpcError(
+        () => call(handlers[_test.METHOD_DESCRIBE_VUL_LIST_FULL], ctx),
+        'UNAVAILABLE',
+      );
+    });
+  });
+
+  // ====== Config ======
+  it('resolveRegionId uses default', () => {
+    assert.equal(_test.resolveRegionId(buildCtx({ config: {} })), 'cn-shanghai');
+  });
+
+  it('resolveTimeoutMs uses default', () => {
+    assert.equal(_test.resolveTimeoutMs(buildCtx({ config: {} })), 10000);
+  });
+});

--- a/services/aliyun__sas-vulnerability-management/test/mock_upstream.js
+++ b/services/aliyun__sas-vulnerability-management/test/mock_upstream.js
@@ -1,0 +1,261 @@
+import http from 'node:http';
+
+/**
+ * Creates a mock SAS (Security Center) API endpoint on a random port.
+ *
+ * Trigger actions (via Action param):
+ *   - "FailAuth"          → 401 with InvalidAccessKeyId error
+ *   - "FailForbidden"     → 403 with Forbidden error
+ *   - "FailServer"        → 500 Internal Server Error
+ *   - "FailInvalidJson"   → 200 with non-JSON body "not-json"
+ *   - "FailBizError"      → 200 with Code: "MissingParameter.NotFound"
+ *   - "FailThrottling"    → 200 with Code: "Throttling.User"
+ *   - "FailNotFound"      → 200 with Code: "Vulnerability.NotFound"
+ */
+export function createMockServer() {
+  const requests = [];
+
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ Code: 'MethodNotAllowed', Message: 'Only POST allowed' }));
+      return;
+    }
+
+    let body = '';
+    req.on('data', (chunk) => { body += chunk.toString(); });
+    req.on('end', () => {
+      const params = new URLSearchParams(body);
+      const action = params.get('Action') || '';
+      const accessKeyId = params.get('AccessKeyId') || '';
+      const signature = params.get('Signature') || '';
+
+      requests.push({ action, params: Object.fromEntries(params) });
+
+      // Missing auth
+      if (!accessKeyId || !signature) {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          Code: 'InvalidAccessKeyId.NotFound',
+          Message: 'Specified access key is not found.',
+          RequestId: 'MOCK-REQ-001',
+        }));
+        return;
+      }
+
+      // Trigger: FailAuth action
+      if (action === 'FailAuth') {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          Code: 'InvalidAccessKeyId.NotFound',
+          Message: 'Specified access key is not found.',
+          RequestId: 'MOCK-REQ-002',
+        }));
+        return;
+      }
+
+      // Trigger: FailForbidden
+      if (action === 'FailForbidden') {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          Code: 'Forbidden.NotAdminUser',
+          Message: 'The specified account is not an admin.',
+          RequestId: 'MOCK-REQ-003',
+        }));
+        return;
+      }
+
+      // Trigger: FailServer
+      if (action === 'FailServer') {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Internal Server Error');
+        return;
+      }
+
+      // Trigger: FailInvalidJson
+      if (action === 'FailInvalidJson') {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('not-json');
+        return;
+      }
+
+      // Trigger: FailThrottling
+      if (action === 'FailThrottling') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          Code: 'Throttling.User',
+          Message: 'Request was throttled.',
+          RequestId: 'MOCK-REQ-004',
+        }));
+        return;
+      }
+
+      // Trigger: FailBizError
+      if (action === 'FailBizError') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          Code: 'MissingParameter.NotFound',
+          Message: 'The specified parameter is missing.',
+          RequestId: 'MOCK-REQ-005',
+        }));
+        return;
+      }
+
+      // Trigger: FailNotFound
+      if (action === 'FailNotFound') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          Code: 'Vulnerability.NotFound',
+          Message: 'The specified vulnerability was not found.',
+          RequestId: 'MOCK-REQ-006',
+        }));
+        return;
+      }
+
+      // Success responses per action type
+      if (action === 'DescribeVulList') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          RequestId: 'MOCK-VUL-LIST',
+          TotalCount: 3,
+          VulRecords: [
+            {
+              Id: 1001,
+              Name: 'CVE-2024-1234',
+              AliasName: 'RHSA-2024:1234',
+              Type: 'cve',
+              Severity: 'high',
+              Status: 3,
+              Necessity: 'Necessary to fix',
+            },
+          ],
+        }));
+        return;
+      }
+
+      if (action === 'DescribeVulDetails') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          RequestId: 'MOCK-VUL-DETAILS',
+          VulDetails: [{
+            Name: 'CVE-2024-1234',
+            Description: 'A critical vulnerability in example package',
+            Solution: 'Upgrade to version 2.0',
+          }],
+        }));
+        return;
+      }
+
+      if (action === 'DescribeUuidsByVulNames') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          RequestId: 'MOCK-UUIDS-BY-VUL',
+          MachineInfoStatistics: [{
+            UuidCount: 5,
+            UuidList: ['uuid-1', 'uuid-2', 'uuid-3'],
+          }],
+        }));
+        return;
+      }
+
+      if (action === 'DescribeCanFixVulList') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          RequestId: 'MOCK-CAN-FIX',
+          TotalCount: 2,
+          VulRecords: [{
+            Id: 2001,
+            Name: 'CVE-2024-5678',
+            Status: 1,
+          }],
+        }));
+        return;
+      }
+
+      if (action === 'ModifyOperateVul') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ RequestId: 'MOCK-MODIFY-OPERATE' }));
+        return;
+      }
+
+      if (action === 'OperateVuls') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ RequestId: 'MOCK-OPERATE' }));
+        return;
+      }
+
+      if (action === 'DescribeVulNumStatistics') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          RequestId: 'MOCK-VUL-NUM',
+          VulLaterSum: 10,
+          VulNntfSum: 5,
+          VulAsapSum: 3,
+          VulTotalCount: 18,
+        }));
+        return;
+      }
+
+      if (action === 'DescribeVulFixStatistics') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          RequestId: 'MOCK-VUL-FIX',
+          FixedTodayNum: 2,
+          FixedTotalNum: 100,
+          NeedFixNum: 18,
+        }));
+        return;
+      }
+
+      if (action === 'DescribeVulWhitelist') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          RequestId: 'MOCK-VUL-WHITELIST',
+          TotalCount: 1,
+          VulWhitelists: [{ Id: 'wl-001', Whitelist: 'CVE-2023-0001', Reason: 'Low risk, accepted' }],
+        }));
+        return;
+      }
+
+      if (action === 'ModifyCreateVulWhitelist') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ RequestId: 'MOCK-CREATE-WHITELIST' }));
+        return;
+      }
+
+      if (action === 'DeleteVulWhitelist') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ RequestId: 'MOCK-DELETE-WHITELIST' }));
+        return;
+      }
+
+      if (action === 'DescribeEmgVulItem') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          RequestId: 'MOCK-EMG-VUL',
+          TotalCount: 1,
+          GroupedVulItems: [{ Name: 'emergency-CVE-2024-9999', Description: 'Critical 0-day' }],
+        }));
+        return;
+      }
+
+      // Default success for any unrecognized action
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ RequestId: 'MOCK-DEFAULT', Code: '200' }));
+    });
+  });
+
+  return {
+    server,
+    requests,
+    get url() {
+      const addr = server.address();
+      return `http://127.0.0.1:${addr.port}`;
+    },
+    close() {
+      return new Promise((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}

--- a/services/bin/aliyun-ddoscoo-20200101.js
+++ b/services/bin/aliyun-ddoscoo-20200101.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import { runServiceMain } from "@chaitin-ai/octobus-sdk";
+
+import { service } from "../aliyun__ddoscoo_20200101/src/service.js";
+
+runServiceMain(service, {
+  entryFile: fileURLToPath(new URL("../aliyun__ddoscoo_20200101/bin/aliyun-ddoscoo-20200101.js", import.meta.url)),
+});

--- a/services/bin/aliyun-sas-vulnerability-management.js
+++ b/services/bin/aliyun-sas-vulnerability-management.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+import { runServiceMain } from "@chaitin-ai/octobus-sdk";
+import { service } from "../aliyun__sas-vulnerability-management/src/service.js";
+runServiceMain(service, {
+  entryFile: fileURLToPath(new URL("../aliyun__sas-vulnerability-management/bin/aliyun-sas-vulnerability-management.js", import.meta.url)),
+});

--- a/services/bin/octobus-tentacles.js
+++ b/services/bin/octobus-tentacles.js
@@ -13,6 +13,10 @@ const services = {
     entryFile: "../chaitin__safeline-waf-eliminate-false-positive/bin/safeline-waf-eliminate-false-positive.js",
     serviceModule: "../chaitin__safeline-waf-eliminate-false-positive/src/service.js",
   },
+  "aliyun-ddoscoo-20200101": {
+    entryFile: "../aliyun__ddoscoo_20200101/bin/aliyun-ddoscoo-20200101.js",
+    serviceModule: "../aliyun__ddoscoo_20200101/src/service.js",
+  },
   "das-gateway-v3": {
     entryFile: "../das__gateway_v3/bin/das-gateway-v3.js",
     serviceModule: "../das__gateway_v3/src/service.js",

--- a/services/bin/octobus-tentacles.js
+++ b/services/bin/octobus-tentacles.js
@@ -17,6 +17,10 @@ const services = {
     entryFile: "../aliyun__ddoscoo_20200101/bin/aliyun-ddoscoo-20200101.js",
     serviceModule: "../aliyun__ddoscoo_20200101/src/service.js",
   },
+  "aliyun-sas-vulnerability-management": {
+    entryFile: "../aliyun__sas-vulnerability-management/bin/aliyun-sas-vulnerability-management.js",
+    serviceModule: "../aliyun__sas-vulnerability-management/src/service.js",
+  },
   "das-gateway-v3": {
     entryFile: "../das__gateway_v3/bin/das-gateway-v3.js",
     serviceModule: "../das__gateway_v3/src/service.js",

--- a/services/package.json
+++ b/services/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "bin": {
     "octobus-tentacles": "bin/octobus-tentacles.js",
+    "aliyun-ddoscoo-20200101": "bin/aliyun-ddoscoo-20200101.js",
     "das-gateway-v3": "bin/das-gateway-v3.js",
     "das-tgfw-v6": "bin/das-tgfw-v6.js",
     "dingtalk-group-robot": "bin/dingtalk-group-robot.js",
@@ -45,6 +46,7 @@
     "wd-k01": "bin/wd-k01.js"
   },
   "files": [
+    "bin/aliyun-ddoscoo-20200101.js",
     "bin/das-gateway-v3.js",
     "bin/das-tgfw-v6.js",
     "bin/dingtalk-group-robot.js",
@@ -83,6 +85,7 @@
     "bin/venus-ads-v3-6.js",
     "bin/wd-k01.js",
     "bin/wangsu-label-ip.js",
+    "aliyun__ddoscoo_20200101",
     "das__gateway_v3",
     "das__tgfw_v6",
     "dingtalk__group-robot",

--- a/services/package.json
+++ b/services/package.json
@@ -6,6 +6,7 @@
   "bin": {
     "octobus-tentacles": "bin/octobus-tentacles.js",
     "aliyun-ddoscoo-20200101": "bin/aliyun-ddoscoo-20200101.js",
+    "aliyun-sas-vulnerability-management": "bin/aliyun-sas-vulnerability-management.js",
     "das-gateway-v3": "bin/das-gateway-v3.js",
     "das-tgfw-v6": "bin/das-tgfw-v6.js",
     "dingtalk-group-robot": "bin/dingtalk-group-robot.js",
@@ -47,6 +48,7 @@
   },
   "files": [
     "bin/aliyun-ddoscoo-20200101.js",
+    "bin/aliyun-sas-vulnerability-management.js",
     "bin/das-gateway-v3.js",
     "bin/das-tgfw-v6.js",
     "bin/dingtalk-group-robot.js",
@@ -86,6 +88,7 @@
     "bin/wd-k01.js",
     "bin/wangsu-label-ip.js",
     "aliyun__ddoscoo_20200101",
+    "aliyun__sas-vulnerability-management",
     "das__gateway_v3",
     "das__tgfw_v6",
     "dingtalk__group-robot",


### PR DESCRIPTION
## Summary

Add `aliyun-sas-vulnerability-management` service package for Alibaba Cloud Security Center (SAS).

- **12 RPC methods**: vul query (4), vul operations (2), statistics (2), whitelist (3), emergency vul (1)
- **Runtime**: on-demand
- **Auth**: HMAC-SHA1 V1
- **Endpoint**: `tds.cn-shanghai.aliyuncs.com` (28-region endpoint map)
- **Real data verified**: SCA:CVE-2017-15715 (Apache Httpd 2.4.29, high)

## Test Results

- `npm run validate -- --service-dir aliyun__sas-vulnerability-management` ✅
- 40 unit tests ✅
- `npm run pack:check` ✅
- 12/12 methods verified via OctoBus Connect HTTP against real SAS API

## Files Changed

```
services/aliyun__sas-vulnerability-management/  (11 files, +1583 lines)
services/bin/aliyun-sas-vulnerability-management.js
services/bin/octobus-tentacles.js
services/package.json
```