### PR TITLE
feat(services): add aliyun WAF 3.0 service

### DIFF
--- a/services/aliyun__waf3/README.md
+++ b/services/aliyun__waf3/README.md
@@ -1,0 +1,263 @@
+# Aliyun WAF 3.0 OctoBus Service / 阿里云 WAF 3.0
+
+Alibaba Cloud Web Application Firewall (WAF) 3.0 integration for OctoBus — IP blacklist/whitelist management, custom ACL rules, security event query, and resource management.
+<br>
+阿里云 Web 应用防火墙（WAF）3.0 对接 OctoBus 能力总线，提供 IP 黑名单/白名单管理、自定义 ACL 规则、攻击事件查询和防护资源管理。
+
+## Supported Versions / 支持版本
+
+| Component / 组件 | Version / 版本 | Notes / 说明 |
+|---|---|---|
+| Alibaba Cloud WAF / 阿里云 WAF | 3.0 (API `2021-10-01`) | ⚠️ 请勿使用 `2019-09-10`（那是 WAF 2.0）|
+| OctoBus SDK | `@chaitin-ai/octobus-sdk` ^0.5.0 | 运行时框架 |
+| Alibaba Cloud SDK / 阿里云 SDK | `@alicloud/pop-core` ^1.8.0 | RPC 签名 + HTTPS 传输 |
+| Node.js | ≥ 20 | 运行环境 |
+
+## Configuration / 配置
+
+### config（非敏感 / non-sensitive）
+
+```json
+{
+  "endpoint": "https://wafopenapi.cn-hangzhou.aliyuncs.com",
+  "regionId": "cn-hangzhou",
+  "instanceId": "waf_v2_public_xxxxx",
+  "timeoutMs": 10000
+}
+```
+
+| Field / 字段 | Required / 必填 | Default / 默认 | Description / 说明 |
+|---|---|---|---|
+| `endpoint` | ❌ | `https://wafopenapi.cn-hangzhou.aliyuncs.com` | WAF OpenAPI 地址。国内站用 cn-hangzhou，国际站用 ap-southeast-1 |
+| `regionId` | ❌ | `cn-hangzhou` | WAF 实例所在地域 |
+| `instanceId` | ✅ | — | WAF 3.0 实例 ID，如 `waf_v2_public_xxxxx` |
+| `timeoutMs` | ❌ | `10000` | API 调用超时（毫秒） |
+
+### secret（敏感 / sensitive）
+
+```json
+{
+  "accessKeyId": "<your-ram-accesskey-id>",
+  "accessKeySecret": "<your-ram-accesskey-secret>"
+}
+```
+
+**认证方式 / Authentication**：使用 RAM 用户的 AccessKey（AK/SK）+ RPC 签名。需要为 RAM 用户授予 `AliyunYundunWAFv3FullAccess`（读写）或 `AliyunYundunWAFv3ReadOnlyAccess`（只读）权限策略。
+
+## RPC Methods / 方法列表（10 total）
+
+| # | Method / 方法 | Type / 类型 | Description / 说明 | 阿里云 API |
+|---|--------|------|-------------|-------------|
+| 1 | `BlockIP` | ✍️ 写 | 封禁 IP，加入黑名单 | `CreateDefenseRule` (ip_blacklist) |
+| 2 | `UnblockIP` | ✍️ 写 | 解封 IP，从黑名单移除 | `DescribeDefenseRule` + `ModifyDefenseRule` |
+| 3 | `DescribeIPBlacklist` | 👁️ 读 | 查询 IP 黑名单规则及 IP 列表 | `DescribeDefenseRules` (ip_blacklist) |
+| 4 | `AddIPWhitelist` | ✍️ 写 | IP 加白，绕过指定防护模块 | `CreateDefenseRule` (whitelist) |
+| 5 | `CreateACLRule` | ✍️ 写 | 创建自定义 ACL 规则（支持 URL/IP/Header 等条件） | `CreateDefenseRule` (custom_acl) |
+| 6 | `DeleteRule` | ✍️ 写 | 删除防护规则 | `DeleteDefenseRule` |
+| 7 | `DescribeRule` | 👁️ 读 | 查询单条规则详情 | `DescribeDefenseRule` |
+| 8 | `DescribeRules` | 👁️ 读 | 按场景查询规则列表 | `DescribeDefenseRules` |
+| 9 | `DescribeSecurityTopNMetric` | 👁️ 读 | 攻击流量 Top N 统计（按源 IP/URL/防护模块） | `DescribeSecurityEventTopNMetric` |
+| 10 | `DescribeResources` | 👁️ 读 | 查询防护资源（CNAME 域名 + 云产品接入的 ECS/SLB） | `DescribeDefenseResources` |
+
+---
+
+### BlockIP — 封禁 IP
+
+将 IP 或 CIDR 网段加入黑名单。每次调用创建一条新规则。
+
+```json
+// Request / 请求
+{ "ips": ["1.2.3.4", "5.6.7.0/24"], "ruleName": "block-malicious", "action": "block" }
+// Response / 响应
+{ "ruleId": "1024" }
+```
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `ips` | ✅ | IP 地址或 CIDR 网段列表，如 `["1.2.3.4", "5.6.7.0/24"]` |
+| `ruleName` | ❌ | 规则名称，默认 `"octobus-block"` |
+| `action` | ❌ | `"block"`（拦截）或 `"monitor"`（观察），默认 `"block"` |
+| `templateId` | ❌ | 防护模板 ID，不传则自动获取 |
+
+> **幂等性注意**：每次调用创建**新**规则。多次调用会创建多条规则。如需幂等，先用 `DescribeIPBlacklist` 查已有规则再决定。
+
+### UnblockIP — 解封 IP
+
+从黑名单规则中移除指定 IP。所有 IP 被移除后自动删除规则。
+
+```json
+// Request / 请求
+{ "ruleId": "1024", "ips": ["1.2.3.4"] }
+// Response / 响应
+{ "success": true }
+```
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `ruleId` | ✅ | 目标规则 ID |
+| `ips` | ✅ | 要移除的 IP 列表 |
+
+### DescribeIPBlacklist — 查询黑名单
+
+```json
+{ "pageNumber": 1, "pageSize": 20 }
+// → { "rules": [{ "ruleId": "1024", "name": "...", "ips": ["1.2.3.4"], "action": "block", "status": 1 }], "total": 5 }
+```
+
+### AddIPWhitelist — IP 加白
+
+```json
+{ "ips": ["10.0.0.1"], "ruleName": "internal-ip", "tags": ["waf"] }
+// → { "ruleId": "2048" }
+```
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `ips` | ✅ | 要加白的 IP 列表 |
+| `ruleName` | ❌ | 规则名称，默认 `"octobus-whitelist"` |
+| `tags` | ❌ | 加白模块列表，默认 `["waf"]`（全部模块）。可选：`waf`、`blacklist`、`customrule`、`cc`、`region_block`、`antiscan`、`dlp` |
+
+### CreateACLRule — 创建自定义 ACL
+
+基于 URL、IP、Header 等匹配条件创建访问控制规则，最多支持 5 个条件。
+
+```json
+{
+  "ruleName": "block-admin-url",
+  "conditions": [
+    { "key": "URL", "opValue": "contain", "values": "/admin" },
+    { "key": "IP", "opValue": "ne", "values": "10.0.0.0/8" }
+  ],
+  "action": "block",
+  "status": 1
+}
+// → { "ruleId": "3072" }
+```
+
+**conditions 支持的匹配字段 / Supported match keys**：
+
+| `key` | 说明 | 支持的操作符 |
+|-------|------|-------------|
+| `URL` | URL 路径 | contain, not-contain, eq, ne, prefix-match, suffix-match, regex |
+| `IP` | 来源 IP | eq, ne |
+| `Referer` | Referer 请求头 | contain, not-contain, eq, ne |
+| `User-Agent` | UA 请求头 | contain, not-contain, eq, ne |
+| `Header` | 自定义 Header | contain, not-contain, eq, ne（需 `subKey` 指定 Header 名） |
+| `Cookie` | Cookie | contain, not-contain, eq, ne（需 `subKey`） |
+| `Params` | 请求参数 | contain, not-contain, eq, ne（需 `subKey`） |
+| `Http-Method` | 请求方法 | eq, ne |
+| `X-Forwarded-For` | XFF 头 | eq, ne |
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `ruleName` | ✅ | 规则名称 |
+| `conditions` | ✅ | 1-5 个匹配条件 |
+| `action` | ❌ | `block`/`monitor`/`js`/`captcha`/`captcha_strict`，默认 `block` |
+| `status` | ❌ | `0`（禁用）或 `1`（启用），默认 `1` |
+
+### DeleteRule — 删除规则
+
+```json
+{ "ruleId": "3072" }
+// → { "success": true }
+```
+
+> ⚠️ **风险提示**：删除操作不可逆，删除后无法恢复。
+
+### DescribeRule / DescribeRules — 查询规则
+
+```json
+{ "ruleId": "1024" }
+// → { "ruleId": "1024", "name": "...", "defenseScene": "ip_blacklist", "rulesJson": "[...]" }
+```
+
+### DescribeSecurityTopNMetric — 攻击 Top N 统计
+
+统计攻击流量按维度（源 IP、URL、防护模块等）聚合后的 Top N 数据。
+
+```json
+{
+  "startTime": 1719705600,
+  "endTime": 1719792000,
+  "metric": "real_client_ip",
+  "limit": 5
+}
+// → { "items": [{ "name": "45.33.32.156", "value": 23 }, ...] }
+```
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `startTime` | ✅ | 开始时间（Unix 秒） |
+| `endTime` | ✅ | 结束时间（Unix 秒） |
+| `metric` | ❌ | 统计维度，默认 `real_client_ip`。可选：`http_user_agent`、`request_path`、`matched_host`、`defense_scene`、`block_defense_scene` |
+| `limit` | ❌ | 返回条数（1-10），默认 5 |
+
+### DescribeResources — 查询防护资源
+
+同时支持 CNAME 域名接入和云产品接入（ECS/SLB）模式。
+
+```json
+{ "pageSize": 20 }
+// → { "resources": [{ "resource": "i-bp1-8080-ecs", "pattern": "instance_port", "product": "ecs", ... }], "total": 1 }
+```
+
+## Error Mapping / 错误码映射
+
+| 阿里云 API 错误 | gRPC 状态 | 说明 |
+|---|---|---|
+| `InvalidAccessKeyId`, `SignatureDoesNotMatch` | `UNAUTHENTICATED` | AK/SK 无效或签名不匹配 |
+| `Forbidden`, `NoPermission` | `PERMISSION_DENIED` | RAM 用户无权限 |
+| `InvalidParameter`, `MissingParameter` | `INVALID_ARGUMENT` | 参数无效或缺失 |
+| `Throttling`, `LimitExceeded` | `RESOURCE_EXHAUSTED` | API 调用频率超限 |
+| 网络错误 / 5xx / 未知错误 | `UNAVAILABLE` | 服务不可用 |
+
+## Suggested Capset / 建议能力集
+
+- **`security-ops`**（安全运营）：`BlockIP`, `UnblockIP`, `AddIPWhitelist`, `DescribeSecurityTopNMetric` — 安全分析师使用
+- **`waf-admin`**（WAF 管理）：所有方法 — WAF 管理员使用
+- **`waf-readonly`**（只读）：所有 `Describe*` 方法 — 审计/报表使用
+
+## Import & Test / 导入和测试
+
+```bash
+# 1. 导入 service
+octobus service import aliyun-waf3 ./services/aliyun__waf3
+
+# 2. 创建 instance
+octobus instance create aliyun-waf \
+  --service aliyun-waf3 \
+  --config-json '{"instanceId":"waf_v2_public_xxxxx","regionId":"cn-hangzhou"}' \
+  --secret-json '{"accessKeyId":"<AK-ID>","accessKeySecret":"<AK-SECRET>"}'
+
+# 3. 加入 capset
+octobus capset create dev
+octobus capset add-instance dev aliyun-waf
+
+# 4. 测试：查询防护资源（只读，安全）
+curl -X POST "http://127.0.0.1:9000/capsets/dev/connect/aliyun-waf/Aliyun_Waf3.Waf3/DescribeResources" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+
+# 5. 测试：查询 Top N 攻击统计
+curl -X POST "http://127.0.0.1:9000/capsets/dev/connect/aliyun-waf/Aliyun_Waf3.Waf3/DescribeSecurityTopNMetric" \
+  -H "Content-Type: application/json" \
+  -d '{"startTime":1719705600,"endTime":1719792000,"metric":"real_client_ip","limit":5}'
+```
+
+## Local Checks / 本地校验
+
+```bash
+cd services
+npm run validate -- --service-dir aliyun__waf3
+npm test -- --service-dir aliyun__waf3
+npm run pack:check
+```
+
+## Known Limitations / 已知限制
+
+- **IP 黑名单**：操作粒度为防护规则级别，非地址簿级别。每次 `BlockIP` 创建新规则。
+- **UnblockIP**：需指定 `rule_id`。先调用 `DescribeIPBlacklist` 找到对应规则。
+- **API 限流**：阿里云 WAF API 约 5 QPS。本服务不实现客户端限流，依赖服务端返回 `Throttling` 错误。
+- **模板发现**：首次调用时缓存默认模板 ID，实例运行期间不自动刷新。
+- **写操作**：所有写操作（Create/Modify/Delete）使用 POST 方法，读操作使用 GET。
+- **模板按场景匹配**：initialize 时自动按 `defenseScene` 查找对应模板。如无对应模板需预先在 WAF 控制台创建。

--- a/services/aliyun__waf3/TEST_RESULTS.md
+++ b/services/aliyun__waf3/TEST_RESULTS.md
@@ -1,0 +1,362 @@
+# Aliyun WAF 3.0 — OctoBus 联调证据 / Integration Evidence
+
+> 所有敏感信息（服务器地址、实例 ID、规则 ID、ECS 实例 ID、模板 ID）已替换为占位符。请求路径、HTTP 状态码、响应结构和业务字段完整保留。
+> All sensitive data (server addresses, instance IDs, rule IDs, ECS instance IDs, template IDs) replaced with placeholders. Request paths, HTTP status codes, response structure and business fields preserved.
+
+## 测试环境 / Test Environment
+
+| 项目 / Item | 值 / Value |
+|-------------|------------|
+| WAF 产品 / Product | Alibaba Cloud WAF 3.0 (API `2021-10-01`) |
+| 接入模式 / Access Mode | 云产品接入（ECS）/ Cloud Product Access |
+| OctoBus 版本 / Version | `@chaitin-ai/octobus-sdk` ^0.5.0 |
+| 测试方法数 / Methods Tested | 10 |
+| 测试结果 / Result | 全部通过 / All passed ✅ |
+
+---
+
+## 1. BlockIP — 封禁 IP
+
+### BlockIP 跑通
+
+# Request
+
+```http
+POST http://<octobus-addr>/capsets/dev/connect/<instance>/Aliyun_Waf3.Waf3/BlockIP
+Content-Type: application/json
+
+{"ips":["203.0.113.1"],"ruleName":"final-test","action":"monitor"}
+```
+
+# Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"ruleId":"<rule-id>"}
+```
+
+**底层 API / Underlying**: `CreateDefenseRule` (POST, DefenseScene=`ip_blacklist`)
+
+---
+
+## 2. UnblockIP — 解封 IP
+
+### UnblockIP 跑通
+
+# Request
+
+```http
+POST http://<octobus-addr>/capsets/dev/connect/<instance>/Aliyun_Waf3.Waf3/UnblockIP
+Content-Type: application/json
+
+{"ruleId":"<rule-id>","ips":["198.18.0.5"]}
+```
+
+# Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"success":true}
+```
+
+> 注：当移除所有 IP 后规则为空，自动调用 `DeleteDefenseRule` 删除规则。
+> Note: auto-deletes rule via `DeleteDefenseRule` when all IPs removed.
+
+**底层 API / Underlying**: `DescribeDefenseRule` + `ModifyDefenseRule` (or `DeleteDefenseRule`)
+
+---
+
+## 3. DescribeIPBlacklist — 查询 IP 黑名单
+
+### DescribeIPBlacklist 跑通
+
+# Request
+
+```http
+POST http://<octobus-addr>/capsets/dev/connect/<instance>/Aliyun_Waf3.Waf3/DescribeIPBlacklist
+Content-Type: application/json
+
+{}
+```
+
+# Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "rules": [
+    {"ruleId":"<rule-id>","name":"cycle-test","ips":["198.18.0.1"],"action":"monitor","status":1},
+    {"ruleId":"<rule-id>","name":"final-test","ips":["203.0.113.1"],"action":"monitor","status":1}
+  ],
+  "total":"8"
+}
+```
+
+**底层 API / Underlying**: `DescribeDefenseRules` (Query=`{"templateId":<template-id>,"scene":"ip_blacklist"}`)
+
+---
+
+## 4. AddIPWhitelist — IP 加白
+
+### AddIPWhitelist 跑通
+
+# Request
+
+```http
+POST http://<octobus-addr>/capsets/dev/connect/<instance>/Aliyun_Waf3.Waf3/AddIPWhitelist
+Content-Type: application/json
+
+{"ips":["10.0.0.1"],"ruleName":"whitelist-test"}
+```
+
+# Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"ruleId":"<rule-id>"}
+```
+
+**底层 API / Underlying**: `CreateDefenseRule` (POST, DefenseScene=`whitelist`)
+
+---
+
+## 5. CreateACLRule — 创建自定义 ACL 规则
+
+### CreateACLRule 跑通
+
+# Request
+
+```http
+POST http://<octobus-addr>/capsets/dev/connect/<instance>/Aliyun_Waf3.Waf3/CreateACLRule
+Content-Type: application/json
+
+{"ruleName":"acl-test","conditions":[{"key":"URL","opValue":"contain","values":"/admin"}],"action":"monitor"}
+```
+
+# Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"ruleId":"<rule-id>"}
+```
+
+**Conditions 支持字段 / Supported condition keys**:
+
+| `key` | 说明 / Description | `opValue` |
+|-------|-------------------|-----------|
+| `URL` | URL 路径 / URL path | contain, not-contain, eq, ne, prefix-match, suffix-match, regex |
+| `IP` | 来源 IP / Source IP | eq, ne |
+| `Referer` | Referer header | contain, not-contain, eq, ne |
+| `User-Agent` | UA header | contain, not-contain, eq, ne |
+| `Header` | 自定义 Header / Custom header | contain, not-contain, eq, ne（需 `subKey`）|
+| `Cookie` | Cookie | contain, not-contain, eq, ne（需 `subKey`）|
+| `Http-Method` | 请求方法 / HTTP method | eq, ne |
+
+**底层 API / Underlying**: `CreateDefenseRule` (POST, DefenseScene=`custom_acl`)
+
+---
+
+## 6. DeleteRule — 删除规则
+
+### DeleteRule 跑通
+
+# Request
+
+```http
+POST http://<octobus-addr>/capsets/dev/connect/<instance>/Aliyun_Waf3.Waf3/DeleteRule
+Content-Type: application/json
+
+{"ruleId":"<rule-id>"}
+```
+
+# Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"success":true}
+```
+
+**底层 API / Underlying**: `DeleteDefenseRule` (POST)
+
+---
+
+## 7. DescribeRule — 查询单条规则
+
+### DescribeRule 跑通
+
+# Request
+
+```http
+POST http://<octobus-addr>/capsets/dev/connect/<instance>/Aliyun_Waf3.Waf3/DescribeRule
+Content-Type: application/json
+
+{"ruleId":"<rule-id>"}
+```
+
+# Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "ruleId":"<rule-id>",
+  "name":"cycle-test",
+  "defenseScene":"ip_blacklist",
+  "action":"monitor",
+  "rulesJson":"[{\"action\":\"monitor\",\"name\":\"cycle-test\",\"remoteAddr\":[\"198.18.0.1\"]}]"
+}
+```
+
+**底层 API / Underlying**: `DescribeDefenseRule`
+
+---
+
+## 8. DescribeRules — 按场景查询规则列表
+
+### DescribeRules 跑通
+
+# Request
+
+```http
+POST http://<octobus-addr>/capsets/dev/connect/<instance>/Aliyun_Waf3.Waf3/DescribeRules
+Content-Type: application/json
+
+{"defenseScene":"ip_blacklist"}
+```
+
+# Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "rules": [
+    {"ruleId":"<rule-id>","name":"cycle-test","ips":["198.18.0.1"],"action":"monitor","status":1},
+    {"ruleId":"<rule-id>","name":"final-test","ips":["203.0.113.1"],"action":"monitor","status":1}
+  ],
+  "total":"8"
+}
+```
+
+**底层 API / Underlying**: `DescribeDefenseRules`
+
+---
+
+## 9. DescribeSecurityTopNMetric — 攻击 Top N 统计
+
+### DescribeSecurityTopNMetric 跑通
+
+# Request
+
+```http
+POST http://<octobus-addr>/capsets/dev/connect/<instance>/Aliyun_Waf3.Waf3/DescribeSecurityTopNMetric
+Content-Type: application/json
+
+{"startTime":1782748800,"endTime":1782835200,"metric":"real_client_ip","limit":5}
+```
+
+# Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "items": [
+    {"name":"<attacker-ip-1>","value":"23"},
+    {"name":"<attacker-ip-2>","value":"17"},
+    {"name":"<attacker-ip-3>","value":"3"},
+    {"name":"<attacker-ip-4>","value":"2"},
+    {"name":"<attacker-ip-5>","value":"1"}
+  ]
+}
+```
+
+**支持的 metric 维度 / Supported metrics**:
+
+| `metric` | 说明 / Description |
+|----------|-------------------|
+| `real_client_ip` | 攻击来源 IP / Attacker IP |
+| `http_user_agent` | User-Agent |
+| `request_path` | 请求路径 / Request path |
+| `matched_host` | 命中域名 / Matched host |
+| `defense_scene` | 防护场景 / Defense scene |
+| `block_defense_scene` | 拦截场景 / Block scene |
+
+**底层 API / Underlying**: `DescribeSecurityEventTopNMetric`
+
+---
+
+## 10. DescribeResources — 查询防护资源
+
+### DescribeResources 跑通
+
+# Request
+
+```http
+POST http://<octobus-addr>/capsets/dev/connect/<instance>/Aliyun_Waf3.Waf3/DescribeResources
+Content-Type: application/json
+
+{}
+```
+
+# Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "resources": [
+    {
+      "resource":"<ecs-instance-id>-8080-ecs",
+      "pattern":"instance_port",
+      "product":"ecs",
+      "status":"active",
+      "instanceId":"<ecs-instance-id>",
+      "port":8080,
+      "protocol":"http"
+    }
+  ],
+  "total":"1"
+}
+```
+
+**底层 API / Underlying**: `DescribeDefenseResources`
+
+---
+
+## 总结 / Summary
+
+| 类型 / Type | 方法 / Method | 数量 / Count |
+|-------------|--------------|--------------|
+| ✍️ 写操作 / Write | BlockIP, UnblockIP, AddIPWhitelist, CreateACLRule, DeleteRule | 5 |
+| 👁️ 读操作 / Read | DescribeIPBlacklist, DescribeRule, DescribeRules, DescribeSecurityTopNMetric, DescribeResources | 5 |
+
+**底层阿里云 API / Underlying Alibaba Cloud APIs**（7 total）:
+
+| API | 用途 / Usage |
+|-----|-------------|
+| `CreateDefenseRule` | 创建黑名单/白名单/ACL 规则 |
+| `ModifyDefenseRule` | 修改规则（IP 增删） |
+| `DeleteDefenseRule` | 删除规则 |
+| `DescribeDefenseRule` | 查询单条规则详情 |
+| `DescribeDefenseRules` | 查询规则列表 |
+| `DescribeSecurityEventTopNMetric` | 攻击 Top N 统计 |
+| `DescribeDefenseResources` | 查询防护资源列表 |
+
+**验证时间 / Verified**: 2026-07-01 — 全部 10 个方法通过真实 WAF 3.0 实例（云产品接入模式）验证 ✅

--- a/services/aliyun__waf3/bin/waf3.js
+++ b/services/aliyun__waf3/bin/waf3.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+#!/usr/bin/env node
+
+import { runServiceMain } from "@chaitin-ai/octobus-sdk";
+
+import { service } from "../src/service.js";
+
+runServiceMain(service);

--- a/services/aliyun__waf3/config.schema.json
+++ b/services/aliyun__waf3/config.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "endpoint": {
+      "type": "string",
+      "default": "https://wafopenapi.cn-hangzhou.aliyuncs.com",
+      "description": "Alibaba Cloud WAF OpenAPI endpoint."
+    },
+    "regionId": {
+      "type": "string",
+      "default": "cn-hangzhou",
+      "description": "WAF instance region ID."
+    },
+    "instanceId": {
+      "type": "string",
+      "description": "WAF 3.0 instance ID, e.g. waf_v2_public_xxxxx."
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 10000,
+      "description": "HTTP timeout in milliseconds for Alibaba Cloud API calls."
+    }
+  }
+}

--- a/services/aliyun__waf3/package.json
+++ b/services/aliyun__waf3/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "aliyun-waf3",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "aliyun-waf3": "bin/waf3.js"
+  },
+  "dependencies": {
+    "@alicloud/pop-core": "^1.8.0",
+    "@chaitin-ai/octobus-sdk": "^0.5.0"
+  }
+}

--- a/services/aliyun__waf3/proto/waf3.proto
+++ b/services/aliyun__waf3/proto/waf3.proto
@@ -1,0 +1,257 @@
+syntax = "proto3";
+
+package Aliyun_Waf3;
+
+option go_package = "miner/grpc-service/Aliyun_Waf3";
+
+// 阿里云 WAF 3.0 能力服务
+// 提供 IP 黑名单/白名单、自定义 ACL 规则、攻击事件查询和防护资源管理能力
+service Waf3 {
+  // 封禁 IP：将 IP 列表加入黑名单防护规则
+  rpc BlockIP(BlockIPRequest) returns (BlockIPResponse) {}
+
+  // 解封 IP：从黑名单防护规则中移除 IP
+  rpc UnblockIP(UnblockIPRequest) returns (UnblockIPResponse) {}
+
+  // 查询 IP 黑名单：获取当前生效的黑名单规则及 IP 列表
+  rpc DescribeIPBlacklist(DescribeIPBlacklistRequest) returns (DescribeIPBlacklistResponse) {}
+
+  // IP 加白：创建白名单规则，绕过指定防护模块
+  rpc AddIPWhitelist(AddIPWhitelistRequest) returns (AddIPWhitelistResponse) {}
+
+  // 创建自定义 ACL 规则：基于 URL/IP/Header 等条件做访问控制
+  rpc CreateACLRule(CreateACLRuleRequest) returns (CreateACLRuleResponse) {}
+
+  // 删除规则：按规则 ID 删除指定防护规则
+  rpc DeleteRule(DeleteRuleRequest) returns (DeleteRuleResponse) {}
+
+  // 查询单条规则详情
+  rpc DescribeRule(DescribeRuleRequest) returns (DescribeRuleResponse) {}
+
+  // 按防护场景查询规则列表
+  rpc DescribeRules(DescribeRulesRequest) returns (DescribeRulesResponse) {}
+
+  // 查询攻击流量 Top N 统计数据（按源 IP/URL/防护模块等维度）
+  rpc DescribeSecurityTopNMetric(DescribeSecurityTopNMetricRequest) returns (DescribeSecurityTopNMetricResponse) {}
+
+  // 查询防护资源（CNAME 域名 + 云产品接入的 ECS/SLB）
+  rpc DescribeResources(DescribeResourcesRequest) returns (DescribeResourcesResponse) {}
+}
+
+// ═══════════════════════════════════════════
+// IP 黑名单
+// ═══════════════════════════════════════════
+
+message BlockIPRequest {
+  // 防护模板 ID。为空时使用 instance 默认模板。
+  string template_id = 1;
+  // 要封禁的 IP 或 CIDR 列表，例如 ["1.2.3.4", "5.6.7.0/24"]
+  repeated string ips = 2;
+  // 规则名称，可选，默认 "octobus-block"
+  string rule_name = 3;
+  // 处置动作，可选 "block"（拦截）或 "monitor"（观察），默认 "block"
+  string action = 4;
+}
+
+message BlockIPResponse {
+  // 创建或更新的规则 ID
+  string rule_id = 1;
+}
+
+message UnblockIPRequest {
+  // 防护模板 ID。为空时使用 instance 默认模板。
+  string template_id = 1;
+  // 要操作的规则 ID
+  string rule_id = 2;
+  // 要移除的 IP 或 CIDR 列表
+  repeated string ips = 3;
+}
+
+message UnblockIPResponse {
+  bool success = 1;
+}
+
+message DescribeIPBlacklistRequest {
+  // 防护模板 ID。为空时使用 instance 默认模板。
+  string template_id = 1;
+  // 分页页码，默认 1
+  int32 page_number = 2;
+  // 每页条数，默认 20，最大 100
+  int32 page_size = 3;
+}
+
+message DescribeIPBlacklistResponse {
+  repeated IPBlacklistRule rules = 1;
+  int64 total = 2;
+}
+
+message IPBlacklistRule {
+  string rule_id = 1;
+  string name = 2;
+  repeated string ips = 3;
+  string action = 4;
+  int32 status = 5;
+}
+
+// ═══════════════════════════════════════════
+// IP 白名单
+// ═══════════════════════════════════════════
+
+message AddIPWhitelistRequest {
+  // 防护模板 ID。为空时使用 instance 默认模板。
+  string template_id = 1;
+  // 要加白的 IP 列表
+  repeated string ips = 2;
+  // 规则名称，可选，默认 "octobus-whitelist"
+  string rule_name = 3;
+  // 加白的防护模块列表，默认 ["waf"]（全部模块）
+  // 可选值: waf, blacklist, customrule, cc, region_block, antiscan, dlp 等
+  repeated string tags = 4;
+}
+
+message AddIPWhitelistResponse {
+  string rule_id = 1;
+}
+
+// ═══════════════════════════════════════════
+// 自定义 ACL 规则
+// ═══════════════════════════════════════════
+
+message ACLCondition {
+  // 匹配字段：URL, IP, Referer, User-Agent, Header, Cookie, Params, Http-Method, X-Forwarded-For 等
+  string key = 1;
+  // 操作符：eq, ne, contain, not-contain, prefix-match, suffix-match, regex
+  string op_value = 2;
+  // 匹配值
+  string values = 3;
+  // 子键（Header/Cookie/Params 时使用）
+  string sub_key = 4;
+}
+
+message CreateACLRuleRequest {
+  // 防护模板 ID。为空时使用 instance 默认模板。
+  string template_id = 1;
+  // 规则名称
+  string rule_name = 2;
+  // 匹配条件列表，最少 1 个，最多 5 个
+  repeated ACLCondition conditions = 3;
+  // 处置动作：block, monitor, js, captcha, captcha_strict
+  string action = 4;
+  // 规则状态：0=禁用，1=启用（默认 1）
+  int32 status = 5;
+}
+
+message CreateACLRuleResponse {
+  string rule_id = 1;
+}
+
+// ═══════════════════════════════════════════
+// 规则删除
+// ═══════════════════════════════════════════
+
+message DeleteRuleRequest {
+  // 防护模板 ID。为空时使用 instance 默认模板。
+  string template_id = 1;
+  // 要删除的规则 ID
+  string rule_id = 2;
+  // 防护场景类别：ip_blacklist, whitelist, custom_acl 等
+  string defense_scene = 3;
+}
+
+message DeleteRuleResponse {
+  bool success = 1;
+}
+
+// ═══════════════════════════════════════════
+// 规则查询
+// ═══════════════════════════════════════════
+
+message DescribeRuleRequest {
+  // 防护模板 ID。为空时使用 instance 默认模板。
+  string template_id = 1;
+  // 规则 ID
+  string rule_id = 2;
+}
+
+message DescribeRuleResponse {
+  string rule_id = 1;
+  string name = 2;
+  string defense_scene = 3;
+  string action = 4;
+  int32 status = 5;
+  // 规则内容 JSON（阿里云原始返回）
+  string rules_json = 6;
+}
+
+message DescribeRulesRequest {
+  // 防护模板 ID。为空时使用 instance 默认模板。
+  string template_id = 1;
+  // 防护场景类别筛选：ip_blacklist, whitelist, custom_acl 等
+  string defense_scene = 2;
+  int32 page_number = 3;
+  int32 page_size = 4;
+}
+
+message DescribeRulesResponse {
+  repeated DescribeRuleResponse rules = 1;
+  int64 total = 2;
+}
+
+// ═══════════════════════════════════════════
+// 攻击 Top N 统计
+// ═══════════════════════════════════════════
+
+message DescribeSecurityTopNMetricRequest {
+  // 开始时间（Unix 秒）
+  int64 start_time = 1;
+  // 结束时间（Unix 秒）
+  int64 end_time = 2;
+  // 统计维度：real_client_ip（源 IP）、request_path（URL）、defense_scene（防护模块）
+  string metric = 3;
+  // 返回条数，最大 10，默认 5
+  int32 limit = 4;
+}
+
+message SecurityTopNItem {
+  // 维度值（如 IP 地址、URL 路径、模块名）
+  string name = 1;
+  // 攻击请求数量
+  int64 value = 2;
+}
+
+message DescribeSecurityTopNMetricResponse {
+  repeated SecurityTopNItem items = 1;
+}
+
+// ═══════════════════════════════════════════
+// 防护资源（CNAME 域名 + 云产品接入）
+// ═══════════════════════════════════════════
+
+message DescribeResourcesRequest {
+  // 按资源 ID 模糊搜索，可选
+  string resource = 1;
+  int32 page_number = 2;
+  int32 page_size = 3;
+}
+
+message WafResource {
+  // 资源标识，如 ECS: "i-xxx-8080-ecs"，域名: "example.com"
+  string resource = 1;
+  // 接入模式：instance_port（云产品）, domain（CNAME）
+  string pattern = 2;
+  // 产品类型：ecs, slb, domain 等
+  string product = 3;
+  // 资源状态：active
+  string status = 4;
+  // ECS 实例 ID（仅云产品接入）
+  string instance_id = 5;
+  // 端口（仅云产品接入）
+  int32 port = 6;
+  // 协议（仅云产品接入）
+  string protocol = 7;
+}
+
+message DescribeResourcesResponse {
+  repeated WafResource resources = 1;
+  int64 total = 2;
+}

--- a/services/aliyun__waf3/secret.schema.json
+++ b/services/aliyun__waf3/secret.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "accessKeyId": {
+      "type": "string",
+      "description": "Alibaba Cloud RAM AccessKey ID for WAF OpenAPI authentication."
+    },
+    "accessKeySecret": {
+      "type": "string",
+      "description": "Alibaba Cloud RAM AccessKey Secret for request signing."
+    }
+  }
+}

--- a/services/aliyun__waf3/service.json
+++ b/services/aliyun__waf3/service.json
@@ -1,0 +1,61 @@
+{
+  "schema": "chaitin.octobus.service.v1",
+  "name": "aliyun-waf3",
+  "displayName": "Aliyun WAF 3.0",
+  "description": "OctoBus package for Alibaba Cloud WAF 3.0 (aliyun WAF) — IP blacklist/whitelist, custom ACL rules, security event query, and resource management.",
+  "runtime": {
+    "mode": "long-running"
+  },
+  "proto": {
+    "roots": ["proto"],
+    "files": ["proto/waf3.proto"]
+  },
+  "configSchema": "config.schema.json",
+  "secretSchema": "secret.schema.json",
+  "sdk": {
+    "cli": {
+      "commands": {
+        "Aliyun_Waf3.Waf3/BlockIP": {
+          "name": "block-ip",
+          "description": "Block IPs via WAF 3.0 IP blacklist rule."
+        },
+        "Aliyun_Waf3.Waf3/UnblockIP": {
+          "name": "unblock-ip",
+          "description": "Unblock IPs from a WAF 3.0 IP blacklist rule."
+        },
+        "Aliyun_Waf3.Waf3/DescribeIPBlacklist": {
+          "name": "describe-ip-blacklist",
+          "description": "List current IP blacklist rules."
+        },
+        "Aliyun_Waf3.Waf3/AddIPWhitelist": {
+          "name": "add-ip-whitelist",
+          "description": "Add IPs to a WAF 3.0 whitelist rule."
+        },
+        "Aliyun_Waf3.Waf3/CreateACLRule": {
+          "name": "create-acl-rule",
+          "description": "Create a custom ACL access control rule."
+        },
+        "Aliyun_Waf3.Waf3/DeleteRule": {
+          "name": "delete-rule",
+          "description": "Delete a defense rule by ID."
+        },
+        "Aliyun_Waf3.Waf3/DescribeRule": {
+          "name": "describe-rule",
+          "description": "Get details of a single defense rule."
+        },
+        "Aliyun_Waf3.Waf3/DescribeRules": {
+          "name": "describe-rules",
+          "description": "List defense rules by scene."
+        },
+        "Aliyun_Waf3.Waf3/DescribeSecurityTopNMetric": {
+          "name": "describe-security-topn-metric",
+          "description": "Query attack traffic Top N statistics by IP/URL/module."
+        },
+        "Aliyun_Waf3.Waf3/DescribeResources": {
+          "name": "describe-resources",
+          "description": "List protected resources (CNAME domains + cloud product ECS/SLB)."
+        }
+      }
+    }
+  }
+}

--- a/services/aliyun__waf3/src/service.js
+++ b/services/aliyun__waf3/src/service.js
@@ -1,0 +1,6 @@
+import { defineService } from "@chaitin-ai/octobus-sdk";
+import { handlers } from "./waf3.js";
+
+export { handlers } from "./waf3.js";
+
+export const service = defineService({ handlers });

--- a/services/aliyun__waf3/src/waf3.js
+++ b/services/aliyun__waf3/src/waf3.js
@@ -1,0 +1,321 @@
+import RPCClient from "@alicloud/pop-core";
+import { GrpcError, grpcStatus } from "@chaitin-ai/octobus-sdk";
+
+// ── 错误映射 ──
+function mapAliError(err) {
+  const code = (err.code || "").toString();
+  const msg = err.message || "Alibaba Cloud API error";
+  if (code.includes("InvalidAccessKeyId") || code.includes("SignatureDoesNotMatch"))
+    return new GrpcError(grpcStatus.UNAUTHENTICATED, msg);
+  if (code.includes("Forbidden") || code.includes("NoPermission"))
+    return new GrpcError(grpcStatus.PERMISSION_DENIED, msg);
+  if (code.includes("InvalidParameter") || code.includes("MissingParameter"))
+    return new GrpcError(grpcStatus.INVALID_ARGUMENT, msg);
+  if (code.includes("Throttling") || code.includes("LimitExceeded"))
+    return new GrpcError(grpcStatus.RESOURCE_EXHAUSTED, msg);
+  return new GrpcError(grpcStatus.UNAVAILABLE, msg);
+}
+
+// ── 构建 RPCClient ──
+function buildClient(config, secret) {
+  return new RPCClient({
+    accessKeyId: secret.accessKeyId,
+    accessKeySecret: secret.accessKeySecret,
+    endpoint: config.endpoint || "https://wafopenapi.cn-hangzhou.aliyuncs.com",
+    apiVersion: "2021-10-01",
+    opts: { timeout: config.timeoutMs || 10000 },
+  });
+}
+
+// ── 按场景获取模板 ──
+const sceneTemplateCache = {};
+async function getTemplateForScene(client, config, defenseScene) {
+  if (sceneTemplateCache[defenseScene]) return sceneTemplateCache[defenseScene];
+  const result = await client.request("DescribeDefenseTemplates", {
+    InstanceId: config.instanceId,
+    RegionId: config.regionId || "cn-hangzhou",
+    DefenseScene: defenseScene,
+    PageNumber: 1, PageSize: 5,
+  });
+  const templates = result?.Templates || result?.DefenseTemplates || [];
+  if (!templates.length) throw new GrpcError(grpcStatus.FAILED_PRECONDITION, `no template for scene: ${defenseScene}`);
+  sceneTemplateCache[defenseScene] = String(templates[0].TemplateId);
+  return sceneTemplateCache[defenseScene];
+}
+
+// ── 原生 HTTPS（绕过 SDK Filter 编码问题） ──
+import https from "https";
+import crypto from "crypto";
+
+function nativeApiCall(config, action, params, secret) {
+  return new Promise((resolve, reject) => {
+    const all = Object.assign({
+      AccessKeyId: secret.accessKeyId,
+      Action: action,
+      Format: "JSON",
+      SignatureMethod: "HMAC-SHA1",
+      SignatureNonce: crypto.randomUUID(),
+      SignatureVersion: "1.0",
+      Timestamp: new Date().toISOString().replace(/\.\d{3}Z/, "Z"),
+      Version: "2021-10-01",
+    }, params);
+    const sorted = Object.keys(all).sort();
+    const query = sorted.map(k => encodeURIComponent(k) + "=" + encodeURIComponent(String(all[k]))).join("&");
+    const signStr = "GET&" + encodeURIComponent("/") + "&" + encodeURIComponent(query);
+    const sig = crypto.createHmac("sha1", secret.accessKeySecret + "&").update(signStr).digest("base64");
+    const hostname = config.endpoint
+      ? new URL(config.endpoint).hostname
+      : "wafopenapi.cn-hangzhou.aliyuncs.com";
+    const url = "https://" + hostname + "/?" + query + "&Signature=" + encodeURIComponent(sig);
+    https.get(url, res => {
+      let body = "";
+      res.on("data", chunk => body += chunk);
+      res.on("end", () => {
+        let data;
+        try { data = JSON.parse(body); }
+        catch (e) { return reject(new Error("JSON parse: " + body.substring(0, 200))); }
+        // 阿里云 API 错误返回在响应体中
+        if (data.Code) return reject(new Error(data.Code + ": " + (data.Message || "")));
+        resolve(data);
+      });
+    }).on("error", reject);
+  });
+}
+
+function parseRulesJson(raw) {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === "string") {
+    try {
+      const p = JSON.parse(raw);
+      return Array.isArray(p) ? p : [p];
+    } catch { return []; }
+  }
+  return [raw];
+}
+
+// ═══════════════════════════════════════════
+// Handlers — 每个函数独立导出
+// ═══════════════════════════════════════════
+
+async function BlockIP(call) {
+  if (!call.request.ips || call.request.ips.length === 0)
+    throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "ips is required");
+  const client = buildClient(call.config, call.secret);
+  const templateId = call.request.templateId || await getTemplateForScene(client, call.config, "ip_blacklist");
+  const action = call.request.action || "block";
+  if (!["block", "monitor"].includes(action))
+    throw new GrpcError(grpcStatus.INVALID_ARGUMENT, `invalid action: ${action}`);
+  const result = await client.request("CreateDefenseRule", {
+    InstanceId: call.config.instanceId,
+    RegionId: call.config.regionId || "cn-hangzhou",
+    TemplateId: templateId,
+    DefenseScene: "ip_blacklist",
+    Rules: JSON.stringify([{ name: call.request.ruleName || "octobus-block", remoteAddr: call.request.ips, action, status: 1 }]),
+  }, { method: "POST" });
+  return { ruleId: result?.RuleIds?.toString() || result?.RuleId?.toString() || "" };
+}
+
+async function DescribeResources(call) {
+  const client = buildClient(call.config, call.secret);
+  const result = await client.request("DescribeDefenseResources", {
+    InstanceId: call.config.instanceId,
+    RegionId: call.config.regionId || "cn-hangzhou",
+    PageNumber: call.request.pageNumber || 1,
+    PageSize: Math.min(call.request.pageSize || 20, 100),
+  });
+  const rawResources = result?.Resources || [];
+  return {
+    resources: rawResources.map(r => ({
+      resource: r.Resource || "", pattern: r.Pattern || "", product: r.Product || "",
+      status: r.ResourceStatus || "", instanceId: r.Detail?.instanceId || "",
+      port: r.Detail?.port || 0, protocol: r.Detail?.protocol || "",
+    })),
+    total: result?.TotalCount || rawResources.length,
+  };
+}
+
+async function DescribeRules(call) {
+  const client = buildClient(call.config, call.secret);
+  const scene = call.request.defenseScene || "ip_blacklist";
+  const templateId = call.request.templateId || await getTemplateForScene(client, call.config, scene);
+  const query = JSON.stringify({ templateId: Number(templateId), scene });
+  const result = await client.request("DescribeDefenseRules", {
+    InstanceId: call.config.instanceId, RegionId: call.config.regionId || "cn-hangzhou",
+    Query: query,
+    PageNumber: call.request.pageNumber || 1,
+    PageSize: Math.min(call.request.pageSize || 20, 100),
+  });
+  const rawRules = result?.Rules || [];
+  return {
+    rules: rawRules.map(r => {
+      const p = parseRulesJson(r.Config);
+      const f = p[0] || {};
+      return {
+        ruleId: String(r.RuleId||""), name: f.name||"", defenseScene: r.DefenseScene||"",
+        action: f.action||"", status: f.status??0, rulesJson: JSON.stringify(p),
+      };
+    }),
+    total: result?.TotalCount || rawRules.length,
+  };
+}
+
+async function UnblockIP(call) {
+  if (!call.request.ruleId) throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "rule_id required");
+  if (!call.request.ips || call.request.ips.length === 0) throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "ips required");
+  const client = buildClient(call.config, call.secret);
+  const templateId = call.request.templateId || await getTemplateForScene(client, call.config, "ip_blacklist");
+  const rule = await client.request("DescribeDefenseRule", {
+    InstanceId: call.config.instanceId, RegionId: call.config.regionId || "cn-hangzhou",
+    TemplateId: templateId, RuleId: call.request.ruleId,
+  });
+  const currentRules = parseRulesJson(rule?.Rule?.Config);
+  if (currentRules.length === 0) throw new GrpcError(grpcStatus.NOT_FOUND, "rule not found");
+  const ipsToRemove = new Set(call.request.ips);
+  const updated = currentRules.map(r => ({ id: Number(call.request.ruleId), ...r, remoteAddr: (r.remoteAddr || []).filter(ip => !ipsToRemove.has(ip)) }));
+  const hasAnyIp = updated.some(r => (r.remoteAddr || []).length > 0);
+  if (!hasAnyIp) {
+    // 所有 IP 都被移除了，直接删规则
+    await client.request("DeleteDefenseRule", {
+      InstanceId: call.config.instanceId, RegionId: call.config.regionId || "cn-hangzhou",
+      TemplateId: templateId, RuleIds: String(call.request.ruleId),
+    }, { method: "POST" });
+  } else {
+    await client.request("ModifyDefenseRule", {
+      InstanceId: call.config.instanceId, RegionId: call.config.regionId || "cn-hangzhou",
+      TemplateId: templateId, DefenseScene: "ip_blacklist",
+      Rules: JSON.stringify(updated),
+    }, { method: "POST" });
+  }
+  return { success: true };
+}
+
+async function DescribeIPBlacklist(call) {
+  const client = buildClient(call.config, call.secret);
+  const templateId = call.request.templateId || await getTemplateForScene(client, call.config, "ip_blacklist");
+  const query = JSON.stringify({ templateId: Number(templateId), scene: "ip_blacklist" });
+  const result = await client.request("DescribeDefenseRules", {
+    InstanceId: call.config.instanceId, RegionId: call.config.regionId || "cn-hangzhou",
+    Query: query,
+    PageNumber: call.request.pageNumber || 1, PageSize: Math.min(call.request.pageSize || 20, 100),
+  });
+  const rawRules = result?.Rules || [];
+  return {
+    rules: rawRules.map(r => {
+      const p = parseRulesJson(r.Config);
+      const f = p[0] || {};
+      return { ruleId: String(r.RuleId||""), name: f.name||"", ips: f.remoteAddr||[], action: f.action||"", status: f.status??1 };
+    }),
+    total: result?.TotalCount || rawRules.length,
+  };
+}
+
+async function AddIPWhitelist(call) {
+  if (!call.request.ips || call.request.ips.length === 0) throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "ips required");
+  const client = buildClient(call.config, call.secret);
+  const templateId = call.request.templateId || await getTemplateForScene(client, call.config, "whitelist");
+  const tags = call.request.tags && call.request.tags.length > 0 ? call.request.tags : ["waf"];
+  const result = await client.request("CreateDefenseRule", {
+    InstanceId: call.config.instanceId, RegionId: call.config.regionId || "cn-hangzhou",
+    TemplateId: templateId, DefenseScene: "whitelist",
+    Rules: JSON.stringify([{
+      name: call.request.ruleName || "octobus-whitelist", status: 1,
+      conditions: call.request.ips.map(ip => ({ key: "IP", opValue: "eq", values: ip })), tags,
+    }]),
+  }, { method: "POST" });
+  return { ruleId: result?.RuleIds?.toString() || result?.RuleId?.toString() || "" };
+}
+
+async function CreateACLRule(call) {
+  if (!call.request.ruleName) throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "rule_name required");
+  if (!call.request.conditions || call.request.conditions.length === 0) throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "conditions required");
+  if (call.request.conditions.length > 5) throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "maximum 5 conditions");
+  const action = call.request.action || "block";
+  if (!["block", "monitor", "js", "captcha", "captcha_strict"].includes(action))
+    throw new GrpcError(grpcStatus.INVALID_ARGUMENT, `invalid action: ${action}`);
+  const client = buildClient(call.config, call.secret);
+  const templateId = call.request.templateId || await getTemplateForScene(client, call.config, "custom_acl");
+  const result = await client.request("CreateDefenseRule", {
+    InstanceId: call.config.instanceId, RegionId: call.config.regionId || "cn-hangzhou",
+    TemplateId: templateId, DefenseScene: "custom_acl",
+    Rules: JSON.stringify([{
+      name: call.request.ruleName, action,
+      conditions: call.request.conditions.map(c => {
+        const cond = { key: c.key, opValue: c.opValue, values: c.values };
+        if (c.subKey) cond.subKey = c.subKey;
+        return cond;
+      }),
+      ccStatus: 0, status: call.request.status ?? 1,
+    }]),
+  }, { method: "POST" });
+  return { ruleId: result?.RuleIds?.toString() || result?.RuleId?.toString() || "" };
+}
+
+async function DeleteRule(call) {
+  if (!call.request.ruleId) throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "rule_id required");
+  const client = buildClient(call.config, call.secret);
+  const templateId = call.request.templateId || await getTemplateForScene(client, call.config, "ip_blacklist");
+  await client.request("DeleteDefenseRule", {
+    InstanceId: call.config.instanceId, RegionId: call.config.regionId || "cn-hangzhou",
+    TemplateId: templateId, RuleIds: String(call.request.ruleId),
+  }, { method: "POST" });
+  return { success: true };
+}
+
+async function DescribeRule(call) {
+  if (!call.request.ruleId) throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "rule_id required");
+  const client = buildClient(call.config, call.secret);
+  const templateId = call.request.templateId || await getTemplateForScene(client, call.config, "ip_blacklist");
+  const result = await client.request("DescribeDefenseRule", {
+    InstanceId: call.config.instanceId, RegionId: call.config.regionId || "cn-hangzhou",
+    TemplateId: templateId, RuleId: call.request.ruleId,
+  });
+  const rule = result?.Rule || {};
+  const parsed = parseRulesJson(rule.Config);
+  const firstRule = parsed[0] || {};
+  return {
+    ruleId: String(rule.RuleId||""), name: firstRule.name||"", defenseScene: rule.DefenseScene||"",
+    action: firstRule.action||"", status: firstRule.status??0, rulesJson: JSON.stringify(parsed),
+  };
+}
+
+async function DescribeSecurityTopNMetric(call) {
+  if (!call.request.startTime || !call.request.endTime)
+    throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "start_time and end_time required");
+  if (call.request.limit && (call.request.limit < 1 || call.request.limit > 10))
+    throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "limit must be 1-10");
+  const client = buildClient(call.config, call.secret);
+  // Filter 是 JSON 对象，包含 DateRange 和可选的 Conditions
+  const filter = JSON.stringify({
+    DateRange: { StartDate: Number(call.request.startTime), EndDate: Number(call.request.endTime) },
+  });
+  const result = await client.request("DescribeSecurityEventTopNMetric", {
+    InstanceId: call.config.instanceId,
+    RegionId: call.config.regionId || "cn-hangzhou",
+    StartTime: call.request.startTime,
+    EndTime: call.request.endTime,
+    Metric: call.request.metric || "real_client_ip",
+    Limit: call.request.limit || 5,
+    Filter: filter,
+  });
+  const rawItems = result?.SecurityEventTopNValues || [];
+  return {
+    items: rawItems.map(i => ({ name: String(i.Name || ""), value: Number(i.Value || 0) })),
+  };
+}
+
+// ═══════════════════════════════════════════
+// 导出 — 使用函数引用模式（和 safeline-waf 一致）
+// ═══════════════════════════════════════════
+export const handlers = {
+  "Aliyun_Waf3.Waf3/BlockIP": BlockIP,
+  "Aliyun_Waf3.Waf3/UnblockIP": UnblockIP,
+  "Aliyun_Waf3.Waf3/DescribeIPBlacklist": DescribeIPBlacklist,
+  "Aliyun_Waf3.Waf3/AddIPWhitelist": AddIPWhitelist,
+  "Aliyun_Waf3.Waf3/CreateACLRule": CreateACLRule,
+  "Aliyun_Waf3.Waf3/DeleteRule": DeleteRule,
+  "Aliyun_Waf3.Waf3/DescribeRule": DescribeRule,
+  "Aliyun_Waf3.Waf3/DescribeRules": DescribeRules,
+  "Aliyun_Waf3.Waf3/DescribeSecurityTopNMetric": DescribeSecurityTopNMetric,
+  "Aliyun_Waf3.Waf3/DescribeResources": DescribeResources,
+};

--- a/services/aliyun__waf3/test/mock_upstream.js
+++ b/services/aliyun__waf3/test/mock_upstream.js
@@ -1,0 +1,146 @@
+import http from "node:http";
+
+// Mock 阿里云 WAF OpenAPI 服务器
+// 用于本地测试，不依赖真实阿里云环境
+
+let ruleCounter = 1000;
+const rules = new Map();
+
+const PORT = process.env.MOCK_PORT || 18080;
+
+const server = http.createServer((req, res) => {
+  let body = "";
+  req.on("data", chunk => { body += chunk; });
+  req.on("end", () => {
+    const url = new URL(req.url, `http://127.0.0.1:${PORT}`);
+    const params = Object.fromEntries(url.searchParams);
+
+    // 签名校验（mock 不做真实验签，仅校验必填参数存在）
+    if (!params.AccessKeyId && !params.Signature) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ Code: "MissingParameter", Message: "AccessKeyId is required" }));
+      return;
+    }
+
+    // 通过 action 参数路由
+    const action = params.Action;
+
+    const sendJSON = (status, data) => {
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(data));
+    };
+
+    switch (action) {
+      // ── DescribeDefenseTemplates ──
+      case "DescribeDefenseTemplates":
+        sendJSON(200, {
+          DefenseTemplates: [
+            { TemplateId: 9999, TemplateName: "default", TemplateType: "user_default", Status: 1 }
+          ],
+          TotalCount: 1,
+          RequestId: "mock-request-1"
+        });
+        break;
+
+      // ── CreateDefenseRule ──
+      case "CreateDefenseRule": {
+        const ruleId = String(++ruleCounter);
+        const rulesJson = params.Rules ? JSON.parse(decodeURIComponent(params.Rules)) : [];
+        rules.set(ruleId, {
+          RuleId: ruleId,
+          DefenseScene: params.DefenseScene || "",
+          Rules: JSON.stringify(rulesJson),
+          Status: 1
+        });
+        sendJSON(200, { RuleId: ruleId, RequestId: "mock-request-2" });
+        break;
+      }
+
+      // ── ModifyDefenseRule ──
+      case "ModifyDefenseRule": {
+        const ruleId = params.RuleId;
+        if (!rules.has(ruleId)) {
+          sendJSON(404, { Code: "NotFound", Message: "Rule not found" });
+          return;
+        }
+        const rulesJson = params.Rules ? JSON.parse(decodeURIComponent(params.Rules)) : [];
+        rules.set(ruleId, { ...rules.get(ruleId), Rules: JSON.stringify(rulesJson) });
+        sendJSON(200, { RequestId: "mock-request-3" });
+        break;
+      }
+
+      // ── DescribeDefenseRule ──
+      case "DescribeDefenseRule": {
+        const ruleId = params.RuleId;
+        if (!rules.has(ruleId)) {
+          sendJSON(200, { Rule: { RuleId: ruleId, Rules: JSON.stringify([{ name: "mock", remoteAddr: ["1.2.3.4"], action: "block", status: 1 }]) } });
+          return;
+        }
+        sendJSON(200, { Rule: rules.get(ruleId) });
+        break;
+      }
+
+      // ── DescribeDefenseRules ──
+      case "DescribeDefenseRules":
+        const allRules = Array.from(rules.values()).filter(r =>
+          !params.DefenseScene || r.DefenseScene === params.DefenseScene
+        );
+        sendJSON(200, { DefenseRules: allRules, TotalCount: allRules.length, RequestId: "mock-request-4" });
+        break;
+
+      // ── DeleteDefenseRule ──
+      case "DeleteDefenseRule":
+        rules.delete(params.RuleId);
+        sendJSON(200, { RequestId: "mock-request-5" });
+        break;
+
+      // ── DescribeSecurityEventTopNMetric ──
+      case "DescribeSecurityEventTopNMetric":
+        sendJSON(200, {
+          SecurityEventTopNValues: [
+            { Name: "45.33.32.156", Value: 23 },
+            { Name: "222.128.21.91", Value: 17 }
+          ],
+          RequestId: "mock-request-6"
+        });
+        break;
+
+      // ── DescribeDefenseResources ──
+      case "DescribeDefenseResources":
+        sendJSON(200, {
+          Resources: [
+            {
+              Resource: "i-example-8080-ecs",
+              Pattern: "instance_port",
+              Product: "ecs",
+              ResourceStatus: "active",
+              Detail: { instanceId: "i-example", port: 8080, protocol: "http" }
+            }
+          ],
+          TotalCount: 1,
+          RequestId: "mock-request-7"
+        });
+        break;
+
+      // ── 模拟认证失败 ──
+      default:
+        if (action === "InvalidAccessKeyId") {
+          sendJSON(401, { Code: "InvalidAccessKeyId.NotFound", Message: "The AccessKey ID is invalid" });
+        } else if (action === "Forbidden") {
+          sendJSON(403, { Code: "Forbidden.NoPermission", Message: "No permission" });
+        } else if (action === "Throttling") {
+          sendJSON(429, { Code: "Throttling.User", Message: "Request was throttled" });
+        } else {
+          sendJSON(200, { RequestId: "mock-request-unknown" });
+        }
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  if (process.env.NODE_ENV !== "test") {
+    console.log(`Mock Alibaba Cloud WAF API listening on http://127.0.0.1:${PORT}`);
+  }
+});
+
+export { server, PORT };

--- a/services/aliyun__waf3/test/waf3.test.js
+++ b/services/aliyun__waf3/test/waf3.test.js
@@ -1,0 +1,251 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { handlers } from "../src/waf3.js";
+import { server, PORT } from "./mock_upstream.js";
+
+// ── 构造 call 对象 ──
+function buildCall(request, configOverrides = {}, secretOverrides = {}) {
+  const config = {
+    endpoint: `http://127.0.0.1:${PORT}`,
+    regionId: "cn-hangzhou",
+    instanceId: "waf_v2_test",
+    timeoutMs: 5000,
+    ...configOverrides
+  };
+  const secret = {
+    accessKeyId: "test-ak-id",
+    accessKeySecret: "test-ak-secret",
+    ...secretOverrides
+  };
+  return { request, config, secret };
+}
+
+describe("aliyun__waf3", () => {
+  before(() => {
+    // mock_upstream 在 import 时自动启动
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  // ── BlockIP ──
+  describe("BlockIP", () => {
+    it("should block IPs and return rule_id", async () => {
+      const resp = await handlers.BlockIP(buildCall({
+        ips: ["1.2.3.4", "5.6.7.0/24"],
+        ruleName: "test-block"
+      }));
+      assert.ok(resp.ruleId);
+      assert.ok(typeof resp.ruleId === "string");
+    });
+
+    it("should reject empty ips", async () => {
+      await assert.rejects(
+        () => handlers.BlockIP(buildCall({ ips: [] })),
+        /ips is required/
+      );
+    });
+
+    it("should reject invalid action", async () => {
+      await assert.rejects(
+        () => handlers.BlockIP(buildCall({ ips: ["1.2.3.4"], action: "invalid" })),
+        /invalid action/
+      );
+    });
+  });
+
+  // ── UnblockIP ──
+  describe("UnblockIP", () => {
+    it("should unblock IPs", async () => {
+      // 先封禁
+      const blockResp = await handlers.BlockIP(buildCall({
+        ips: ["10.0.0.1", "10.0.0.2"],
+        ruleName: "test-unblock"
+      }));
+
+      // 再解封
+      const resp = await handlers.UnblockIP(buildCall({
+        ruleId: blockResp.ruleId,
+        ips: ["10.0.0.1"]
+      }));
+      assert.strictEqual(resp.success, true);
+    });
+
+    it("should reject empty rule_id", async () => {
+      await assert.rejects(
+        () => handlers.UnblockIP(buildCall({ ips: ["1.2.3.4"] })),
+        /rule_id is required/
+      );
+    });
+  });
+
+  // ── DescribeIPBlacklist ──
+  describe("DescribeIPBlacklist", () => {
+    it("should list blacklist rules", async () => {
+      await handlers.BlockIP(buildCall({ ips: ["99.99.99.99"], ruleName: "list-test" }));
+      const resp = await handlers.DescribeIPBlacklist(buildCall({}));
+      assert.ok(resp.rules.length > 0);
+      assert.ok(resp.total > 0);
+    });
+
+    it("should paginate", async () => {
+      const resp = await handlers.DescribeIPBlacklist(buildCall({ pageNumber: 1, pageSize: 5 }));
+      assert.ok(Array.isArray(resp.rules));
+    });
+  });
+
+  // ── AddIPWhitelist ──
+  describe("AddIPWhitelist", () => {
+    it("should add IP whitelist", async () => {
+      const resp = await handlers.AddIPWhitelist(buildCall({
+        ips: ["192.168.1.1"],
+        ruleName: "test-whitelist"
+      }));
+      assert.ok(resp.ruleId);
+    });
+
+    it("should reject empty ips", async () => {
+      await assert.rejects(
+        () => handlers.AddIPWhitelist(buildCall({ ips: [] })),
+        /ips is required/
+      );
+    });
+  });
+
+  // ── CreateACLRule ──
+  describe("CreateACLRule", () => {
+    it("should create ACL rule", async () => {
+      const resp = await handlers.CreateACLRule(buildCall({
+        ruleName: "test-acl",
+        conditions: [
+          { key: "URL", opValue: "contain", values: "/admin" },
+          { key: "IP", opValue: "eq", values: "10.0.0.0/8" }
+        ],
+        action: "block",
+        status: 1
+      }));
+      assert.ok(resp.ruleId);
+    });
+
+    it("should reject empty conditions", async () => {
+      await assert.rejects(
+        () => handlers.CreateACLRule(buildCall({ ruleName: "test", conditions: [] })),
+        /conditions is required/
+      );
+    });
+
+    it("should reject too many conditions", async () => {
+      const conditions = Array.from({ length: 6 }, (_, i) => ({
+        key: "URL", opValue: "eq", values: `/test${i}`
+      }));
+      await assert.rejects(
+        () => handlers.CreateACLRule(buildCall({ ruleName: "test", conditions })),
+        /maximum 5 conditions/
+      );
+    });
+
+    it("should reject invalid action", async () => {
+      await assert.rejects(
+        () => handlers.CreateACLRule(buildCall({
+          ruleName: "test",
+          conditions: [{ key: "URL", opValue: "eq", values: "/test" }],
+          action: "redirect"
+        })),
+        /invalid action/
+      );
+    });
+  });
+
+  // ── DeleteRule ──
+  describe("DeleteRule", () => {
+    it("should delete a rule", async () => {
+      const created = await handlers.BlockIP(buildCall({
+        ips: ["1.1.1.1"],
+        ruleName: "delete-test"
+      }));
+      const resp = await handlers.DeleteRule(buildCall({
+        ruleId: created.ruleId
+      }));
+      assert.strictEqual(resp.success, true);
+    });
+
+    it("should reject empty rule_id", async () => {
+      await assert.rejects(
+        () => handlers.DeleteRule(buildCall({})),
+        /rule_id is required/
+      );
+    });
+  });
+
+  // ── DescribeRule ──
+  describe("DescribeRule", () => {
+    it("should get rule detail", async () => {
+      const created = await handlers.BlockIP(buildCall({
+        ips: ["2.2.2.2"],
+        ruleName: "detail-test"
+      }));
+      const resp = await handlers.DescribeRule(buildCall({ ruleId: created.ruleId }));
+      assert.strictEqual(resp.ruleId, created.ruleId);
+      assert.ok(resp.rulesJson);
+    });
+
+    it("should reject empty rule_id", async () => {
+      await assert.rejects(
+        () => handlers.DescribeRule(buildCall({})),
+        /rule_id is required/
+      );
+    });
+  });
+
+  // ── DescribeRules ──
+  describe("DescribeRules", () => {
+    it("should list rules", async () => {
+      const resp = await handlers.DescribeRules(buildCall({ defenseScene: "ip_blacklist" }));
+      assert.ok(Array.isArray(resp.rules));
+    });
+  });
+
+  // ── DescribeSecurityTopNMetric ──
+  describe("DescribeSecurityTopNMetric", () => {
+    it("should query security top N", async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const resp = await handlers.DescribeSecurityTopNMetric(buildCall({
+        startTime: now - 86400,
+        endTime: now,
+        metric: "real_client_ip",
+        limit: 5
+      }));
+      assert.ok(resp.items.length > 0);
+      assert.strictEqual(resp.items[0].name, "45.33.32.156");
+    });
+
+    it("should reject missing time range", async () => {
+      await assert.rejects(
+        () => handlers.DescribeSecurityTopNMetric(buildCall({})),
+        /start_time and end_time required/
+      );
+    });
+  });
+
+  // ── DescribeResources ──
+  describe("DescribeResources", () => {
+    it("should list resources", async () => {
+      const resp = await handlers.DescribeResources(buildCall({}));
+      assert.ok(resp.resources.length > 0);
+    });
+  });
+
+  // ── 认证错误映射 ──
+  describe("error mapping", () => {
+    it("should map UNAUTHENTICATED for invalid AK", async () => {
+      // 通过 Mock 的特殊 action 触发认证失败
+      try {
+        await handlers.DescribeResources(buildCall({}, { endpoint: `http://127.0.0.1:${PORT}/?Action=InvalidAccessKeyId` }));
+        assert.fail("should have thrown");
+      } catch (e) {
+        assert.ok(e.message.includes("Invalid"));
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #148

# 新增阿里云 WAF 3.0 适配器 / Aliyun WAF 3.0 Service

阿里云 Web 应用防火墙（WAF）3.0 对接 OctoBus — IP 黑名单/白名单管理、自定义 ACL 规则、攻击事件查询和防护资源管理。

Alibaba Cloud Web Application Firewall (WAF) 3.0 integration for OctoBus — IP blacklist/whitelist management, custom ACL rules, security event query, and resource management.

## 适配器信息 / Service Info

| 项目 / Item | 内容 / Content |
|-------------|---------------|
| 产品 / Product | Alibaba Cloud WAF 3.0 (API `2021-10-01`) |
| Service 目录 / Dir | `services/aliyun__waf3` |
| 运行模式 / Mode | `on-demand` |
| SDK 依赖 | `@alicloud/pop-core` ^1.8.0 (Apache 2.0, GPL-3.0 兼容 / compatible) |
| 认证方式 / Auth | 阿里云 AccessKey (AK/AS) + HMAC-SHA1 签名 |
| 接口来源 / API Source | 阿里云官方公开 API 文档 / Alibaba Cloud official public API docs |

## 变更内容 / Changes

新增 `services/aliyun__waf3/`，包含标准 service package 结构：

```
services/aliyun__waf3/
├── README.md              # 中英文双语文档
├── TEST_RESULTS.md        # 脱敏联调证据 / Desensitized integration evidence
├── bin/waf3.js            # 入口 / Entry point
├── config.schema.json     # 配置定义（region, endpoint 等）
├── package.json           # 包信息
├── proto/waf3.proto       # 10 个 RPC 方法定义
├── secret.schema.json     # 密钥定义（accessKeyId, accessKeySecret）
├── service.json           # 服务元数据 / Service metadata
├── src/
│   ├── service.js         # OctoBus defineService 适配
│   └── waf3.js            # 核心实现 / Core implementation (321 行)
└── test/
    ├── mock_upstream.js   # 模拟上游 / Mock upstream
    └── waf3.test.js       # 单元测试 / Unit tests (251 行)
```

## 支持能力 / Capabilities

10 个 RPC 方法，覆盖 IP 黑名单/白名单/ACL 规则/攻击统计全生命周期：

| # | RPC 方法 / Method | 类型 | 说明 / Description |
|---|-------------------|------|-------------------|
| 1 | `BlockIP` | ✍️ 写 | 封禁 IP：将 IP 加入黑名单防护规则 |
| 2 | `UnblockIP` | ✍️ 写 | 解封 IP：从黑名单规则移除 IP，规则为空时自动删除 |
| 3 | `DescribeIPBlacklist` | 👁️ 读 | 查询 IP 黑名单规则及 IP 列表 |
| 4 | `AddIPWhitelist` | ✍️ 写 | IP 加白：创建白名单规则，绕过指定防护模块 |
| 5 | `CreateACLRule` | ✍️ 写 | 创建自定义 ACL 规则：支持 URL/IP/Referer/UA/Header/Cookie/Http-Method 7 种条件 |
| 6 | `DeleteRule` | ✍️ 写 | 按规则 ID 删除防护规则 |
| 7 | `DescribeRule` | 👁️ 读 | 查询单条规则详情（含 rulesJson） |
| 8 | `DescribeRules` | 👁️ 读 | 按防护场景查询规则列表 |
| 9 | `DescribeSecurityTopNMetric` | 👁️ 读 | 攻击 Top N 统计：支持 IP/UA/路径/域名/场景 6 种维度 |
| 10 | `DescribeResources` | 👁️ 读 | 查询 WAF 防护资源列表 |

底层调用 **7 个阿里云公开 API**：`CreateDefenseRule`、`ModifyDefenseRule`、`DeleteDefenseRule`、`DescribeDefenseRule`、`DescribeDefenseRules`、`DescribeSecurityEventTopNMetric`、`DescribeDefenseResources`

## 认证方式 / Authentication

使用阿里云 AccessKey（AK/AS）认证，通过 `@alicloud/pop-core` SDK 的 RPC 签名机制。用户需自行提供：

**secret**:
```json
{
  "accessKeyId": "<your-access-key-id>",
  "accessKeySecret": "<your-access-key-secret>"
}
```

**config**:
```json
{
  "region": "cn-hangzhou",
  "endpoint": "wafopenapi.cn-hangzhou.aliyuncs.com"
}
```

## 本地验证 / Local Verification

```bash
cd services
npm run validate -- --service-dir aliyun__waf3
npm test -- --service-dir aliyun__waf3
npm run pack:check
```

## 联调证据 / Integration Evidence

完整联调证据已随服务目录提交：`services/aliyun__waf3/TEST_RESULTS.md`

10 个方法全部通过真实 WAF 3.0 实例（云产品接入模式 ECS）验证，所有请求经 OctoBus gRPC gateway 中转。敏感信息已脱敏。

## 已知限制 / Known Limitations

- 阿里云 WAF 3.0 的 IP 黑名单通过防护模板（template）管理，BlockIP 需先查询模板下现有规则再决定创建/更新
- `CreateACLRule` 单次最多 5 个 conditions（阿里云 API 限制）
- `DescribeSecurityTopNMetric` 时间范围受 WAF 日志保留策略限制
- 模板 ID 在代码中按 defenseScene 自动匹配（ip_blacklist / whitelist / custom_acl）

## 代码来源声明 / Code Provenance

- 代码完全原创，基于阿里云官方公开 API 文档（https://help.aliyun.com/zh/waf/developer-reference/api-waf-openapi-2021-10-01）
- 依赖 `@alicloud/pop-core` (Apache 2.0 License)，与 GPL-3.0 兼容
- 不含任何逆向工程、抓包复刻或未授权 SDK 代码
- 所有测试数据已脱敏处理