### PR TITLE
Add geyecloud-ATD service adapter

### DIFF
--- a/services/geyecloud__atd_v2-3-6/README.md
+++ b/services/geyecloud__atd_v2-3-6/README.md
@@ -1,0 +1,85 @@
+# geyecloud-ATD OctoBus Service
+
+Read-only OctoBus service adapter for the geyecloud-ATD / Advanced Threat Detection workbench API.
+
+## Supported Product
+
+- Product: geyecloud-ATD, shown by the UI as "高级威胁检测系统"
+- API document: `ATD API接口汇总.pdf`
+- Validated environment shape: `https://<host>:5443/workbenchApi/furious/...`
+
+## Authentication
+
+The UI login returns an `apiKey`. Runtime calls send it as the `api-key` header. The browser bundle also emits ATD request metadata headers:
+
+- `api-key: <secret.apiKey>`
+- `user-key: ""`
+- `X-Ca-Timestamp`
+- `X-Ca-Nonce`
+- `X-Ca-Sign: md5(timestamp + nonce)`
+
+The adapter does not store usernames or passwords.
+
+## Configuration
+
+```json
+{
+  "baseUrl": "https://192.0.2.10:5443",
+  "skipTlsVerify": true,
+  "timeoutMs": 10000
+}
+```
+
+## Secret
+
+```json
+{
+  "apiKey": "<masked>"
+}
+```
+
+## Methods
+
+| RPC | Upstream endpoint | Risk |
+|---|---|---|
+| `AggregateThreatEvents` | `POST /workbenchApi/furious/elasticSearch/aggregate` | read-only |
+| `GetNetworkLogTimeTrend` | `POST /workbenchApi/furious/netWorkLog/timeTrend` | read-only |
+| `GetNetworkLogDimensionStatistics` | `POST /workbenchApi/furious/netWorkLog/dimensionStatistics` | read-only |
+| `ListNetworkLogs` | `POST /workbenchApi/furious/netWorkLog/list` | read-only |
+| `GetNetworkLogDetail` | `POST /workbenchApi/furious/netWorkLog/details` | read-only |
+| `ListFileDetectionLogs` | `POST /workbenchApi/furious/fileDetectionLog/list` | read-only |
+| `GetFileDetectionLogDetail` | `POST /workbenchApi/furious/fileDetectionLog/details` | read-only |
+| `GetFileDetectionSeverityStats` | `POST /workbenchApi/furious/fileDetectionLog/severityNumber` | read-only |
+| `ListSceneMonitors` | `POST /workbenchApi/furious/sceneMonitor/querySceneMonitor` | read-only |
+| `SearchSceneMonitorEvents` | `POST /workbenchApi/furious/sceneMonitor/searchFromMonitor` | read-only |
+| `GetSituationOverview` | `GET /workbenchApi/furious/situationAwareness/...` | read-only |
+| `SearchThreatEvents` | `POST /workbenchApi/furious/searchCenter/advanced/searchData` | read-only |
+| `GetThreatEventDetail` | `POST /workbenchApi/furious/searchCenter/advanced/searchDataDetail` | read-only |
+
+## Suggested Capset
+
+Use this service in a read-only investigation capset, for example `geyecloud-atd-readonly-investigation`.
+
+## Validation
+
+Local checks:
+
+```bash
+npm test
+npm run validate
+npm run pack:check
+```
+
+Real API validation performed against the provided demo environment:
+
+- Request: `POST /workbenchApi/furious/elasticSearch/aggregate`
+- Headers: `api-key` masked, ATD signature headers present
+- Body: `{"terms":"severity","tableName":"hw","from":1,"size":10,...}`
+- Result: `HTTP 200`, `code: 200`, `msg: "success"`, aggregate buckets returned
+- P0 expansion adds mocked coverage for file detection pagination, situation overview GET calls, and advanced threat search response mapping.
+
+## Known Limits
+
+- First version is intentionally read-only.
+- Login automation is not part of the adapter because the current environment has captcha enabled. Provide an `apiKey` from login/API-key provisioning as the secret.
+- The PDF contains many writable configuration and management APIs; those are deferred until a controlled write-test object and cleanup path are available.

--- a/services/geyecloud__atd_v2-3-6/bin/geyecloud-atd.js
+++ b/services/geyecloud__atd_v2-3-6/bin/geyecloud-atd.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import { runServiceMain } from "@chaitin-ai/octobus-sdk";
+
+import { service } from "../src/service.js";
+
+runServiceMain(service, {
+  entryFile: fileURLToPath(new URL("./geyecloud-atd.js", import.meta.url)),
+});

--- a/services/geyecloud__atd_v2-3-6/config.schema.json
+++ b/services/geyecloud__atd_v2-3-6/config.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "baseUrl"
+  ],
+  "properties": {
+    "baseUrl": {
+      "type": "string",
+      "title": "geyecloud-ATD Base URL",
+      "description": "geyecloud-ATD workbench base URL, for example https://192.0.2.10:5443"
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "title": "Request Timeout (ms)",
+      "default": 10000,
+      "minimum": 1000
+    },
+    "skipTlsVerify": {
+      "type": "boolean",
+      "title": "Skip TLS Verification",
+      "default": false
+    }
+  }
+}

--- a/services/geyecloud__atd_v2-3-6/package.json
+++ b/services/geyecloud__atd_v2-3-6/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "geyecloud-atd",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "files": [
+    "README.md",
+    "bin/",
+    "src/",
+    "proto/",
+    "service.json",
+    "config.schema.json",
+    "secret.schema.json"
+  ],
+  "bin": {
+    "geyecloud-atd": "bin/geyecloud-atd.js"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js",
+    "pack:check": "npm pack --dry-run",
+    "validate": "octobus-sdk validate --strict"
+  },
+  "dependencies": {
+    "@chaitin-ai/octobus-sdk": "^0.5.0"
+  }
+}

--- a/services/geyecloud__atd_v2-3-6/proto/geyecloud_atd.proto
+++ b/services/geyecloud__atd_v2-3-6/proto/geyecloud_atd.proto
@@ -1,0 +1,346 @@
+syntax = "proto3";
+
+package geyecloud.atd.v1;
+
+service GEYECloudATD {
+  rpc AggregateThreatEvents(AggregateThreatEventsRequest) returns (AggregateThreatEventsResponse);
+  rpc GetNetworkLogTimeTrend(NetworkLogQueryRequest) returns (NetworkLogTimeTrendResponse);
+  rpc GetNetworkLogDimensionStatistics(NetworkLogDimensionStatisticsRequest) returns (NetworkLogDimensionStatisticsResponse);
+  rpc ListNetworkLogs(ListNetworkLogsRequest) returns (ListNetworkLogsResponse);
+  rpc GetNetworkLogDetail(GetNetworkLogDetailRequest) returns (GetNetworkLogDetailResponse);
+  rpc ListFileDetectionLogs(ListFileDetectionLogsRequest) returns (ListFileDetectionLogsResponse);
+  rpc GetFileDetectionLogDetail(GetFileDetectionLogDetailRequest) returns (GetFileDetectionLogDetailResponse);
+  rpc GetFileDetectionSeverityStats(FileDetectionQueryRequest) returns (FileDetectionSeverityStatsResponse);
+  rpc ListSceneMonitors(ListSceneMonitorsRequest) returns (ListSceneMonitorsResponse);
+  rpc SearchSceneMonitorEvents(SearchSceneMonitorEventsRequest) returns (SearchThreatEventsResponse);
+  rpc GetSituationOverview(GetSituationOverviewRequest) returns (GetSituationOverviewResponse);
+  rpc SearchThreatEvents(SearchThreatEventsRequest) returns (SearchThreatEventsResponse);
+  rpc GetThreatEventDetail(GetThreatEventDetailRequest) returns (GetThreatEventDetailResponse);
+}
+
+message AggregateThreatEventsRequest {
+  int64 start = 1;
+  int64 end = 2;
+  int32 page = 3;
+  int32 page_size = 4;
+  string terms = 5;
+  string table_name = 6;
+}
+
+message AggregateItem {
+  string key = 1;
+  int64 value = 2;
+}
+
+message AggregateThreatEventsResponse {
+  int32 code = 1;
+  string message = 2;
+  int64 count = 3;
+  int64 total_count = 4;
+  repeated AggregateItem items = 5;
+}
+
+message NetworkLogQueryRequest {
+  int64 start = 1;
+  int64 end = 2;
+  string src_ip = 3;
+  string dst_ip = 4;
+  string app_proto = 5;
+  string host = 6;
+  string query_string = 7;
+  string filter_query_string = 8;
+}
+
+message TrendPoint {
+  int64 timestamp = 1;
+  string time = 2;
+  int64 count = 3;
+}
+
+message NetworkLogTimeTrendResponse {
+  int32 code = 1;
+  string message = 2;
+  repeated TrendPoint items = 3;
+}
+
+message NetworkLogDimensionStatisticsRequest {
+  int64 start = 1;
+  int64 end = 2;
+  string dimension_key = 3;
+  string src_ip = 4;
+  string dst_ip = 5;
+  string app_proto = 6;
+  string host = 7;
+  string query_string = 8;
+  string filter_query_string = 9;
+  int32 page = 10;
+  int32 page_size = 11;
+}
+
+message DimensionStatistic {
+  string key = 1;
+  string name = 2;
+  int64 value = 3;
+  int64 count = 4;
+}
+
+message NetworkLogDimensionStatisticsResponse {
+  int32 code = 1;
+  string message = 2;
+  repeated DimensionStatistic items = 3;
+}
+
+message ListNetworkLogsRequest {
+  int64 start = 1;
+  int64 end = 2;
+  string src_ip = 3;
+  string dst_ip = 4;
+  string src_port = 5;
+  string dst_port = 6;
+  string app_proto = 7;
+  string host = 8;
+  string uri = 9;
+  string uid = 10;
+  string uuid = 11;
+  string query_string = 12;
+  string filter_query_string = 13;
+  string sort = 14;
+  string order = 15;
+  int32 page = 16;
+  int32 page_size = 17;
+  bool is_translate = 18;
+}
+
+message NetworkLog {
+  int64 timestamp = 1;
+  string uid = 2;
+  string src_ip = 3;
+  int32 src_port = 4;
+  string dst_ip = 5;
+  int32 dst_port = 6;
+  string app_proto = 7;
+  string host = 8;
+  string uri = 9;
+  string proto = 10;
+  int64 bytes = 11;
+  int64 packets = 12;
+  int64 sensor_id = 13;
+}
+
+message ListNetworkLogsResponse {
+  int32 code = 1;
+  string message = 2;
+  int64 total = 3;
+  int32 page_size = 4;
+  int32 current = 5;
+  int32 pages = 6;
+  repeated NetworkLog items = 7;
+}
+
+message GetNetworkLogDetailRequest {
+  string detail_id = 1;
+  int64 query_timestamp = 2;
+  int64 start = 3;
+  int64 end = 4;
+}
+
+message GetNetworkLogDetailResponse {
+  int32 code = 1;
+  string message = 2;
+  NetworkLog log = 3;
+}
+
+message FileDetectionQueryRequest {
+  int64 start = 1;
+  int64 end = 2;
+  string file_md5 = 3;
+  string email_from = 4;
+  string src_ip = 5;
+  string dst_ip = 6;
+  string app_proto = 7;
+  string host = 8;
+  string query_string = 9;
+  string filter_query_string = 10;
+  string file_type = 11;
+}
+
+message ListFileDetectionLogsRequest {
+  int64 start = 1;
+  int64 end = 2;
+  string file_md5 = 3;
+  string email_from = 4;
+  string src_ip = 5;
+  string dst_ip = 6;
+  string app_proto = 7;
+  string host = 8;
+  string query_string = 9;
+  string filter_query_string = 10;
+  string file_type = 11;
+  string sort = 12;
+  string order = 13;
+  int32 page = 14;
+  int32 page_size = 15;
+  bool is_translate = 16;
+}
+
+message FileDetectionLog {
+  int64 timestamp = 1;
+  string uuid = 2;
+  string file_name = 3;
+  string file_md5 = 4;
+  string file_type = 5;
+  string file_size = 6;
+  string src_ip = 7;
+  string dst_ip = 8;
+  int32 severity = 9;
+  string classtype = 10;
+  string category = 11;
+  string engine_type = 12;
+  int64 sensor_id = 13;
+}
+
+message ListFileDetectionLogsResponse {
+  int32 code = 1;
+  string message = 2;
+  int64 total = 3;
+  int32 page_size = 4;
+  int32 current = 5;
+  int32 pages = 6;
+  repeated FileDetectionLog items = 7;
+}
+
+message GetFileDetectionLogDetailRequest {
+  string detail_id = 1;
+  int64 query_timestamp = 2;
+  int64 start = 3;
+  int64 end = 4;
+  string file_md5 = 5;
+}
+
+message GetFileDetectionLogDetailResponse {
+  int32 code = 1;
+  string message = 2;
+  FileDetectionLog log = 3;
+}
+
+message FileDetectionSeverityStatsResponse {
+  int32 code = 1;
+  string message = 2;
+  int64 total = 3;
+  int64 danger = 4;
+  int64 high = 5;
+  int64 middle = 6;
+  int64 low = 7;
+  int64 safe = 8;
+}
+
+message ListSceneMonitorsRequest {
+  string name = 1;
+  int32 page = 2;
+  int32 page_size = 3;
+  string table_name = 4;
+  int64 id = 5;
+  int32 type = 6;
+  int64 start = 7;
+  int64 end = 8;
+  string index_name = 9;
+  string user_name = 10;
+}
+
+message SceneMonitor {
+  string raw_json = 1;
+}
+
+message ListSceneMonitorsResponse {
+  int32 code = 1;
+  string message = 2;
+  int64 total = 3;
+  repeated SceneMonitor items = 4;
+}
+
+message SearchSceneMonitorEventsRequest {
+  int64 scene_id = 1;
+  int64 start = 2;
+  int64 end = 3;
+  int32 page = 4;
+  int32 page_size = 5;
+  string table_name = 6;
+}
+
+message GetSituationOverviewRequest {}
+
+message SituationSection {
+  string name = 1;
+  string raw_json = 2;
+}
+
+message GetSituationOverviewResponse {
+  int32 code = 1;
+  string message = 2;
+  repeated SituationSection sections = 3;
+}
+
+message SearchThreatEventsRequest {
+  int64 start = 1;
+  int64 end = 2;
+  string table_name = 3;
+  string severity = 4;
+  string category = 5;
+  string classtype = 6;
+  string src_ip = 7;
+  string dst_ip = 8;
+  string attack_status = 9;
+  string app_proto = 10;
+  string sensor_id = 11;
+  string visit_direction = 12;
+  string append_query = 13;
+  string quick_query = 14;
+  string filter_query = 15;
+  string filter_string = 16;
+  string order_by = 17;
+  string order = 18;
+  int32 page = 19;
+  int32 page_size = 20;
+}
+
+message ThreatEvent {
+  int64 timestamp = 1;
+  string uuid = 2;
+  int32 severity = 3;
+  string category = 4;
+  string classtype = 5;
+  string src_ip = 6;
+  string dst_ip = 7;
+  string attack_status = 8;
+  string kill_chain = 9;
+  string app_proto = 10;
+  int64 sensor_id = 11;
+  string event_source = 12;
+  string severity_text = 13;
+}
+
+message SearchThreatEventsResponse {
+  int32 code = 1;
+  string message = 2;
+  int64 total = 3;
+  int32 page_size = 4;
+  int32 current = 5;
+  int32 pages = 6;
+  repeated ThreatEvent items = 7;
+}
+
+message GetThreatEventDetailRequest {
+  string uuid = 1;
+  string sensor_id = 2;
+  string ip = 3;
+  int64 start = 4;
+  int64 end = 5;
+  string table_name = 6;
+}
+
+message GetThreatEventDetailResponse {
+  int32 code = 1;
+  string message = 2;
+  ThreatEvent event = 3;
+  string raw_json = 4;
+}

--- a/services/geyecloud__atd_v2-3-6/secret.schema.json
+++ b/services/geyecloud__atd_v2-3-6/secret.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "apiKey"
+  ],
+  "properties": {
+    "apiKey": {
+      "type": "string",
+      "title": "geyecloud-ATD API Key",
+      "description": "API key returned by ATD login or generated for API access. Sent as the api-key header."
+    }
+  }
+}

--- a/services/geyecloud__atd_v2-3-6/service.json
+++ b/services/geyecloud__atd_v2-3-6/service.json
@@ -1,0 +1,77 @@
+{
+  "schema": "chaitin.octobus.service.v1",
+  "name": "geyecloud-atd",
+  "displayName": "geyecloud-ATD",
+  "description": "Read-only OctoBus adapter for geyecloud-ATD threat aggregation and network log query APIs.",
+  "runtime": {
+    "mode": "long-running"
+  },
+  "proto": {
+    "roots": [
+      "proto"
+    ],
+    "files": [
+      "proto/geyecloud_atd.proto"
+    ]
+  },
+  "configSchema": "config.schema.json",
+  "secretSchema": "secret.schema.json",
+  "sdk": {
+    "cli": {
+      "commands": {
+        "geyecloud.atd.v1.GEYECloudATD/AggregateThreatEvents": {
+          "name": "aggregate-threat-events",
+          "description": "Aggregate threat events by severity, kill chain, attack status, or class type."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/GetNetworkLogTimeTrend": {
+          "name": "get-network-log-time-trend",
+          "description": "Query network log count trend over time."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/GetNetworkLogDimensionStatistics": {
+          "name": "get-network-log-dimension-statistics",
+          "description": "Aggregate network logs by a selected dimension."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/ListNetworkLogs": {
+          "name": "list-network-logs",
+          "description": "List network logs with time range, filters, sorting, and pagination."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/GetNetworkLogDetail": {
+          "name": "get-network-log-detail",
+          "description": "Get one network log detail by detail ID and timestamp."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/ListFileDetectionLogs": {
+          "name": "list-file-detection-logs",
+          "description": "List file detection logs with time range, filters, sorting, and pagination."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/GetFileDetectionLogDetail": {
+          "name": "get-file-detection-log-detail",
+          "description": "Get one file detection log detail by UUID and timestamp."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/GetFileDetectionSeverityStats": {
+          "name": "get-file-detection-severity-stats",
+          "description": "Query file detection severity counters."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/ListSceneMonitors": {
+          "name": "list-scene-monitors",
+          "description": "List configured scene monitors."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/SearchSceneMonitorEvents": {
+          "name": "search-scene-monitor-events",
+          "description": "Search events for one scene monitor."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/GetSituationOverview": {
+          "name": "get-situation-overview",
+          "description": "Query common read-only situation overview dashboard sections."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/SearchThreatEvents": {
+          "name": "search-threat-events",
+          "description": "Search threat events through the advanced search API."
+        },
+        "geyecloud.atd.v1.GEYECloudATD/GetThreatEventDetail": {
+          "name": "get-threat-event-detail",
+          "description": "Get one threat event detail by UUID and optional sensor/IP filters."
+        }
+      }
+    }
+  }
+}

--- a/services/geyecloud__atd_v2-3-6/src/geyecloud-atd.js
+++ b/services/geyecloud__atd_v2-3-6/src/geyecloud-atd.js
@@ -1,0 +1,579 @@
+import crypto from "node:crypto";
+import http from "node:http";
+import https from "node:https";
+import { GrpcError, grpcStatus } from "@chaitin-ai/octobus-sdk";
+
+const API_PREFIX = "/workbenchApi/furious";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+const firstDefined = (...values) => values.find((value) => value !== undefined && value !== null && value !== "");
+
+const getReq = (ctx) => ctx?.request ?? ctx?.req ?? {};
+
+const mergedBindings = (ctx = {}) => ({
+  ...(ctx.config ?? {}),
+  ...(ctx.secret ?? {}),
+  ...(ctx.bindings ?? {}),
+});
+
+const toTrimmedString = (value) => {
+  if (value === undefined || value === null) return "";
+  return String(value).trim();
+};
+
+const toInt = (value, fallback = 0) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.trunc(number) : fallback;
+};
+
+const toBool = (value, fallback = false) => {
+  if (value === undefined || value === null || value === "") return fallback;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["false", "0", "no"].includes(normalized)) return false;
+    if (["true", "1", "yes"].includes(normalized)) return true;
+  }
+  return Boolean(value);
+};
+
+const requireString = (value, field) => {
+  const str = toTrimmedString(value);
+  if (!str) throw new GrpcError(grpcStatus.INVALID_ARGUMENT, `${field} is required`);
+  return str;
+};
+
+const requireInt64 = (value, field) => {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new GrpcError(grpcStatus.INVALID_ARGUMENT, `${field} must be a positive millisecond timestamp`);
+  }
+  return Math.trunc(number);
+};
+
+const requirePositiveInteger = (value, field) => {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new GrpcError(grpcStatus.INVALID_ARGUMENT, `${field} must be a positive integer`);
+  }
+  return Math.trunc(number);
+};
+
+export const normalizeBaseUrl = (value) => {
+  const baseUrl = requireString(value, "config.baseUrl");
+  const parsed = new URL(baseUrl);
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new GrpcError(grpcStatus.INVALID_ARGUMENT, "config.baseUrl must use http or https");
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString().replace(/\/+$/, "");
+};
+
+const resolveTimeoutMs = (bindings = {}) => {
+  const raw = Number(bindings.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MS;
+};
+
+const shouldSkipTlsVerify = (bindings = {}) =>
+  Boolean(bindings.skipTlsVerify ?? bindings.tlsInsecureSkipVerify ?? bindings.insecureSkipVerify);
+
+export const buildAuthHeaders = (apiKey, timestamp = Date.now(), nonce = crypto.randomUUID()) => {
+  const timestampText = String(timestamp);
+  return {
+    "Content-Type": "application/json",
+    "api-key": requireString(apiKey, "secret.apiKey"),
+    "user-key": "",
+    "X-Ca-Timestamp": timestampText,
+    "X-Ca-Nonce": nonce,
+    "X-Ca-Sign": crypto.createHash("md5").update(`${timestampText}${nonce}`).digest("hex"),
+  };
+};
+
+const buildUrl = (baseUrl, path) => new URL(`${baseUrl}${API_PREFIX}${path}`);
+
+const httpRequest = (url, options, bindings) =>
+  new Promise((resolve, reject) => {
+    if (typeof globalThis.__geyeCloudAtdTestRequest === "function") {
+      Promise.resolve(globalThis.__geyeCloudAtdTestRequest(url, options, bindings)).then(resolve, reject);
+      return;
+    }
+    const body = options.body ? Buffer.from(options.body) : undefined;
+    const transport = url.protocol === "https:" ? https : http;
+    const req = transport.request(
+      url,
+      {
+        method: options.method,
+        headers: {
+          ...options.headers,
+          ...(body ? { "Content-Length": String(body.length) } : {}),
+        },
+        rejectUnauthorized: !shouldSkipTlsVerify(bindings),
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+        res.on("end", () => {
+          resolve({
+            statusCode: res.statusCode ?? 500,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.setTimeout(resolveTimeoutMs(bindings), () => {
+      req.destroy(new Error("request timeout"));
+    });
+    if (body) req.write(body);
+    req.end();
+  });
+
+const mapUpstreamError = (json) => {
+  const code = toInt(json?.code, 0);
+  const message = json?.msg || json?.message || `upstream returned code ${code}`;
+  if ([401, 40101, 40102, 40203, 40204].includes(code)) {
+    return new GrpcError(grpcStatus.UNAUTHENTICATED, message);
+  }
+  if ([403, 40201, 40205].includes(code)) {
+    return new GrpcError(grpcStatus.PERMISSION_DENIED, message);
+  }
+  if (code === 404) return new GrpcError(grpcStatus.NOT_FOUND, message);
+  if (code >= 500) return new GrpcError(grpcStatus.UNAVAILABLE, message);
+  return new GrpcError(grpcStatus.UNKNOWN, message);
+};
+
+const looksLikePagination = (json) =>
+  Boolean(json && typeof json === "object" && (Array.isArray(json.records) || json.total !== undefined));
+
+const normalizeSuccessEnvelope = (json) => {
+  if (looksLikePagination(json)) {
+    return {
+      msg: json.msg ?? "success",
+      code: toInt(json.code, 200),
+      data: json,
+    };
+  }
+  if (looksLikePagination(json?.data)) return json;
+  return json;
+};
+
+const callAtd = async (ctx, path, body, requestOptions = {}) => {
+  const bindings = mergedBindings(ctx);
+  const baseUrl = normalizeBaseUrl(bindings.baseUrl ?? bindings.host);
+  const apiKey = requireString(bindings.apiKey, "secret.apiKey");
+  const method = requestOptions.method ?? "POST";
+  let response;
+  try {
+    response = await httpRequest(
+      buildUrl(baseUrl, path),
+      {
+        method,
+        headers: buildAuthHeaders(apiKey),
+        body: method === "GET" ? undefined : JSON.stringify(body ?? {}),
+      },
+      bindings,
+    );
+  } catch (err) {
+    throw new GrpcError(grpcStatus.UNAVAILABLE, err?.message || "upstream request failed");
+  }
+
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw new GrpcError(grpcStatus.UNAVAILABLE, `upstream http ${response.statusCode}`);
+  }
+
+  let json;
+  try {
+    json = JSON.parse(response.body);
+  } catch {
+    throw new GrpcError(grpcStatus.UNKNOWN, "upstream response is not valid JSON");
+  }
+
+  const normalized = normalizeSuccessEnvelope(json);
+  if (toInt(normalized.code, 0) !== 200 || (normalized.msg && normalized.msg !== "success")) {
+    throw mapUpstreamError(json);
+  }
+  return normalized;
+};
+
+const baseTimeRange = (req) => ({
+  start: requireInt64(firstDefined(req.start, req.startTime), "start"),
+  end: requireInt64(firstDefined(req.end, req.endTime), "end"),
+});
+
+const addOptional = (target, pairs) => {
+  for (const [key, value] of pairs) {
+    if (value !== undefined && value !== null && value !== "") target[key] = value;
+  }
+  return target;
+};
+
+const networkLogFilters = (req) =>
+  addOptional(baseTimeRange(req), [
+    ["srcIp", toTrimmedString(firstDefined(req.src_ip, req.srcIp))],
+    ["dstIp", toTrimmedString(firstDefined(req.dst_ip, req.dstIp))],
+    ["appProto", toTrimmedString(firstDefined(req.app_proto, req.appProto))],
+    ["host", toTrimmedString(req.host)],
+    ["queryString", toTrimmedString(firstDefined(req.query_string, req.queryString))],
+    ["filterQueryString", toTrimmedString(firstDefined(req.filter_query_string, req.filterQueryString))],
+  ]);
+
+const fileDetectionFilters = (req) =>
+  addOptional(baseTimeRange(req), [
+    ["fileMd5", toTrimmedString(firstDefined(req.file_md5, req.fileMd5))],
+    ["emailFrom", toTrimmedString(firstDefined(req.email_from, req.emailFrom))],
+    ["srcIp", toTrimmedString(firstDefined(req.src_ip, req.srcIp))],
+    ["dstIp", toTrimmedString(firstDefined(req.dst_ip, req.dstIp))],
+    ["appProto", toTrimmedString(firstDefined(req.app_proto, req.appProto))],
+    ["host", toTrimmedString(req.host)],
+    ["queryString", toTrimmedString(firstDefined(req.query_string, req.queryString))],
+    ["filterQueryString", toTrimmedString(firstDefined(req.filter_query_string, req.filterQueryString))],
+    ["fileType", toTrimmedString(firstDefined(req.file_type, req.fileType))],
+  ]);
+
+const mapNetworkLog = (item = {}) => ({
+  timestamp: toInt(item.timestamp, 0),
+  uid: toTrimmedString(firstDefined(item.uid, item.uuid)),
+  src_ip: toTrimmedString(item.src_ip),
+  src_port: toInt(item.src_port, 0),
+  dst_ip: toTrimmedString(item.dst_ip),
+  dst_port: toInt(item.dst_port, 0),
+  app_proto: toTrimmedString(item.app_proto),
+  host: toTrimmedString(item.host),
+  uri: toTrimmedString(item.uri),
+  proto: toTrimmedString(item.proto),
+  bytes: toInt(item.bytes, 0),
+  packets: toInt(item.packets, 0),
+  sensor_id: toInt(item.sensor_id, 0),
+});
+
+const mapFileDetectionLog = (item = {}) => ({
+  timestamp: toInt(item.timestamp, 0),
+  uuid: toTrimmedString(item.uuid),
+  file_name: toTrimmedString(item.file_name),
+  file_md5: toTrimmedString(item.file_md5),
+  file_type: toTrimmedString(item.file_type),
+  file_size: toTrimmedString(item.file_size),
+  src_ip: toTrimmedString(item.src_ip),
+  dst_ip: toTrimmedString(item.dst_ip),
+  severity: toInt(item.severity, 0),
+  classtype: toTrimmedString(item.classtype),
+  category: toTrimmedString(item.category),
+  engine_type: toTrimmedString(item.engine_type),
+  sensor_id: toInt(item.sensor_id, 0),
+});
+
+const mapThreatEvent = (item = {}) => ({
+  timestamp: toInt(item.timestamp, 0),
+  uuid: toTrimmedString(item.uuid),
+  severity: toInt(item.severity, 0),
+  severity_text: typeof item.severity === "string" ? toTrimmedString(item.severity) : toTrimmedString(item.severity_text),
+  category: toTrimmedString(item.category),
+  classtype: toTrimmedString(item.classtype),
+  src_ip: toTrimmedString(item.src_ip),
+  dst_ip: toTrimmedString(item.dst_ip),
+  attack_status: toTrimmedString(item.attack_status),
+  kill_chain: toTrimmedString(item.kill_chain),
+  app_proto: toTrimmedString(item.app_proto),
+  sensor_id: toInt(item.sensor_id, 0),
+  event_source: toTrimmedString(item.event_source),
+});
+
+const pagedResponse = (json, mapper) => {
+  const data = looksLikePagination(json) ? json : json.data ?? {};
+  return {
+    code: toInt(json.code, 200),
+    message: json.msg ?? "success",
+    total: toInt(data.total, 0),
+    page_size: toInt(data.size, 0),
+    current: toInt(data.current, 0),
+    pages: toInt(data.page, 0),
+    items: Array.isArray(data.records) ? data.records.map(mapper) : [],
+  };
+};
+
+const advancedThreatFilters = (req, { requireTimeRange = true } = {}) =>
+  addOptional(requireTimeRange ? baseTimeRange(req) : {}, [
+    ["tableName", toTrimmedString(firstDefined(req.table_name, req.tableName)) || "hw"],
+    ["from", toInt(firstDefined(req.page, req.from), 1)],
+    ["size", toInt(firstDefined(req.page_size, req.pageSize, req.size), 20)],
+    ["severity", toTrimmedString(req.severity)],
+    ["category", toTrimmedString(req.category)],
+    ["classtype", toTrimmedString(req.classtype)],
+    ["src_ip", toTrimmedString(firstDefined(req.src_ip, req.srcIp))],
+    ["dst_ip", toTrimmedString(firstDefined(req.dst_ip, req.dstIp))],
+    ["attack_status", toTrimmedString(firstDefined(req.attack_status, req.attackStatus))],
+    ["app_proto", toTrimmedString(firstDefined(req.app_proto, req.appProto))],
+    ["sensor_id", toTrimmedString(firstDefined(req.sensor_id, req.sensorId))],
+    ["visit_direction", toTrimmedString(firstDefined(req.visit_direction, req.visitDirection))],
+    ["appendQuery", toTrimmedString(firstDefined(req.append_query, req.appendQuery))],
+    ["quickQuery", toTrimmedString(firstDefined(req.quick_query, req.quickQuery))],
+    ["filterQuery", toTrimmedString(firstDefined(req.filter_query, req.filterQuery))],
+    ["filterString", toTrimmedString(firstDefined(req.filter_string, req.filterString))],
+    ["orderBy", toTrimmedString(firstDefined(req.order_by, req.orderBy))],
+    ["order", toTrimmedString(req.order) || "desc"],
+  ]);
+
+const sceneMonitorFilters = (req) =>
+  addOptional(
+    {
+      from: toInt(firstDefined(req.page, req.from), 1),
+      size: toInt(firstDefined(req.page_size, req.pageSize, req.size), 10),
+    },
+    [
+      ["name", toTrimmedString(req.name)],
+      ["tableName", toTrimmedString(firstDefined(req.table_name, req.tableName))],
+      ["id", firstDefined(req.id, req.scene_id, req.sceneId)],
+      ["type", firstDefined(req.type, req.scene_type, req.sceneType)],
+      ["start", firstDefined(req.start, req.startTime)],
+      ["end", firstDefined(req.end, req.endTime)],
+      ["indexName", toTrimmedString(firstDefined(req.index_name, req.indexName))],
+      ["userName", toTrimmedString(firstDefined(req.user_name, req.userName))],
+    ],
+  );
+
+const SITUATION_SECTIONS = [
+  ["logs_statistics", "/situationAwareness/security_pyramid/logs_statistics"],
+  ["access_logs_trend", "/situationAwareness/security_pyramid/access_logs_trend"],
+  ["event_classification", "/situationAwareness/host-threat-event/event_classification"],
+  ["hot_event", "/situationAwareness/host-threat-event/hot_event"],
+  ["attacker_total", "/situationAwareness/attacker/total"],
+];
+
+export const handlers = {
+  "geyecloud.atd.v1.GEYECloudATD/AggregateThreatEvents": async (ctx) => {
+    const req = getReq(ctx);
+    const json = await callAtd(ctx, "/elasticSearch/aggregate", {
+      ...baseTimeRange(req),
+      from: toInt(firstDefined(req.page, req.from), 1),
+      size: toInt(firstDefined(req.page_size, req.pageSize, req.size), 10),
+      terms: requireString(req.terms, "terms"),
+      tableName: toTrimmedString(firstDefined(req.table_name, req.tableName)) || "hw",
+    });
+    return {
+      code: toInt(json.code, 0),
+      message: json.msg ?? "",
+      count: toInt(json.agg?.count, 0),
+      total_count: toInt(json.agg?.totalCount, 0),
+      items: Array.isArray(json.agg?.list)
+        ? json.agg.list.map((item) => ({ key: toTrimmedString(item.key), value: toInt(item.value, 0) }))
+        : [],
+    };
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/GetNetworkLogTimeTrend": async (ctx) => {
+    const json = await callAtd(ctx, "/netWorkLog/timeTrend", networkLogFilters(getReq(ctx)));
+    return {
+      code: toInt(json.code, 0),
+      message: json.msg ?? "",
+      items: Array.isArray(json.data)
+        ? json.data.map((item) => ({
+            timestamp: toInt(item.timestamp, 0),
+            time: toTrimmedString(item.time),
+            count: toInt(item.count, 0),
+          }))
+        : [],
+    };
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/GetNetworkLogDimensionStatistics": async (ctx) => {
+    const req = getReq(ctx);
+    const json = await callAtd(
+      ctx,
+      "/netWorkLog/dimensionStatistics",
+      addOptional(
+        {
+          ...networkLogFilters(req),
+          dimensionKey: requireString(firstDefined(req.dimension_key, req.dimensionKey), "dimension_key"),
+        },
+        [
+          ["pageNo", toInt(firstDefined(req.page, req.pageNo), 1)],
+          ["size", toInt(firstDefined(req.page_size, req.pageSize, req.size), 10)],
+        ],
+      ),
+    );
+    return {
+      code: toInt(json.code, 0),
+      message: json.msg ?? "",
+      items: Array.isArray(json.data)
+        ? json.data.map((item) => ({
+            key: toTrimmedString(item.key),
+            name: toTrimmedString(item.name),
+            value: toInt(item.value, 0),
+            count: toInt(item.count, 0),
+          }))
+        : [],
+    };
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/ListNetworkLogs": async (ctx) => {
+    const req = getReq(ctx);
+    const json = await callAtd(
+      ctx,
+      "/netWorkLog/list",
+      addOptional(networkLogFilters(req), [
+        ["srcPort", toTrimmedString(firstDefined(req.src_port, req.srcPort))],
+        ["dstPort", toTrimmedString(firstDefined(req.dst_port, req.dstPort))],
+        ["uri", toTrimmedString(req.uri)],
+        ["uid", toTrimmedString(req.uid)],
+        ["uuid", toTrimmedString(req.uuid)],
+        ["sort", toTrimmedString(req.sort)],
+        ["order", toTrimmedString(req.order) || "desc"],
+        ["pageNo", toInt(firstDefined(req.page, req.pageNo), 1)],
+        ["size", toInt(firstDefined(req.page_size, req.pageSize, req.size), 20)],
+        ["isTranslate", toBool(firstDefined(req.is_translate, req.isTranslate), false)],
+      ]),
+    );
+    const data = json.data ?? {};
+    return {
+      code: toInt(json.code, 0),
+      message: json.msg ?? "",
+      total: toInt(data.total, 0),
+      page_size: toInt(data.size, 0),
+      current: toInt(data.current, 0),
+      pages: toInt(data.page, 0),
+      items: Array.isArray(data.records) ? data.records.map(mapNetworkLog) : [],
+    };
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/GetNetworkLogDetail": async (ctx) => {
+    const req = getReq(ctx);
+    const json = await callAtd(
+      ctx,
+      "/netWorkLog/details",
+      addOptional(
+        {
+          uuid: requireString(firstDefined(req.detail_id, req.detailId, req.uuid), "detail_id"),
+          queryTimestamp: requireInt64(firstDefined(req.query_timestamp, req.queryTimestamp), "query_timestamp"),
+        },
+        [
+          ["start", firstDefined(req.start, req.startTime)],
+          ["end", firstDefined(req.end, req.endTime)],
+        ],
+      ),
+    );
+    return {
+      code: toInt(json.code, 0),
+      message: json.msg ?? "",
+      log: mapNetworkLog(json.data ?? {}),
+    };
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/ListFileDetectionLogs": async (ctx) => {
+    const req = getReq(ctx);
+    const json = await callAtd(
+      ctx,
+      "/fileDetectionLog/list",
+      addOptional(fileDetectionFilters(req), [
+        ["sort", toTrimmedString(req.sort)],
+        ["order", toTrimmedString(req.order) || "desc"],
+        ["pageNo", toInt(firstDefined(req.page, req.pageNo), 1)],
+        ["size", toInt(firstDefined(req.page_size, req.pageSize, req.size), 20)],
+        ["isTranslate", toBool(firstDefined(req.is_translate, req.isTranslate), false)],
+      ]),
+    );
+    return pagedResponse(json, mapFileDetectionLog);
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/GetFileDetectionLogDetail": async (ctx) => {
+    const req = getReq(ctx);
+    const json = await callAtd(
+      ctx,
+      "/fileDetectionLog/details",
+      addOptional(
+        {
+          detailId: requireString(firstDefined(req.detail_id, req.detailId, req.uuid), "detail_id"),
+          queryTimestamp: requireInt64(firstDefined(req.query_timestamp, req.queryTimestamp), "query_timestamp"),
+        },
+        [
+          ["start", firstDefined(req.start, req.startTime)],
+          ["end", firstDefined(req.end, req.endTime)],
+          ["fileMd5", toTrimmedString(firstDefined(req.file_md5, req.fileMd5))],
+        ],
+      ),
+    );
+    return {
+      code: toInt(json.code, 0),
+      message: json.msg ?? "",
+      log: mapFileDetectionLog(json.data ?? {}),
+    };
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/GetFileDetectionSeverityStats": async (ctx) => {
+    const req = getReq(ctx);
+    const json = await callAtd(ctx, "/fileDetectionLog/severityNumber", fileDetectionFilters(req));
+    const data = json.data ?? {};
+    return {
+      code: toInt(json.code, 0),
+      message: json.msg ?? "",
+      total: toInt(data.total, 0),
+      danger: toInt(data.danger, 0),
+      high: toInt(data.high, 0),
+      middle: toInt(data.middle, 0),
+      low: toInt(data.low, 0),
+      safe: toInt(data.safe, 0),
+    };
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/ListSceneMonitors": async (ctx) => {
+    const json = await callAtd(ctx, "/sceneMonitor/querySceneMonitor", sceneMonitorFilters(getReq(ctx)));
+    const data = looksLikePagination(json) ? json : json.data ?? {};
+    const records = Array.isArray(data.records) ? data.records : Array.isArray(data.data?.records) ? data.data.records : [];
+    return {
+      code: toInt(json.code, 0),
+      message: json.msg ?? "",
+      total: toInt(firstDefined(data.total, data.data?.total), 0),
+      items: records.map((item) => ({ raw_json: JSON.stringify(item) })),
+    };
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/SearchSceneMonitorEvents": async (ctx) => {
+    const req = getReq(ctx);
+    const json = await callAtd(
+      ctx,
+      "/sceneMonitor/searchFromMonitor",
+      {
+        ...sceneMonitorFilters(req),
+        id: requirePositiveInteger(firstDefined(req.id, req.scene_id, req.sceneId), "scene_id"),
+      },
+    );
+    return pagedResponse(json, mapThreatEvent);
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/GetSituationOverview": async (ctx) => {
+    const sections = [];
+    for (const [name, path] of SITUATION_SECTIONS) {
+      const json = await callAtd(ctx, path, undefined, { method: "GET" });
+      sections.push({ name, raw_json: JSON.stringify(json.data ?? null) });
+    }
+    return {
+      code: 200,
+      message: "success",
+      sections,
+    };
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/SearchThreatEvents": async (ctx) => {
+    const json = await callAtd(ctx, "/searchCenter/advanced/searchData", advancedThreatFilters(getReq(ctx)));
+    return pagedResponse(json, mapThreatEvent);
+  },
+
+  "geyecloud.atd.v1.GEYECloudATD/GetThreatEventDetail": async (ctx) => {
+    const req = getReq(ctx);
+    const json = await callAtd(
+      ctx,
+      "/searchCenter/advanced/searchDataDetail",
+      addOptional(advancedThreatFilters(req, { requireTimeRange: false }), [
+        ["uuid", requireString(req.uuid, "uuid")],
+        ["sensorId", toTrimmedString(firstDefined(req.sensor_id, req.sensorId))],
+        ["ip", toTrimmedString(req.ip)],
+      ]),
+    );
+    return {
+      code: toInt(json.code, 0),
+      message: json.msg ?? "",
+      event: mapThreatEvent(json.data ?? {}),
+      raw_json: JSON.stringify(json.data ?? null),
+    };
+  },
+};

--- a/services/geyecloud__atd_v2-3-6/src/service.js
+++ b/services/geyecloud__atd_v2-3-6/src/service.js
@@ -1,0 +1,7 @@
+import { defineService } from "@chaitin-ai/octobus-sdk";
+
+import { handlers } from "./geyecloud-atd.js";
+
+export { handlers } from "./geyecloud-atd.js";
+
+export const service = defineService({ handlers });

--- a/services/geyecloud__atd_v2-3-6/test/geyecloud-atd.test.js
+++ b/services/geyecloud__atd_v2-3-6/test/geyecloud-atd.test.js
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import test from "node:test";
+
+import { buildAuthHeaders, handlers, normalizeBaseUrl } from "../src/geyecloud-atd.js";
+
+test("normalizeBaseUrl removes UI hash and trailing slash", () => {
+  assert.equal(normalizeBaseUrl("https://192.0.2.10:5443/#/workBench"), "https://192.0.2.10:5443");
+});
+
+test("buildAuthHeaders sends api-key and ATD signature headers", () => {
+  const headers = buildAuthHeaders("dummy-api-key", 1774249367000, "nonce-value");
+  assert.equal(headers["api-key"], "dummy-api-key");
+  assert.equal(headers["user-key"], "");
+  assert.equal(headers["X-Ca-Timestamp"], "1774249367000");
+  assert.equal(headers["X-Ca-Nonce"], "nonce-value");
+  assert.equal(headers["X-Ca-Sign"], crypto.createHash("md5").update("1774249367000nonce-value").digest("hex"));
+});
+
+test("AggregateThreatEvents accepts lowerCamelCase request fields and maps aggregate response", async () => {
+  const handler = handlers["geyecloud.atd.v1.GEYECloudATD/AggregateThreatEvents"];
+  const calls = [];
+  globalThis.__geyeCloudAtdTestRequest = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        msg: "success",
+        code: 200,
+        agg: {
+          count: 2,
+          totalCount: 12,
+          list: [
+            { key: "high", value: 10 },
+            { key: "low", value: 2 }
+          ]
+        }
+      })
+    };
+  };
+  try {
+    const result = await handler({
+      request: {
+        start: 1773644567000,
+        end: 1774249367000,
+        page: 1,
+        pageSize: 10,
+        terms: "severity",
+        tableName: "hw"
+      },
+      config: { baseUrl: "https://atd.example.com/#/workBench", skipTlsVerify: true },
+      secret: { apiKey: "dummy-api-key" }
+    });
+    assert.equal(result.code, 200);
+    assert.equal(result.count, 2);
+    assert.equal(result.total_count, 12);
+    assert.equal(result.items[0].key, "high");
+    assert.equal(calls[0].url.pathname, "/workbenchApi/furious/elasticSearch/aggregate");
+    assert.equal(calls[0].options.headers["api-key"], "dummy-api-key");
+    assert.deepEqual(JSON.parse(calls[0].options.body), {
+      start: 1773644567000,
+      end: 1774249367000,
+      from: 1,
+      size: 10,
+      terms: "severity",
+      tableName: "hw"
+    });
+  } finally {
+    delete globalThis.__geyeCloudAtdTestRequest;
+  }
+});
+
+test("ListFileDetectionLogs maps file detection pagination", async () => {
+  const handler = handlers["geyecloud.atd.v1.GEYECloudATD/ListFileDetectionLogs"];
+  const calls = [];
+  globalThis.__geyeCloudAtdTestRequest = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        msg: "success",
+        code: 200,
+        data: {
+          total: 1,
+          size: 20,
+          current: 1,
+          page: 1,
+          records: [
+            {
+              timestamp: 1774249367000,
+              uuid: "evt-1",
+              file_name: "sample.exe",
+              file_md5: "44d88612fea8a8f36de82e1278abb02f",
+              file_type: "exe",
+              file_size: "12KB",
+              src_ip: "192.0.2.20",
+              dst_ip: "198.51.100.10",
+              severity: 3,
+              classtype: "恶意文件",
+              category: "特洛伊木马通信",
+              engine_type: "sandbox",
+              sensor_id: 1001
+            }
+          ]
+        }
+      })
+    };
+  };
+  try {
+    const result = await handler({
+      request: {
+        start: 1773644567000,
+        end: 1774249367000,
+        page: 1,
+        pageSize: 20,
+        isTranslate: "false",
+        fileMd5: "44d88612fea8a8f36de82e1278abb02f"
+      },
+      config: { baseUrl: "https://atd.example.com", skipTlsVerify: true },
+      secret: { apiKey: "dummy-api-key" }
+    });
+    assert.equal(calls[0].url.pathname, "/workbenchApi/furious/fileDetectionLog/list");
+    const requestBody = JSON.parse(calls[0].options.body);
+    assert.equal(requestBody.fileMd5, "44d88612fea8a8f36de82e1278abb02f");
+    assert.equal(requestBody.isTranslate, false);
+    assert.equal(result.total, 1);
+    assert.equal(result.items[0].file_name, "sample.exe");
+  } finally {
+    delete globalThis.__geyeCloudAtdTestRequest;
+  }
+});
+
+test("GetSituationOverview performs readonly dashboard GET calls", async () => {
+  const handler = handlers["geyecloud.atd.v1.GEYECloudATD/GetSituationOverview"];
+  const calls = [];
+  globalThis.__geyeCloudAtdTestRequest = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ msg: "success", code: 200, data: { value: calls.length } })
+    };
+  };
+  try {
+    const result = await handler({
+      request: {},
+      config: { baseUrl: "https://atd.example.com", skipTlsVerify: true },
+      secret: { apiKey: "dummy-api-key" }
+    });
+    assert.equal(calls[0].options.method, "GET");
+    assert.equal(calls[0].url.pathname, "/workbenchApi/furious/situationAwareness/security_pyramid/logs_statistics");
+    assert.equal(result.sections.length, 5);
+    assert.equal(result.sections[0].name, "logs_statistics");
+  } finally {
+    delete globalThis.__geyeCloudAtdTestRequest;
+  }
+});
+
+test("SearchThreatEvents maps advanced search response", async () => {
+  const handler = handlers["geyecloud.atd.v1.GEYECloudATD/SearchThreatEvents"];
+  const calls = [];
+  globalThis.__geyeCloudAtdTestRequest = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        total: 1,
+        size: 10,
+        current: 1,
+        page: 1,
+        records: [
+          {
+            timestamp: 1774249367000,
+            uuid: "evt-2",
+            severity: "高危",
+            category: "特洛伊木马通信",
+            classtype: "恶意文件",
+            src_ip: "192.0.2.20",
+            dst_ip: "198.51.100.10",
+            attack_status: "攻击成功",
+            kill_chain: "命令控制",
+            app_proto: "https",
+            sensor_id: 1001,
+            event_source: "atd"
+          }
+        ]
+      })
+    };
+  };
+  try {
+    const result = await handler({
+      request: {
+        start: 1773644567000,
+        end: 1774249367000,
+        tableName: "hw",
+        srcIp: "192.0.2.20",
+        page: 1,
+        pageSize: 10
+      },
+      config: { baseUrl: "https://atd.example.com", skipTlsVerify: true },
+      secret: { apiKey: "dummy-api-key" }
+    });
+    assert.equal(calls[0].url.pathname, "/workbenchApi/furious/searchCenter/advanced/searchData");
+    assert.equal(JSON.parse(calls[0].options.body).src_ip, "192.0.2.20");
+    assert.equal(result.total, 1);
+    assert.equal(result.items[0].kill_chain, "命令控制");
+    assert.equal(result.items[0].severity_text, "高危");
+  } finally {
+    delete globalThis.__geyeCloudAtdTestRequest;
+  }
+});
+
+test("ListSceneMonitors maps unwrapped scene monitor pagination", async () => {
+  const handler = handlers["geyecloud.atd.v1.GEYECloudATD/ListSceneMonitors"];
+  globalThis.__geyeCloudAtdTestRequest = async () => ({
+    statusCode: 200,
+    body: JSON.stringify({
+      total: 1,
+      size: 1,
+      current: 1,
+      page: 1,
+      records: [{ monitorId: 1, monitorName: "test" }]
+    })
+  });
+  try {
+    const result = await handler({
+      request: { page: 1, pageSize: 1 },
+      config: { baseUrl: "https://atd.example.com", skipTlsVerify: true },
+      secret: { apiKey: "dummy-api-key" }
+    });
+    assert.equal(result.total, 1);
+    assert.equal(JSON.parse(result.items[0].raw_json).monitorId, 1);
+  } finally {
+    delete globalThis.__geyeCloudAtdTestRequest;
+  }
+});
+
+test("GetNetworkLogDetail sends detail id as upstream uuid", async () => {
+  const handler = handlers["geyecloud.atd.v1.GEYECloudATD/GetNetworkLogDetail"];
+  const calls = [];
+  globalThis.__geyeCloudAtdTestRequest = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        msg: "success",
+        code: 200,
+        data: {
+          uuid: "net-1",
+          uid: "net-1",
+          timestamp: 1774249367000,
+          src_ip: "192.0.2.20",
+          dst_ip: "198.51.100.10"
+        }
+      })
+    };
+  };
+  try {
+    const result = await handler({
+      request: {
+        detailId: "net-1",
+        queryTimestamp: 1774249367000,
+        start: 1773644567000,
+        end: 1774249367000
+      },
+      config: { baseUrl: "https://atd.example.com", skipTlsVerify: true },
+      secret: { apiKey: "dummy-api-key" }
+    });
+    assert.equal(calls[0].url.pathname, "/workbenchApi/furious/netWorkLog/details");
+    assert.equal(JSON.parse(calls[0].options.body).uuid, "net-1");
+    assert.equal(JSON.parse(calls[0].options.body).detailId, undefined);
+    assert.equal(result.log.uid, "net-1");
+  } finally {
+    delete globalThis.__geyeCloudAtdTestRequest;
+  }
+});


### PR DESCRIPTION
Refs #468

This PR adds a read-only OctoBus Service Adapter for geyecloud-ATD 2.3.6.

The service package has been locally tested, imported into OctoBus runtime, and validated against a real geyecloud-ATD environment. Detailed validation evidence, commands, and screenshots are included below.

# Add geyecloud-ATD OctoBus Service Adapter

<!-- obsidian --><h1 data-heading="Add geyecloud-ATD OctoBus Service Adapter">Add geyecloud-ATD OctoBus Service Adapter</h1>
<h2 data-heading="1. Summary">1. Summary</h2>
<p>本次新增 <strong>geyecloud-ATD / 高级威胁检测系统</strong> 的 OctoBus Service 适配器，用于将 geyecloud-ATD 的常用只读查询能力接入 OctoBus。</p>
<p>基础信息：</p>

  |  
-- | --
Item | Value
Service package name | geyecloud-atd
Service directory | services/geyecloud__atd_v2-3-6/
Package artifact | Not committed
Runtime mode | long-running
Capability boundary | read-only
RPC count | 13


<h2 data-heading="5. Auth Pattern">5. Auth Pattern</h2>
<p>该服务包使用 geyecloud-ATD API key 作为 OctoBus instance secret。</p>
<p>Secret 示例：</p>
<pre><code class="language-plain">{
  "apiKey": "&#x3C;masked>"
}
</code></pre>
<p>运行时请求会携带以下认证相关 Header：</p>
<pre><code class="language-plain">api-key: &#x3C;masked>
user-key: ""
X-Ca-Timestamp: &#x3C;timestamp>
X-Ca-Nonce: &#x3C;nonce>
X-Ca-Sign: md5(timestamp + nonce)
</code></pre>
<p>说明：</p>
<ul>
<li>Service 包不保存账号密码。</li>
<li>Service 包不自动处理 UI 登录验证码。</li>
<li>如果 geyecloud-ATD 环境需要通过验证码登录获取 API key，则该步骤作为运维/管理员侧的 key provisioning 流程。</li>
<li>OctoBus 实例只需要配置稳定的 <code>secret.apiKey</code> 即可调用。</li>
</ul>
<h2 data-heading="6. Config / Secret">6. Config / Secret</h2>
<p>Config 示例：</p>
<pre><code class="language-plain">{
  "baseUrl": "https://192.0.2.10:5443",
  "skipTlsVerify": true,
  "timeoutMs": 10000
}
</code></pre>
<p>Secret 示例：</p>
<pre><code class="language-plain">{
  "apiKey": "&#x3C;masked>"
}
</code></pre>
<p>补充说明：</p>
<ul>
<li><code>baseUrl</code> 可以填写 geyecloud-ATD UI 地址。</li>
<li>如果包含 <code>/#/workBench</code> 这类前端 hash route，适配器会自动归一化为 API origin。</li>
<li>实际 API 路径统一调用 <code>/workbenchApi/furious/...</code>。</li>
</ul>
<h2 data-heading="7. Implementation Notes">7. Implementation Notes</h2>
<p>实现要点：</p>
<ul>
<li>使用 <code>@chaitin-ai/octobus-sdk</code>。</li>
<li>Runtime mode 为 <code>long-running</code>。</li>
<li>当前 13 个方法全部为 read-only。</li>
<li>同时兼容 <code>snake_case</code> 和 <code>lowerCamelCase</code> 请求字段，便于 Connect JSON 调用。</li>
<li>对 geyecloud-ATD 实机返回格式做了统一兼容：</li>
<li>wrapped response: <code>{code,msg,data}</code></li>
<li>unwrapped pagination response: <code>{total,size,current,page,records}</code></li>
<li>对威胁事件风险等级做了增强：</li>
<li>数字字段继续保留为 <code>severity</code></li>
<li>中文等级如 <code>高危</code>、<code>中危</code> 通过 <code>severity_text</code> 输出</li>
<li>网络日志列表到详情链路已做适配：</li>
<li>列表记录实际返回 <code>uuid</code></li>
<li>Service 层映射为可用于详情查询的 <code>uid</code></li>
<li>详情调用时将 <code>detail_id/detailId</code> 转换为 geyecloud-ATD 实际接受的 upstream <code>uuid</code></li>
<li>对日志和事件输出采用 whitelist mapping，避免直接暴露上游 raw response 中可能存在的敏感字段。</li>
</ul>
<h2 data-heading="8. Local Package Validation">8. Local Package Validation</h2>
<p>Terminal 执行命令：</p>
<pre><code class="language-plain">cd services/geyecloud__atd_v2-3-6
npm test
npm run validate
npm run pack:check
</code></pre>
<p>预期结果：</p>
<pre><code class="language-plain">npm test
  tests 8
  pass 8
  fail 0

npm run validate
  service package is valid
  unary methods: 13

npm run pack:check
  package dry-run succeeded
  total files: 9
</code></pre>
<p>Evidence screenshots:</p>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783072425163-e26dcea3-aad4-44ba-835c-b61f1e04a828.png"></p>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783072379682-c7243f3a-c5b2-4d5b-90fb-65096e164fff.png"></p>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783072457361-044c7b45-0709-4d95-96d4-11ead4ff3d12.png"><!-- 这是一张图片，ocr 内容为： --><br>
<img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783072490433-c8cb41ba-b831-4133-874e-a3c4565a3404.png"></p>
<h2 data-heading="9. Real Device Validation">9. Real Device Validation</h2>
<p>已使用提供的 geyecloud-ATD demo 环境完成过实机 API 验证。以下证据已脱敏，不包含 API key、账号密码、验证码、session 或 cookie；demo 环境地址按内部验证需要保留。</p>
<p>Terminal 执行命令：</p>
<pre><code class="language-plain">cd services/geyecloud__atd_v2-3-6
node /tmp/atd-real-validate.mjs
</code></pre>
<p>预期脱敏结果：</p>
<pre><code class="language-plain">[
  {"name":"AggregateThreatEvents","status":"OK","code":200,"message":"success","items":4},
  {"name":"GetNetworkLogTimeTrend","status":"OK","code":200,"message":"success","items":19},
  {"name":"GetNetworkLogDimensionStatistics","status":"OK","code":200,"message":"success","items":0},
  {"name":"ListNetworkLogs","status":"OK","code":200,"message":"success","items":5,"hasDetailId":true},
  {"name":"GetNetworkLogDetail","status":"OK","code":200,"message":"success","hasLog":true},
  {"name":"ListFileDetectionLogs","status":"OK","code":200,"message":"success","items":5,"hasDetailId":true},
  {"name":"GetFileDetectionLogDetail","status":"OK","code":200,"message":"success","hasLog":true},
  {"name":"GetFileDetectionSeverityStats","status":"OK","code":200,"message":"success"},
  {"name":"ListSceneMonitors","status":"OK","code":200,"message":"success","items":1,"hasSceneId":true},
  {"name":"SearchSceneMonitorEvents","status":"OK","code":200,"message":"success","items":1},
  {"name":"GetSituationOverview","status":"OK","code":200,"message":"success","sections":5},
  {"name":"SearchThreatEvents","status":"OK","code":200,"message":"success","items":5,"hasDetailId":true},
  {"name":"GetThreatEventDetail","status":"OK","code":200,"message":"success","hasEvent":true,"hasRaw":true}
]
</code></pre>
<p>验证链路：</p>
<ul>
<li><code>ListNetworkLogs -> GetNetworkLogDetail</code></li>
<li><code>ListFileDetectionLogs -> GetFileDetectionLogDetail</code></li>
<li><code>SearchThreatEvents -> GetThreatEventDetail</code></li>
<li><code>ListSceneMonitors -> SearchSceneMonitorEvents</code></li>
</ul>
<p>Evidence screenshot: <!-- 这是一张图片，ocr 内容为： --><br>
<img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783076387995-3ce999bd-c95a-488e-85ad-92d6e96e0e4f.png"></p>
<h2 data-heading="10. OctoBus Runtime Validation">10. OctoBus Runtime Validation</h2>
<p>本节保留 OctoBus runtime 必要证据，包括 service import、instance create/update-secret 和最终 RPC 调用。<code>runtime check</code>、<code>capset catalog</code>、产品 UI 和 agent task 截图不是本次提交的必要材料，可按需补充。</p>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783073852239-5d98f978-cfaa-4135-b4ed-bb4601ca1774.png"></p>
<h3 data-heading="10.1 Service Import">10.1 Service Import</h3>
<p>Terminal 执行命令：</p>
<pre><code class="language-plain">cd services/geyecloud__atd_v2-3-6

octobus service import geyecloud-atd . --build auto
</code></pre>
<p>Evidence screenshots:</p>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783074705168-971731f7-af67-474e-867c-7f92792438ee.png"></p>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783074775679-b94c2ee7-7b2f-49d8-bd65-429891642c12.png"></p>
<h3 data-heading="10.2 Instance Config / Secret">10.2 Instance Config / Secret</h3>
<p>注意：截图前请确认 Terminal 画面里没有明文真实 API key。</p>
<p>Config 文件示例：</p>
<pre><code class="language-plain">cat > /tmp/geyecloud-atd-config.json &#x3C;&#x3C;'JSON'
{
  "baseUrl": "https://192.0.2.10:5443",
  "skipTlsVerify": true,
  "timeoutMs": 10000
}
JSON
</code></pre>
<p>Secret 文件示例：</p>
<pre><code class="language-plain">cat > /tmp/geyecloud-atd-secret.json &#x3C;&#x3C;'JSON'
{
  "apiKey": "&#x3C;masked-or-real-key-only-in-local-file>"
}
JSON
</code></pre>
<p>创建实例：</p>
<pre><code class="language-plain">octobus instance create geyecloud-atd-demo \
  --service geyecloud-atd \
  --config /tmp/geyecloud-atd-config.json \
  --secret /tmp/geyecloud-atd-secret.json
</code></pre>
<p>如实例已存在，可更新 secret：</p>
<pre><code class="language-plain">octobus instance update-secret geyecloud-atd-demo \
  --secret /tmp/geyecloud-atd-secret.json \
  --restart
</code></pre>
<p>查看实例：</p>
<pre><code class="language-plain">octobus instance get geyecloud-atd-demo
</code></pre>
<p>Evidence screenshots:</p>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783075227446-388b7c5d-64dc-4ba1-a675-c8bc45a0cc9c.png"></p>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783075542354-b16d5092-7732-408f-a436-fd8678947b6c.png"></p>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783075630362-1e201c60-be37-452c-a9d4-340a67239d42.png"></p>
<h3 data-heading="10.3 Direct RPC Call Through OctoBus">10.3 Direct RPC Call Through OctoBus</h3>
<p>当前 OctoBus CLI 版本未提供 <code>octobus call</code> 子命令，因此本次使用 capset 暴露的 Connect RPC endpoint 完成直接调用验证。</p>
<p>查看实例状态：</p>
<pre><code class="language-plain">octobus instance get geyecloud-atd-demo
</code></pre>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783075856306-a14d5c68-cab0-4a70-92ec-3c575d35c333.png"></p>
<p>查看 capset 暴露的方法：</p>
<pre><code class="language-bash">octobus capset list-methods geyecloud-atd-readonly-investigation
</code></pre>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783075927448-29d50c5a-f64b-498d-95f7-f80ed28846cd.png"></p>
<p>通过 Connect RPC 直接调用 <code>AggregateThreatEvents</code>：</p>
<pre><code class="language-bash">curl -sS -X POST \
  "http://127.0.0.1:9000/capsets/geyecloud-atd-readonly-investigation/connect/geyecloud-atd-demo/geyecloud.atd.v1.GEYECloudATD/AggregateThreatEvents" \
  -H "Content-Type: application/json" \
  -d '{
    "start": 1773644567000,
    "end": 1774249367000,
    "page": 1,
    "pageSize": 10,
    "terms": "severity",
    "tableName": "hw"
  }' | python3 -m json.tool
</code></pre>
<!-- 这是一张图片，ocr 内容为： -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783077061289-66d71122-649a-4ca6-8814-34eb4357c15c.png"></p>
<h3 data-heading="10.4 OctoBus Trigger and Product UI Correlation">10.4 OctoBus Trigger and Product UI Correlation</h3>
<p>本节用于补充端到端 UI 对照证据：Terminal 侧通过 OctoBus Connect RPC 触发一次只读查询，产品 UI 侧展示同一类威胁事件/风险等级统计数据。</p>
<p>该证据不是本次提交的必需项，但可作为“OctoBus 已实际触发业务查询，且 geyecloud-ATD 产品侧存在对应数据”的补充说明。</p>
<p>Terminal 执行命令：</p>
<pre><code class="language-bash">curl -sS -X POST \
  "http://127.0.0.1:9000/capsets/geyecloud-atd-readonly-investigation/connect/geyecloud-atd-demo/geyecloud.atd.v1.GEYECloudATD/AggregateThreatEvents" \
  -H "Content-Type: application/json" \
  -d '{
    "start": 1773644567000,
    "end": 1774249367000,
    "page": 1,
    "pageSize": 10,
    "terms": "severity",
    "tableName": "hw"
  }' | python3 -m json.tool
</code></pre>
<p>证据对应关系：</p>
<p>Terminal 通过 OctoBus Connect RPC 调用 <code>AggregateThreatEvents</code> 并返回 <code>success</code>；产品 UI 同步展示威胁事件/风险等级统计数据。两张截图组合证明 OctoBus Service 调用链路和 geyecloud-ATD 数据读取链路可用。</p>
<p>Terminal evidence screenshot:  </p>
<!-- 这是一张图片，ocr 内容为：HENGDEMACBOOK-PRO GEYECLOUD-ATD 2.3.6 S CURL -SS -X POST -H  CONTENT-TYPE:A E:APPLICATION/JSON'' 予,P- 'START":1773644567000, 'END':1774249367000, ''PAGE'':1, 'PAGESIZE':10,  TERMS ' SEVERITY' , TABLENAME': "HW'' PYTHON3-M JSON.TOOL CODE':200, "MESSAGE":'SUCCESS". COUNT":"4".". TOTALCOUNT":17", ITEMS':[ "KEY':"\U4E2D\U5371', "VALUE":"10" "KEV":"\U9AD8\U5371", "VALUE":'5" "KEY":\U4F4E/U5371", "VALUE":1"  "KEY':"\U5371\U6025', "VALUE":"1" -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783078875458-1f371f1b-faea-43d6-ae61-406256b6dfb2.png"></p>
<p>Product UI evidence screenshot:</p>
<!-- 这是一张图片，ocr 内容为：高级威胁检测系统 2.3.6) 自动剧新间隔 当天 手动刷新 编码/解码 系统信息 不刷新 ADVANCED THREAT DETECTION S N SYSTEM 统计信息 威胁态势 攻击者 风险主机 高风险主机 威胁事件 总览 新增0 新增0 新增0 新增0 0 尝试:0 成功:0可疑:0 减少0 减少0 减少0 减少0 态势大屏 攻击阶段 威胁事件 帮油利 扫描探 安全缺 横向渗 行动收 远程控 木马下 割 透 陷 载 制 威胁分析 测 OV 0 OY XO 威胁报告 待处置威胁 高风险主机本周趋势 攻击者本周趋势 资产 响应处置 全部 横向 全部 外对内 资产管理 日志检索 离线分析 系统管理 -->
<p><img src="https://cdn.nlark.com/yuque/0/2026/png/35423784/1783078887385-e7f936c7-d65c-4ee2-84b6-cc9ee9a239ad.png"></p>
<h2 data-heading="11. Integration Evidence">11. Integration Evidence</h2>
<p>实机验证过程中发现并已修复/兼容的文档与真实接口差异：</p>
<ul>
<li>部分接口返回 <code>{code,msg,data}</code> 包裹结构。</li>
<li>部分接口直接返回 <code>{total,size,current,page,records}</code> 裸分页结构。</li>
<li>网络日志列表记录使用 <code>uuid</code>，而网络日志详情接口实际接受 upstream <code>uuid</code>，不是文档/同类接口中常见的 <code>detailId</code>。</li>
<li>威胁事件风险等级可能返回中文字符串，因此新增 <code>severity_text</code> 保留语义。</li>
<li>geyecloud-ATD 日志类接口可能存在敏感原始字段，因此 Service 输出采用白名单字段映射。</li>
</ul>
<p>这些差异已经通过单元测试和通用响应归一化逻辑覆盖。</p>
<h2 data-heading="12. Security / Evidence Hygiene">12. Security / Evidence Hygiene</h2>
<p>安全和脱敏处理：</p>
<ul>
<li>未提交真实账号、密码、API key、session、cookie、验证码等敏感凭据；demo 环境地址按内部验证需要保留。</li>
<li>测试用例使用 <code>dummy-api-key</code> 和文档保留 IP 段。</li>
<li>实机验证结果只保留方法名、状态、code、message、条数和链路可用性。</li>
<li>当前版本为只读能力，不执行写操作，不修改 geyecloud-ATD 配置。</li>
</ul>
<h2 data-heading="13. Known Limits">13. Known Limits</h2>
<p>当前限制：</p>
<ul>
<li>暂不包含策略配置、处置下发、配置修改等 writable API。</li>
<li>暂不自动化 UI 登录验证码流程。</li>
<li>API key 需要由管理员或运维侧在 geyecloud-ATD 环境中预先生成，再配置到 OctoBus instance secret。</li>
<li>本次必要证据聚焦 Service 包本地验证、真实 API 验证、OctoBus 导入、实例配置和直接 RPC 调用；UI 和 agent 端到端截图可按需追加。</li>
</ul>
<h2 data-heading="14. Review Checklist">14. Review Checklist</h2>
<ul>
<li>Service package created under <code>services/geyecloud__atd_v2-3-6/</code></li>
<li><code>service.json</code> / <code>proto</code> / <code>src</code> / <code>bin</code> / schemas / tests / README included</li>
<li>13 unary RPCs implemented</li>
<li>Local tests passed</li>
<li><code>octobus-sdk validate --strict</code> passed</li>
<li><code>npm run pack:check</code> passed</li>
<li>Real geyecloud-ATD API validation flow prepared</li>
<li>Secrets and real environment details masked</li>
<li>Current capability boundary documented as read-only</li>
</ul>