### PR TITLE
feat: 新增 state-manager 服务 — 智能体状态层（记忆引擎 + 蒸馏引擎 + 任务状态机 + 事件日志）

### DIFF
--- a/services/state-manager/bin/state-service.js
+++ b/services/state-manager/bin/state-service.js
@@ -1,0 +1,844 @@
+#!/usr/bin/env node
+/**
+ * Agent State Manager - OctoBus Service Entry Point
+ *
+ * Capability modules (28 RPCs):
+ * 1. Project Config — read projects.yaml, provide query/match (3 RPCs)
+ * 2. Weekly Buffer — accumulate summaries, clear after sync (3 RPCs, delegated to memory engine commitment type)
+ * 3. Meeting Tracking — register meetings, track state, query pending (3 RPCs, delegated to memory engine commitment type)
+ * 4. User Config — read user-config.json personal config (1 RPC)
+ * 5. Memory Engine — Remember/Recall/Forget + stats (4 RPCs)
+ * 6. Distillation Engine — action_log compression + session summary + correction management (2 RPCs)
+ * 7. Task State Machine — task lifecycle + step tracking + timeout detection (6 RPCs)
+ * 8. Event Log — append-only event records + range queries (3 RPCs)
+ * 9. General Storage — simple key-value store (backward-compatible API) (2 RPCs)
+ *
+ * OctoBus service display name mapping:
+ *   state-manager     → Agent State Manager (this package)
+ *   dingtalk-aitable  → DingTalk AITable
+ *   dingtalk-calendar → DingTalk Calendar
+ *   dingtalk-doc      → DingTalk Doc
+ *   dingtalk-message  → DingTalk Message
+ *   dingtalk-todo     → DingTalk Todo
+ */
+
+import { defineService, runServiceMain } from '@chaitin-ai/octobus-sdk';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { StorageAdapter } from '../lib/storage-adapter.js';
+import { MemoryIndex } from '../lib/memory-index.js';
+import { TTLManager } from '../lib/ttl-manager.js';
+import { MemoryEngine } from '../lib/memory-engine.js';
+import { DistillationEngine } from '../lib/distillation-engine.js';
+import { TaskMachine } from '../lib/task-machine.js';
+import { EventLog } from '../lib/event-log.js';
+
+// ====== Config ======
+const config = {
+  dataDir: process.env.DATA_DIR || './data',
+  projectsConfigPath: process.env.PROJECTS_CONFIG_PATH || process.env.PROJECTS_CONFIG || './config/projects.yaml',
+  userConfigPath: process.env.USER_CONFIG_PATH || process.env.USER_CONFIG || './config/user-config.json',
+};
+
+// ====== Project Config Cache ======
+let projectsCache = null;
+let projectsCacheTime = 0;
+const CACHE_TTL = 60000; // 1 minute
+
+async function loadProjects() {
+  const now = Date.now();
+  if (projectsCache && (now - projectsCacheTime) < CACHE_TTL) {
+    return projectsCache;
+  }
+
+  const yaml = await import('js-yaml');
+  const raw = await readFile(config.projectsConfigPath, 'utf-8');
+  const parsed = yaml.load(raw);
+
+  projectsCache = parsed;
+  projectsCacheTime = now;
+  return parsed;
+}
+
+// ====== JSON Persistence Helpers ======
+async function loadJSON(filePath, defaultValue = {}) {
+  try {
+    const raw = await readFile(filePath, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return defaultValue;
+  }
+}
+
+async function saveJSON(filePath, data) {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+// ====== Meeting State Machine (migrated to memory engine, this constant is for internal filtering only) ======
+const VALID_MEETING_STATES = ['registered', 'notes_submitted', 'doc_created', 'reminded'];
+
+// ====== Memory Engine (global singleton) ======
+const storageAdapter = new StorageAdapter(config.dataDir);
+const memoryIndex = new MemoryIndex();
+const ttlManager = new TTLManager(memoryIndex, storageAdapter);
+const memoryEngine = new MemoryEngine(memoryIndex, storageAdapter, ttlManager);
+
+// ====== Distillation Engine ======
+const distillationEngine = new DistillationEngine(memoryEngine);
+
+// ====== Task State Machine ======
+const taskMachine = new TaskMachine(config.dataDir);
+
+// ====== Event Log ======
+const eventLog = new EventLog(config.dataDir);
+
+// ====== Startup Initialization ======
+async function initialize() {
+  // 1. Load tenant/userId from user-config
+  await memoryEngine.loadIdentity(config.userConfigPath);
+
+  // 2. Load existing memories from files into index
+  const allEntries = await storageAdapter.loadAll();
+  memoryIndex.rebuild(allEntries);
+
+  // 3. Start TTL background scan
+  ttlManager.start();
+
+  // 4. Initialize task state machine
+  await taskMachine.initialize();
+
+  // 5. Initialize event log
+  await eventLog.initialize();
+
+  console.log(`[MemoryEngine] initialized: tenant=${memoryEngine.tenant}, user=${memoryEngine.userId}, entries=${memoryIndex.entries.size}`);
+  console.log(`[TaskMachine] ${taskMachine.tasks.size} tasks, [EventLog] ${eventLog.events.length} events`);
+}
+
+// Initialization (runs immediately after service start)
+const initPromise = initialize();
+
+// ====== Service Definition ======
+const service = defineService({
+  handlers: {
+
+    // ====== Project Config ======
+
+    /**
+     * Get project config by key
+     */
+    'state.manager.v1.StateManagerService/GetProject': async (ctx) => {
+      const { key } = ctx.request;
+      try {
+        const parsed = await loadProjects();
+        const projects = parsed.projects || {};
+        const proj = projects[key];
+        if (!proj) {
+          return { success: false, error: `Project "${key}" not found` };
+        }
+        return {
+          success: true,
+          project: {
+            key,
+            name: proj.name || '',
+            nodeId: proj.node_id || '',
+            customer: proj.customer || '',
+            keywords: proj.keywords || [],
+            detailFolder: proj.detail_folder || '',
+            background: proj.background || '',
+          },
+          error: '',
+        };
+      } catch (err) {
+        return { success: false, error: err.message };
+      }
+    },
+
+    /**
+     * List all projects
+     */
+    'state.manager.v1.StateManagerService/ListProjects': async () => {
+      try {
+        const parsed = await loadProjects();
+        const projects = parsed.projects || {};
+        const list = Object.entries(projects).map(([key, proj]) => ({
+          key,
+          name: proj.name || '',
+          nodeId: proj.node_id || '',
+          customer: proj.customer || '',
+          keywords: proj.keywords || [],
+          detailFolder: proj.detail_folder || '',
+          background: proj.background || '',
+        }));
+        return { success: true, projects: list, error: '' };
+      } catch (err) {
+        return { success: false, projects: [], error: err.message };
+      }
+    },
+
+    /**
+     * Match project by keywords
+     * Ported from Python doc_creator.py match_customer_to_project()
+     */
+    'state.manager.v1.StateManagerService/MatchProject': async (ctx) => {
+      const { text } = ctx.request;
+      try {
+        const parsed = await loadProjects();
+        const projects = parsed.projects || {};
+
+        let bestMatch = null;
+        let bestScore = 0;
+
+        for (const [key, proj] of Object.entries(projects)) {
+          const keywords = proj.keywords || [];
+          for (const kw of keywords) {
+            if (text.includes(kw)) {
+              const score = kw.length / Math.max(text.length, 1);
+              if (score > bestScore) {
+                bestScore = score;
+                bestMatch = {
+                  key,
+                  name: proj.name || '',
+                  nodeId: proj.node_id || '',
+                  customer: proj.customer || '',
+                  keywords,
+                  detailFolder: proj.detail_folder || '',
+                  background: proj.background || '',
+                };
+              }
+            }
+          }
+        }
+
+        return {
+          success: true,
+          project: bestMatch || { key: '', name: '', nodeId: '', customer: '', keywords: [], detailFolder: '', background: '' },
+          confidence: bestMatch ? Math.min(bestScore * 5, 1.0) : 0,
+          error: '',
+        };
+      } catch (err) {
+        return { success: false, confidence: 0, error: err.message };
+      }
+    },
+
+    // ====== Weekly Pending Buffer (migrated to memory engine commitment type) ======
+
+    /**
+     * Add a pending weekly summary item
+     * Internally delegates to Remember(type=commitment, key=weekly_item:{date}:{hash})
+     */
+    'state.manager.v1.StateManagerService/AddPendingItem': async (ctx) => {
+      await initPromise;
+      const { summary, category, date } = ctx.request;
+      const itemDate = date || new Date().toISOString().slice(0, 10);
+      const itemCategory = category || 'Communication';
+      const key = `weekly_item:${itemDate}:${(summary || '').slice(0, 20)}`;
+      const value = JSON.stringify({
+        summary: summary || '',
+        category: itemCategory,
+        date: itemDate,
+      });
+
+      try {
+        const result = await memoryEngine.remember({
+          type: 'commitment',
+          key,
+          value,
+          ttl_seconds: 30 * 86400, // 30 days
+        });
+
+        // Count current pending total
+        const all = await memoryEngine.recall({ prefix: 'weekly_item:', type: 'commitment', limit: 100 });
+
+        return { success: result.success, pendingCount: all.entries.length, error: result.error || '' };
+      } catch (err) {
+        return { success: false, pendingCount: 0, error: err.message };
+      }
+    },
+
+    /**
+     * Get all pending sync items
+     * Internally delegates to Recall(prefix=weekly_item:, type=commitment)
+     */
+    'state.manager.v1.StateManagerService/GetPendingItems': async () => {
+      await initPromise;
+      try {
+        const result = await memoryEngine.recall({ prefix: 'weekly_item:', type: 'commitment', limit: 100 });
+        const items = (result.entries || []).map((entry) => {
+          try {
+            const parsed = JSON.parse(entry.value);
+            return {
+              summary: parsed.summary || '',
+              category: parsed.category || '',
+              date: parsed.date || '',
+            };
+          } catch {
+            return { summary: entry.value || '', category: '', date: '' };
+          }
+        });
+        return { success: true, items, error: '' };
+      } catch (err) {
+        return { success: false, items: [], error: err.message };
+      }
+    },
+
+    /**
+     * Clear pending buffer (called after successful sync)
+     * Internally delegates to Forget(prefix=weekly_item:, type=commitment) + records last_synced
+     */
+    'state.manager.v1.StateManagerService/ClearPending': async () => {
+      await initPromise;
+      try {
+        // Get current entry count (for returning clearedCount)
+        const all = await memoryEngine.recall({ prefix: 'weekly_item:', type: 'commitment', limit: 100 });
+        const clearedCount = all.entries.length;
+
+        // Batch delete all weekly_item entries
+        await memoryEngine.forget({ prefix: 'weekly_item:', type: 'commitment' });
+
+        // Record last_synced time
+        await memoryEngine.remember({
+          type: 'commitment',
+          key: 'weekly:last_synced',
+          value: JSON.stringify({ last_synced: new Date().toISOString() }),
+          ttl_seconds: 30 * 86400,
+        });
+
+        return { success: true, clearedCount, error: '' };
+      } catch (err) {
+        return { success: false, clearedCount: 0, error: err.message };
+      }
+    },
+
+    // ====== Meeting Tracking (migrated to memory engine commitment type) ======
+
+    /**
+     * Register a meeting
+     * Internally delegates to Remember(type=commitment, key=meeting:{eventId})
+     */
+    'state.manager.v1.StateManagerService/RegisterMeeting': async (ctx) => {
+      await initPromise;
+      const { eventId, summary, startTime, endTime, attendees } = ctx.request;
+
+      try {
+        // Check if already exists
+        const existing = await memoryEngine.recall({ key: `meeting:${eventId}`, type: 'commitment' });
+
+        if (existing.entries && existing.entries.length > 0) {
+          // Already exists, skip but update last_check
+          return { success: true, isNew: false, error: '' };
+        }
+
+        // New meeting, write to memory engine
+        const value = JSON.stringify({
+          eventId: eventId || '',
+          summary: summary || '',
+          startTime: startTime || '',
+          endTime: endTime || '',
+          attendees: attendees || [],
+          state: 'registered',
+          registeredAt: new Date().toISOString(),
+        });
+
+        await memoryEngine.remember({
+          type: 'commitment',
+          key: `meeting:${eventId}`,
+          value,
+          ttl_seconds: 30 * 86400, // 30 days
+        });
+
+        return { success: true, isNew: true, error: '' };
+      } catch (err) {
+        return { success: false, isNew: false, error: err.message };
+      }
+    },
+
+    /**
+     * Get pending meetings (ended but no minutes submitted yet)
+     * Internally delegates to Recall(prefix=meeting:, type=commitment) + filtering
+     */
+    'state.manager.v1.StateManagerService/GetPendingMeetings': async (ctx) => {
+      await initPromise;
+      const graceHours = ctx.request.graceHours || 24;
+
+      try {
+        const result = await memoryEngine.recall({ prefix: 'meeting:', type: 'commitment', limit: 200 });
+        const now = new Date();
+        const graceMs = graceHours * 3600 * 1000;
+
+        const meetings = (result.entries || [])
+          .map((entry) => {
+            try {
+              return JSON.parse(entry.value);
+            } catch {
+              return null;
+            }
+          })
+          .filter((m) => {
+            if (!m || m.state !== 'registered') return false;
+            if (!m.endTime && !m.end_time) return false;
+            const endTime = new Date(m.endTime || m.end_time);
+            return (now - endTime) > graceMs;
+          })
+          .map((m) => ({
+            eventId: m.eventId || m.event_id || '',
+            summary: m.summary || '',
+            startTime: m.startTime || m.start_time || '',
+            endTime: m.endTime || m.end_time || '',
+            attendees: m.attendees || [],
+            state: m.state || 'registered',
+          }));
+
+        return { success: true, meetings, error: '' };
+      } catch (err) {
+        return { success: false, meetings: [], error: err.message };
+      }
+    },
+
+    /**
+     * Update meeting state
+     * Internally delegates to Recall + Remember to update memory entry
+     */
+    'state.manager.v1.StateManagerService/UpdateMeetingState': async (ctx) => {
+      await initPromise;
+      const { eventId, newState } = ctx.request;
+
+      if (!VALID_MEETING_STATES.includes(newState)) {
+        return { success: false, error: `Invalid state "${newState}", valid values: ${VALID_MEETING_STATES.join(', ')}` };
+      }
+
+      try {
+        const existing = await memoryEngine.recall({ key: `meeting:${eventId}`, type: 'commitment' });
+
+        if (!existing.entries || existing.entries.length === 0) {
+          return { success: false, error: `Meeting "${eventId}" not found` };
+        }
+
+        const entry = existing.entries[0];
+        let meeting;
+        try {
+          meeting = JSON.parse(entry.value);
+        } catch {
+          return { success: false, error: `Meeting "${eventId}" data corrupted` };
+        }
+
+        meeting.state = newState;
+        meeting.updatedAt = new Date().toISOString();
+
+        await memoryEngine.remember({
+          type: 'commitment',
+          key: `meeting:${eventId}`,
+          value: JSON.stringify(meeting),
+          ttl_seconds: 30 * 86400,
+        });
+
+        return { success: true, error: '' };
+      } catch (err) {
+        return { success: false, error: err.message };
+      }
+    },
+
+    // ====== User Config ======
+
+    /**
+     * Read user personal config
+     * Config file: config/user-config.json (filled by deployer per actual environment)
+     */
+    'state.manager.v1.StateManagerService/GetUserConfig': async () => {
+      try {
+        const raw = await readFile(config.userConfigPath, 'utf-8');
+        const userConfig = JSON.parse(raw);
+        return { success: true, config: userConfig, error: '' };
+      } catch (err) {
+        if (err.code === 'ENOENT') {
+          return {
+            success: false,
+            config: null,
+            error: `User config file not found: ${config.userConfigPath}, please create and fill in personal config`,
+          };
+        }
+        return { success: false, config: null, error: `Failed to read config: ${err.message}` };
+      }
+    },
+
+    // ====== Agent Memory ======
+
+    /**
+     * Write a memory entry
+     */
+    'state.manager.v1.StateManagerService/Remember': async (ctx) => {
+      await initPromise; // Ensure initialization is complete
+      const result = await memoryEngine.remember(ctx.request);
+
+      // Log to event log (non-blocking)
+      eventLog.logEvent({
+        event_type: 'memory.remember',
+        actor: 'agent',
+        description: `Remember: type=${ctx.request.type}, key=${ctx.request.key}, unchanged=${result.unchanged}`,
+        level: 'info',
+      }).catch(() => {});
+
+      return {
+        success: result.success,
+        unchanged: result.unchanged || false,
+        evictedCount: result.evictedCount || 0,
+        error: result.error || '',
+      };
+    },
+
+    /**
+     * Read memory (exact match or prefix match)
+     */
+    'state.manager.v1.StateManagerService/Recall': async (ctx) => {
+      await initPromise;
+      const result = await memoryEngine.recall(ctx.request);
+      return {
+        success: result.success,
+        entries: result.entries || [],
+        error: result.error || '',
+      };
+    },
+
+    /**
+     * Delete memory
+     */
+    'state.manager.v1.StateManagerService/Forget': async (ctx) => {
+      await initPromise;
+      const result = await memoryEngine.forget(ctx.request);
+
+      // Log to event log
+      eventLog.logEvent({
+        event_type: 'memory.forget',
+        actor: 'agent',
+        description: `Forget: key=${ctx.request.key || ctx.request.prefix}, deleted=${result.deletedCount}`,
+        level: 'info',
+      });
+
+      return {
+        success: result.success,
+        deletedCount: result.deletedCount || 0,
+        error: result.error || '',
+      };
+    },
+
+    /**
+     * Get memory engine runtime statistics
+     */
+    'state.manager.v1.StateManagerService/GetMemoryStats': async () => {
+      await initPromise;
+      const stats = memoryEngine.getStats();
+      return {
+        success: true,
+        totalEntries: stats.totalEntries || 0,
+        typeStats: stats.types || {},
+        rememberCalls: stats.rememberCalls || 0,
+        recallCalls: stats.recallCalls || 0,
+        forgetCalls: stats.forgetCalls || 0,
+        totalEvictions: stats.totalEvictions || 0,
+        totalDedups: stats.totalDedups || 0,
+        tenant: stats.tenant || '',
+        userId: stats.userId || '',
+        error: '',
+      };
+    },
+
+    // ====== Distillation Engine ======
+
+    /**
+     * Manually trigger a full distillation
+     */
+    'state.manager.v1.StateManagerService/Distill': async () => {
+      await initPromise;
+      const result = await distillationEngine.distill();
+
+      eventLog.logEvent({
+        event_type: 'distillation.run',
+        actor: 'system',
+        description: `Distill: actionLog=${JSON.stringify(result.summary?.actionLog)}, session=${JSON.stringify(result.summary?.sessionSummary)}`,
+        level: result.success ? 'info' : 'error',
+      });
+
+      const s = result.summary || {};
+      return {
+        success: result.success,
+        actionLog: s.actionLog ? { compressed: s.actionLog.compressed || 0, created: s.actionLog.created || 0, deleted: s.actionLog.deleted || 0, reason: s.actionLog.reason || '' } : null,
+        sessionSummary: s.sessionSummary ? { compressed: s.sessionSummary.compressed || 0, created: s.sessionSummary.created || 0, deleted: s.sessionSummary.deleted || 0, reason: s.sessionSummary.reason || '' } : null,
+        correctionsUpgraded: s.userCorrection?.upgraded || 0,
+        correctionsDemoted: s.userCorrection?.demoted || 0,
+        error: result.error || '',
+      };
+    },
+
+    /**
+     * Get distillation statistics
+     */
+    'state.manager.v1.StateManagerService/GetDistillStats': async () => {
+      await initPromise;
+      const stats = distillationEngine.getStats();
+      return {
+        success: true,
+        totalRuns: stats.totalRuns || 0,
+        lastRunAt: stats.lastRunAt || '',
+        actionLogCompressed: stats.actionLogCompressed || 0,
+        sessionSummaryCompressed: stats.sessionSummaryCompressed || 0,
+        correctionsUpgraded: stats.correctionsUpgraded || 0,
+        error: '',
+      };
+    },
+
+    // ====== Task State Machine ======
+
+    /**
+     * Create a task
+     */
+    'state.manager.v1.StateManagerService/CreateTask': async (ctx) => {
+      await initPromise;
+      const r = ctx.request;
+      const result = await taskMachine.createTask({
+        task_id: r.taskId || r.task_id,
+        name: r.name,
+        description: r.description,
+        assignee: r.assignee,
+        due_date: r.dueDate || r.due_date,
+        steps: r.steps,
+        priority: r.priority,
+      });
+
+      eventLog.logEvent({
+        event_type: 'task.created',
+        actor: ctx.request.assignee || 'agent',
+        description: `CreateTask: ${ctx.request.name} (${result.task_id})`,
+        level: 'info',
+      });
+
+      return { success: result.success, taskId: result.task_id || '', error: result.error || '' };
+    },
+
+    /**
+     * Update task state
+     */
+    'state.manager.v1.StateManagerService/UpdateTask': async (ctx) => {
+      await initPromise;
+      const r = ctx.request;
+      const result = await taskMachine.updateTask({
+        task_id: r.taskId || r.task_id,
+        new_state: r.newState || r.new_state,
+        reason: r.reason,
+      });
+
+      eventLog.logEvent({
+        event_type: 'task.state_changed',
+        actor: 'agent',
+        description: `UpdateTask: ${ctx.request.taskId || ctx.request.task_id} ${result.old_state} → ${result.new_state}`,
+        level: result.new_state === 'failed' ? 'warning' : 'info',
+      });
+
+      return {
+        success: result.success,
+        oldState: result.old_state || '',
+        newState: result.new_state || '',
+        error: result.error || '',
+      };
+    },
+
+    /**
+     * Add/update a step
+     */
+    'state.manager.v1.StateManagerService/UpdateStep': async (ctx) => {
+      await initPromise;
+      const r = ctx.request;
+      const result = await taskMachine.updateStep({
+        task_id: r.taskId || r.task_id,
+        step_id: r.stepId || r.step_id,
+        name: r.name,
+        state: r.state,
+        notes: r.notes,
+      });
+      return { success: result.success, stepId: result.step_id || '', error: result.error || '' };
+    },
+
+    /**
+     * Get a single task
+     */
+    'state.manager.v1.StateManagerService/GetTask': async (ctx) => {
+      await initPromise;
+      const taskId = ctx.request.taskId || ctx.request.task_id;
+      const result = taskMachine.getTask(taskId);
+      return {
+        success: result.success,
+        task: result.task || null,
+        error: result.error || '',
+      };
+    },
+
+    /**
+     * List tasks (with filtering)
+     */
+    'state.manager.v1.StateManagerService/ListTasks': async (ctx) => {
+      await initPromise;
+      const r = ctx.request;
+      const result = taskMachine.listTasks({
+        state: r.state,
+        assignee: r.assignee,
+        priority: r.priority,
+        due_before: r.dueBefore || r.due_before,
+        due_after: r.dueAfter || r.due_after,
+        limit: r.limit,
+      });
+      return {
+        success: result.success,
+        tasks: result.tasks || [],
+        total: result.total || 0,
+        error: result.error || '',
+      };
+    },
+
+    /**
+     * Get task statistics
+     */
+    'state.manager.v1.StateManagerService/GetTaskStats': async () => {
+      await initPromise;
+      const stats = taskMachine.getStats();
+      return {
+        success: true,
+        totalTasks: stats.totalTasks || 0,
+        stateCounts: stats.stateCounts || {},
+        totalCreated: stats.totalCreated || 0,
+        totalCompleted: stats.totalCompleted || 0,
+        totalFailed: stats.totalFailed || 0,
+        totalTimedOut: stats.totalTimedOut || 0,
+        error: '',
+      };
+    },
+
+    // ====== Event Log ======
+
+    /**
+     * Log an event
+     */
+    'state.manager.v1.StateManagerService/LogEvent': async (ctx) => {
+      await initPromise;
+      let data = ctx.request.data || '{}';
+      try { JSON.parse(data); } catch { data = JSON.stringify({ raw: data }); }
+      const result = await eventLog.logEvent({
+        event_type: ctx.request.eventType || ctx.request.event_type || 'unknown',
+        actor: ctx.request.actor || 'unknown',
+        description: ctx.request.description || '',
+        data: JSON.parse(data),
+        level: ctx.request.level || 'info',
+      });
+      return { success: result.success, eventId: result.event_id || '', error: result.error || '' };
+    },
+
+    /**
+     * Query events
+     */
+    'state.manager.v1.StateManagerService/QueryEvents': async (ctx) => {
+      await initPromise;
+      const r = ctx.request;
+      const result = await eventLog.queryEvents({
+        event_type: r.eventType || r.event_type,
+        actor: r.actor,
+        level: r.level,
+        since: r.since,
+        until: r.until,
+        search: r.search,
+        limit: r.limit,
+      });
+      return {
+        success: result.success,
+        events: (result.events || []).map(e => ({
+          eventId: e.event_id,
+          eventType: e.event_type,
+          actor: e.actor,
+          description: e.description,
+          data: JSON.stringify(e.data),
+          level: e.level,
+          timestamp: e.timestamp,
+        })),
+        total: result.total || 0,
+        error: result.error || '',
+      };
+    },
+
+    /**
+     * Get event log statistics
+     */
+    'state.manager.v1.StateManagerService/GetEventStats': async () => {
+      await initPromise;
+      const stats = eventLog.getStats();
+      return {
+        success: true,
+        totalEvents: stats.totalEvents || 0,
+        totalLogged: stats.totalLogged || 0,
+        totalRotated: stats.totalRotated || 0,
+        oldestEvent: stats.oldestEvent || '',
+        newestEvent: stats.newestEvent || '',
+        error: '',
+      };
+    },
+
+    // ====== General KV Storage ======
+
+    /**
+     * Read state
+     */
+    'state.manager.v1.StateManagerService/GetState': async (ctx) => {
+      const { key } = ctx.request;
+      const filePath = join(config.dataDir, 'kv_state.json');
+
+      try {
+        const data = await loadJSON(filePath, {});
+        return { success: true, value: JSON.stringify(data[key] ?? null), error: '' };
+      } catch (err) {
+        return { success: false, value: '', error: err.message };
+      }
+    },
+
+    /**
+     * Write state
+     */
+    'state.manager.v1.StateManagerService/SetState': async (ctx) => {
+      const { key, value } = ctx.request;
+      const filePath = join(config.dataDir, 'kv_state.json');
+
+      try {
+        const data = await loadJSON(filePath, {});
+        try {
+          data[key] = JSON.parse(value);
+        } catch {
+          data[key] = value;
+        }
+        await saveJSON(filePath, data);
+
+        return { success: true, error: '' };
+      } catch (err) {
+        return { success: false, error: err.message };
+      }
+    },
+  },
+});
+
+runServiceMain(service);
+
+// ====== Graceful Shutdown ======
+async function gracefulShutdown(signal) {
+  console.log(`[StateService] received ${signal}, shutting down gracefully...`);
+
+  // 1. Stop TTL scan
+  ttlManager.stop();
+
+  // 2. Stop task timeout detection
+  taskMachine.stop();
+
+  // 3. Final persistence: wait for all in-flight writes
+  await storageAdapter.waitForPendingWrites();
+  await taskMachine.shutdown();
+  await eventLog.shutdown();
+
+  console.log('[StateService] shutdown complete');
+  process.exit(0);
+}
+
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));

--- a/services/state-manager/config.schema.json
+++ b/services/state-manager/config.schema.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "dataDir": {
+      "type": "string",
+      "description": "Data directory path, can be overridden via DATA_DIR env var",
+      "default": "./data"
+    },
+    "projectsConfigPath": {
+      "type": "string",
+      "description": "Project config file path, can be overridden via PROJECTS_CONFIG env var",
+      "default": "./config/projects.yaml"
+    },
+    "userConfigPath": {
+      "type": "string",
+      "description": "User personal config file path (identity/kanban/CRM/instance mapping), can be overridden via USER_CONFIG env var. New users only need to edit this one file during deployment.",
+      "default": "./config/user-config.json"
+    }
+  }
+}

--- a/services/state-manager/config/user-config.example.json
+++ b/services/state-manager/config/user-config.example.json
@@ -1,0 +1,58 @@
+{
+  "_README": "Personal config file — change this one file when switching users/environments. All agents read via GetUserConfig.",
+  "identity": {
+    "user_id": "YOUR_LOGIN_ID",
+    "display_name": "Your Name",
+    "role": "Your role (pre-sales/sales/tech-support)",
+    "crm_user_id": "CRM user ID (look up via ListUsers on first use, can leave empty for agent auto-lookup)",
+    "default_sales_user_id": "Default sales userId",
+    "default_sales_name": "Default sales name",
+    "team": "Your team name"
+  },
+  "kanban": {
+    "base_id": "AITable base ID (from alidocs URL nodeId)",
+    "table_id": "AITable table ID",
+    "instance": "OctoBus instance name (e.g. aitable-instance)",
+    "fields": {
+      "start_date": "Start date field ID",
+      "end_date": "Due date field ID",
+      "task_type": "Task type field ID",
+      "task_desc": "Task description field ID",
+      "sales": "Sales field ID",
+      "owner": "Owner field ID",
+      "notes": "Description field ID",
+      "customer_l1": "Customer tier field ID",
+      "customer_l2": "Sub-department field ID",
+      "status": "Status field ID",
+      "presale": "Pre-sales field ID",
+      "crm_link": "CRM project link field ID"
+    },
+    "task_types": {
+      "communication": [{"id": "option ID", "name": "Communication"}],
+      "documentation": [{"id": "option ID", "name": "Documentation"}],
+      "bidding": [{"id": "option ID", "name": "Bidding"}],
+      "poc": [{"id": "option ID", "name": "POC & Others"}]
+    },
+    "statuses": {
+      "completed": [{"id": "option ID", "name": "Done"}],
+      "in_progress": [{"id": "option ID", "name": "In Progress"}]
+    },
+    "customers": {
+      "customers": [
+        {"id": "option ID", "name": "Customer Name"}
+      ]
+    }
+  },
+  "instances": {
+    "aitable": "aitable-instance",
+    "doc": "doc-instance",
+    "calendar": "calendar-instance",
+    "todo": "todo-instance",
+    "message": "message-instance",
+    "crm": "crm-instance",
+    "state": "state-instance"
+  },
+  "knowledge_file": "/opt/knowledge/company-products.md",
+  "company_name": "Your Company",
+  "company_english": "CompanyNameEn"
+}

--- a/services/state-manager/lib/distillation-engine.js
+++ b/services/state-manager/lib/distillation-engine.js
@@ -1,0 +1,415 @@
+/**
+ * DistillationEngine — Memory Distillation Engine
+ *
+ * Core value: makes memory more than just "store and retrieve" —
+ * it continuously compresses and refines.
+ * Three levels of distillation:
+ *   1. action_log → session_summary (weekly summary, ~10:1 compression)
+ *   2. session_summary → monthly_summary (monthly rollup, ~10:1 compression)
+ *   3. user_correction pattern extraction (multiple corrections for same key → upgrade to permanent preference)
+ *
+ * The distillation engine is driven by deterministic rules, not LLM.
+ * It is a "clever tool", not an agent.
+ */
+
+export class DistillationEngine {
+  /**
+   * @param {import('./memory-engine.js').MemoryEngine} memoryEngine
+   * @param {object} opts
+   * @param {number} opts.weeklyWindowDays - action_log weekly summary window (default 7 days)
+   * @param {number} opts.monthlyWindowDays - session_summary monthly rollup window (default 30 days)
+   * @param {number} opts.correctionThreshold - Number of corrections for same key to trigger upgrade (default 3)
+   */
+  constructor(memoryEngine, opts = {}) {
+    this.engine = memoryEngine;
+    this.weeklyWindowDays = opts.weeklyWindowDays || 7;
+    this.monthlyWindowDays = opts.monthlyWindowDays || 30;
+    this.correctionThreshold = opts.correctionThreshold || 3;
+
+    // Distillation statistics
+    this._stats = {
+      totalRuns: 0,
+      lastRunAt: null,
+      actionLogCompressed: 0,
+      sessionSummaryCompressed: 0,
+      correctionsUpgraded: 0,
+      errors: 0,
+    };
+  }
+
+  /**
+   * Run a full distillation pass (all types)
+   * @returns {object} { success, summary, error }
+   */
+  async distill() {
+    this._stats.totalRuns++;
+    this._stats.lastRunAt = new Date().toISOString();
+
+    const summary = {
+      actionLog: null,
+      sessionSummary: null,
+      userCorrection: null,
+    };
+
+    try {
+      // 1. action_log weekly summary
+      summary.actionLog = await this._distillActionLogs();
+
+      // 2. session_summary monthly rollup
+      summary.sessionSummary = await this._distillSessionSummaries();
+
+      // 3. user_correction pattern extraction
+      summary.userCorrection = await this._distillUserCorrections();
+
+      return { success: true, summary, error: '' };
+    } catch (err) {
+      this._stats.errors++;
+      return { success: false, summary, error: err.message };
+    }
+  }
+
+  /**
+   * Get distillation statistics
+   */
+  getStats() {
+    return { ...this._stats };
+  }
+
+  // ─── 1. Action Log Weekly Summary ───
+
+  /**
+   * Compress action_log entries within 7 days into 1 session_summary
+   * @returns {object} { compressed, created, deleted }
+   */
+  async _distillActionLogs() {
+    const now = new Date();
+    const windowMs = this.weeklyWindowDays * 86400 * 1000;
+    const cutoff = new Date(now.getTime() - windowMs);
+
+    // Collect action_log entries within the window
+    const typeEntries = this.engine.index.getEntriesByType('action_log');
+    const candidates = [];
+    for (const [fullKey, entry] of typeEntries) {
+      const created = new Date(entry.createdAt);
+      if (created >= cutoff && created < now) {
+        candidates.push({ fullKey, entry });
+      }
+    }
+
+    if (candidates.length < 3) {
+      // Too few, not worth compressing
+      return { compressed: 0, created: 0, deleted: 0, reason: 'too_few_entries' };
+    }
+
+    // Analyze action_logs: extract patterns
+    const analysis = this._analyzeActionLogs(candidates);
+
+    // Build summary
+    const summaryValue = JSON.stringify({
+      source: 'distillation:action_log',
+      period: {
+        from: cutoff.toISOString(),
+        to: now.toISOString(),
+      },
+      totalActions: candidates.length,
+      topActions: analysis.topActions,
+      topEntities: analysis.topEntities,
+      frequency: analysis.frequency,
+      patterns: analysis.patterns,
+    });
+
+    // Write session_summary
+    const weekLabel = `${cutoff.toISOString().slice(0, 10)}_to_${now.toISOString().slice(0, 10)}`;
+    const writeResult = await this.engine.remember({
+      key: `distilled:action_log:${weekLabel}`,
+      value: summaryValue,
+      type: 'session_summary',
+      ttl_seconds: 30 * 86400,  // 30 days
+      confidence: 1.0,
+    });
+
+    let deletedCount = 0;
+    if (writeResult.success) {
+      // Delete compressed action_log entries
+      for (const { fullKey } of candidates) {
+        const entry = this.engine.index.delete(fullKey);
+        if (entry) deletedCount++;
+      }
+      // Persist action_log
+      await this.engine._persistType('action_log');
+      // Persist session_summary (since a new entry was just written)
+      await this.engine._persistType('session_summary');
+    }
+
+    this._stats.actionLogCompressed += deletedCount;
+
+    return {
+      compressed: candidates.length,
+      created: writeResult.success ? 1 : 0,
+      deleted: deletedCount,
+    };
+  }
+
+  /**
+   * Analyze action_log entries and extract patterns
+   */
+  _analyzeActionLogs(candidates) {
+    const actionCounts = new Map();   // action → count
+    const entityCounts = new Map();   // entity → count
+    const dailyCounts = new Map();    // date → count
+    const patterns = [];
+
+    for (const { entry } of candidates) {
+      // Extract action and entity from key
+      // Key format: "action:<action_type>:<entity>:<date>" or similar structure
+      const originalKey = entry._originalKey || '';
+      const parts = originalKey.split(':');
+      const action = parts[0] || 'unknown';
+      const entity = parts[1] || 'unknown';
+
+      // Count action frequency
+      actionCounts.set(action, (actionCounts.get(action) || 0) + 1);
+
+      // Count entity frequency
+      entityCounts.set(entity, (entityCounts.get(entity) || 0) + 1);
+
+      // Count daily frequency
+      const date = entry.createdAt.slice(0, 10);
+      dailyCounts.set(date, (dailyCounts.get(date) || 0) + 1);
+
+      // Parse value to extract extra info
+      try {
+        const val = typeof entry.value === 'string' ? JSON.parse(entry.value) : entry.value;
+        if (val && typeof val === 'object') {
+          // Record success/failure
+          if (val.success === false) {
+            patterns.push(`Failed action: ${action}(${entity})`);
+          }
+        }
+      } catch {
+        // Value is not JSON, skip
+      }
+    }
+
+    // Top 5 actions
+    const topActions = [...actionCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([action, count]) => ({ action, count }));
+
+    // Top 5 entities
+    const topEntities = [...entityCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([entity, count]) => ({ entity, count }));
+
+    // Frequency distribution
+    const dailyArr = [...dailyCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+    const avgPerDay = candidates.length / Math.max(dailyArr.length, 1);
+    const frequency = {
+      avgPerDay: Math.round(avgPerDay * 10) / 10,
+      activeDays: dailyArr.length,
+      totalDays: this.weeklyWindowDays,
+    };
+
+    // Pattern detection
+    const uniquePatterns = [...new Set(patterns)].slice(0, 5);
+
+    return { topActions, topEntities, frequency, patterns: uniquePatterns };
+  }
+
+  // ─── 2. Session Summary Monthly Rollup ───
+
+  /**
+   * Compress session_summary entries within 30 days into 1 monthly rollup
+   * @returns {object} { compressed, created, deleted }
+   */
+  async _distillSessionSummaries() {
+    const now = new Date();
+    const windowMs = this.monthlyWindowDays * 86400 * 1000;
+    const cutoff = new Date(now.getTime() - windowMs);
+
+    const typeEntries = this.engine.index.getEntriesByType('session_summary');
+    const candidates = [];
+    for (const [fullKey, entry] of typeEntries) {
+      const created = new Date(entry.createdAt);
+      // Only compress non-distilled session_summary (avoid recursive compression)
+      if (created >= cutoff && created < now) {
+        const val = typeof entry.value === 'string' ? entry.value : JSON.stringify(entry.value);
+        if (!val.includes('distillation:monthly_rollup')) {
+          candidates.push({ fullKey, entry });
+        }
+      }
+    }
+
+    if (candidates.length < 2) {
+      return { compressed: 0, created: 0, deleted: 0, reason: 'too_few_entries' };
+    }
+
+    // Merge all session_summary entries
+    const analysis = this._mergeSessionSummaries(candidates);
+
+    const summaryValue = JSON.stringify({
+      source: 'distillation:monthly_rollup',
+      period: {
+        from: cutoff.toISOString(),
+        to: now.toISOString(),
+      },
+      sessionCount: candidates.length,
+      allTopics: analysis.topTopics,
+      keyDecisions: analysis.keyDecisions,
+      pendingItems: analysis.pendingItems,
+      entitiesTouched: analysis.topEntities,
+    });
+
+    const monthLabel = cutoff.toISOString().slice(0, 7); // YYYY-MM
+    const writeResult = await this.engine.remember({
+      key: `distilled:monthly:${monthLabel}`,
+      value: summaryValue,
+      type: 'session_summary',
+      ttl_seconds: 90 * 86400,  // Monthly rollup retained for 90 days
+      confidence: 1.0,
+    });
+
+    let deletedCount = 0;
+    if (writeResult.success) {
+      for (const { fullKey } of candidates) {
+        const entry = this.engine.index.delete(fullKey);
+        if (entry) deletedCount++;
+      }
+      await this.engine._persistType('session_summary');
+    }
+
+    this._stats.sessionSummaryCompressed += deletedCount;
+
+    return {
+      compressed: candidates.length,
+      created: writeResult.success ? 1 : 0,
+      deleted: deletedCount,
+    };
+  }
+
+  /**
+   * Merge multiple session_summary entries
+   */
+  _mergeSessionSummaries(candidates) {
+    const topicCounts = new Map();
+    const decisions = [];
+    const pendingItems = [];
+    const entityCounts = new Map();
+
+    for (const { entry } of candidates) {
+      try {
+        const val = typeof entry.value === 'string' ? JSON.parse(entry.value) : entry.value;
+        if (!val || typeof val !== 'object') continue;
+
+        // Merge topics
+        if (Array.isArray(val.topics)) {
+          for (const t of val.topics) {
+            topicCounts.set(t, (topicCounts.get(t) || 0) + 1);
+          }
+        }
+
+        // Merge decisions (keep all, deduplicate)
+        if (Array.isArray(val.decisions)) {
+          for (const d of val.decisions) {
+            if (!decisions.includes(d)) decisions.push(d);
+          }
+        }
+
+        // Merge pending (keep only uncompleted)
+        if (Array.isArray(val.pending)) {
+          for (const p of val.pending) {
+            if (!pendingItems.includes(p)) pendingItems.push(p);
+          }
+        }
+
+        // Merge entities_touched
+        if (Array.isArray(val.entities_touched)) {
+          for (const e of val.entities_touched) {
+            entityCounts.set(e, (entityCounts.get(e) || 0) + 1);
+          }
+        }
+      } catch {
+        // Parse failed, skip
+      }
+    }
+
+    const topTopics = [...topicCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([topic, count]) => ({ topic, count }));
+
+    const topEntities = [...entityCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([entity, count]) => ({ entity, count }));
+
+    return {
+      topTopics,
+      keyDecisions: decisions.slice(0, 20),
+      pendingItems: pendingItems.slice(0, 10),
+      topEntities,
+    };
+  }
+
+  // ─── 3. User Correction Capacity Management ───
+
+  /**
+   * user_correction capacity management:
+   * When user_correction entries approach the capacity limit, demote the oldest
+   * entries to action_log. This keeps the latest correction records and frees
+   * space for new corrections.
+   *
+   * Note: user_correction is designed for same-key overwrite (keeps latest),
+   * so there will never be "multiple entries for the same key".
+   * Distillation focuses on overall capacity control.
+   * @returns {object} { demoted }
+   */
+  async _distillUserCorrections() {
+    const typeEntries = this.engine.index.getEntriesByType('user_correction');
+    const maxEntries = 100; // user_correction capacity limit
+    const threshold = Math.floor(maxEntries * 0.7); // Trigger cleanup at 70%
+
+    if (typeEntries.size < threshold) {
+      return { upgraded: 0, demoted: 0, reason: 'below_threshold' };
+    }
+
+    // Sort by creation time, oldest first
+    const sorted = [...typeEntries.entries()]
+      .sort((a, b) => new Date(a[1].createdAt) - new Date(b[1].createdAt));
+
+    // Demote oldest entries (keep latest 50%)
+    const toDemote = Math.floor(sorted.length * 0.5);
+    let demoted = 0;
+
+    for (let i = 0; i < toDemote; i++) {
+      const [fullKey, entry] = sorted[i];
+
+      // Skip protected entries
+      if (entry.protected) continue;
+
+      // Demote to action_log
+      await this.engine.remember({
+        key: `correction_archived:${entry._originalKey || fullKey}`,
+        value: typeof entry.value === 'string' ? entry.value : JSON.stringify(entry.value),
+        type: 'action_log',
+        ttl_seconds: 7 * 86400,
+        confidence: 0.5,
+      });
+
+      // Delete from user_correction
+      this.engine.index.delete(fullKey);
+      demoted++;
+    }
+
+    if (demoted > 0) {
+      await this.engine._persistType('user_correction');
+      await this.engine._persistType('action_log');
+    }
+
+    return { upgraded: 0, demoted };
+  }
+}
+
+export default DistillationEngine;

--- a/services/state-manager/lib/event-log.js
+++ b/services/state-manager/lib/event-log.js
@@ -1,0 +1,255 @@
+/**
+ * 事件日志（EventLog）— Append-only 事件日志
+ *
+ * 记录智能体平台中"发生了什么"，用于审计/调试/回溯。
+ * 与 Loader 的 Event Bus 互补：
+ *   - Loader Event Bus：实时触发（pub/sub），"什么时候跑"
+ *   - EventLog：历史记录（append-only），"发生了什么"
+ *
+ * 设计原则：
+ *   - Append-only，不删除不修改
+ *   - 按时间排序，支持范围查询
+ *   - 文件按大小轮转（maxEvents 条后新建文件）
+ *   - 不引入 pub/sub，与 Loader 零耦合
+ */
+
+import { readFile, writeFile, mkdir, readdir, rename } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+
+const DEFAULT_MAX_EVENTS = 5000;    // 单文件最大事件数
+const DEFAULT_MAX_FILES = 5;        // 最多保留的轮转文件数
+
+export class EventLog {
+  /**
+   * @param {string} dataDir
+   * @param {object} opts
+   * @param {number} opts.maxEvents - 单文件最大事件数
+   * @param {number} opts.maxFiles - 轮转文件数上限
+   */
+  constructor(dataDir, opts = {}) {
+    this.dataDir = dataDir;
+    this.filePath = join(dataDir, 'event_log.json');
+    this.maxEvents = opts.maxEvents || DEFAULT_MAX_EVENTS;
+    this.maxFiles = opts.maxFiles || DEFAULT_MAX_FILES;
+
+    // 内存中的事件缓冲（最近的事件）
+    this.events = [];
+    this._dirty = false;
+
+    // 统计
+    this._stats = {
+      totalLogged: 0,
+      totalRotated: 0,
+    };
+  }
+
+  // ─── 生命周期 ───
+
+  async initialize() {
+    await this._load();
+    console.log(`[EventLog] initialized: ${this.events.length} events loaded`);
+  }
+
+  async shutdown() {
+    if (this._dirty) await this._save();
+  }
+
+  // ─── 写入事件 ───
+
+  /**
+   * 记录一个事件
+   * @param {object} request
+   * @param {string} request.event_type - 事件类型（如 agent.remember, loader.triggered, task.state_changed）
+   * @param {string} request.actor - 触发者（智能体名称/系统/用户）
+   * @param {string} request.description - 事件描述
+   * @param {object} request.data - 附加数据
+   * @param {string} request.level - info / warning / error
+   * @returns {object} { success, event_id, error }
+   */
+  async logEvent(request) {
+    try {
+      const eventId = `evt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const event = {
+        event_id: eventId,
+        event_type: request.event_type || 'unknown',
+        actor: request.actor || 'system',
+        description: request.description || '',
+        data: request.data || {},
+        level: request.level || 'info',
+        timestamp: new Date().toISOString(),
+      };
+
+      this.events.push(event);
+      this._stats.totalLogged++;
+      this._dirty = true;
+
+      // 检查是否需要轮转
+      if (this.events.length >= this.maxEvents) {
+        await this._rotate();
+      }
+
+      // 立即持久化（事件日志要求可靠写入）
+      await this._save();
+
+      return { success: true, event_id: eventId, error: '' };
+    } catch (err) {
+      return { success: false, event_id: '', error: err.message };
+    }
+  }
+
+  // ─── 查询事件 ───
+
+  /**
+   * 查询事件
+   * @param {object} filter
+   * @param {string} filter.event_type - 按事件类型过滤
+   * @param {string} filter.actor - 按触发者过滤
+   * @param {string} filter.level - 按级别过滤
+   * @param {string} filter.since - 起始时间（ISO 8601）
+   * @param {string} filter.until - 结束时间（ISO 8601）
+   * @param {string} filter.search - 关键词搜索（在 description 中匹配）
+   * @param {number} filter.limit - 最大返回条数（默认 50）
+   * @returns {object} { success, events, total, error }
+   */
+  async queryEvents(filter = {}) {
+    let results = [...this.events];
+
+    // 按事件类型过滤
+    if (filter.event_type) {
+      const types = filter.event_type.split(',');
+      results = results.filter(e => types.includes(e.event_type));
+    }
+
+    // 按触发者过滤
+    if (filter.actor) {
+      results = results.filter(e => e.actor === filter.actor);
+    }
+
+    // 按级别过滤
+    if (filter.level) {
+      results = results.filter(e => e.level === filter.level);
+    }
+
+    // 按时间范围过滤
+    if (filter.since) {
+      const since = new Date(filter.since);
+      results = results.filter(e => new Date(e.timestamp) >= since);
+    }
+    if (filter.until) {
+      const until = new Date(filter.until);
+      results = results.filter(e => new Date(e.timestamp) <= until);
+    }
+
+    // 关键词搜索
+    if (filter.search) {
+      const keyword = filter.search.toLowerCase();
+      results = results.filter(e =>
+        (e.description || '').toLowerCase().includes(keyword) ||
+        (e.event_type || '').toLowerCase().includes(keyword)
+      );
+    }
+
+    // 按时间倒序（最新的在前）
+    results.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+
+    const total = results.length;
+    const limit = filter.limit || 50;
+    results = results.slice(0, limit);
+
+    return { success: true, events: results, total, error: '' };
+  }
+
+  /**
+   * 获取事件日志统计
+   */
+  getStats() {
+    const typeCounts = {};
+    const actorCounts = {};
+    const levelCounts = { info: 0, warning: 0, error: 0 };
+
+    for (const event of this.events) {
+      typeCounts[event.event_type] = (typeCounts[event.event_type] || 0) + 1;
+      actorCounts[event.actor] = (actorCounts[event.actor] || 0) + 1;
+      if (levelCounts[event.level] !== undefined) {
+        levelCounts[event.level]++;
+      }
+    }
+
+    return {
+      totalEvents: this.events.length,
+      ...this._stats,
+      typeCounts,
+      actorCounts,
+      levelCounts,
+      oldestEvent: this.events.length > 0 ? this.events[0].timestamp : null,
+      newestEvent: this.events.length > 0 ? this.events[this.events.length - 1].timestamp : null,
+    };
+  }
+
+  // ─── 内部方法 ───
+
+  /**
+   * 文件轮转：当前文件重命名为 .1，旧文件递增
+   */
+  async _rotate() {
+    try {
+      // 递增轮转文件编号
+      for (let i = this.maxFiles - 1; i >= 1; i--) {
+        const from = join(this.dataDir, `event_log.${i}.json`);
+        const to = join(this.dataDir, `event_log.${i + 1}.json`);
+        try {
+          await rename(from, to);
+        } catch {
+          // 文件不存在，跳过
+        }
+      }
+
+      // 当前文件 → .1
+      try {
+        await rename(this.filePath, join(this.dataDir, 'event_log.1.json'));
+      } catch {
+        // 当前文件不存在，忽略
+      }
+
+      // 清空内存
+      this.events = [];
+      this._stats.totalRotated++;
+      this._dirty = false;
+    } catch (err) {
+      console.error('[EventLog] rotation error:', err.message);
+    }
+  }
+
+  async _load() {
+    try {
+      await mkdir(this.dataDir, { recursive: true });
+      const raw = await readFile(this.filePath, 'utf-8');
+      const data = JSON.parse(raw);
+      if (Array.isArray(data.events)) {
+        this.events = data.events;
+      }
+    } catch {
+      // 文件不存在，从空开始
+    }
+  }
+
+  async _save() {
+    try {
+      await mkdir(this.dataDir, { recursive: true });
+      const data = {
+        version: 1,
+        updatedAt: new Date().toISOString(),
+        eventCount: this.events.length,
+        events: this.events,
+      };
+      const tmpPath = this.filePath + '.tmp';
+      await writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+      await rename(tmpPath, this.filePath);
+      this._dirty = false;
+    } catch (err) {
+      console.error('[EventLog] save error:', err.message);
+    }
+  }
+}
+
+export default EventLog;

--- a/services/state-manager/lib/memory-engine.js
+++ b/services/state-manager/lib/memory-engine.js
@@ -1,0 +1,367 @@
+/**
+ * 记忆引擎（MemoryEngine）— Remember/Recall/Forget 核心逻辑
+ *
+ * 职责：
+ * - 前缀拼接（tenant:user:type:key）
+ * - 去重检查（dedup_window 内同 key 同值跳过）
+ * - 容量管理（超限触发 LRU/oldest 淘汰）
+ * - 置信度保护（high confidence + 永不过期 → 不被淘汰）
+ */
+
+import { resolve as resolveType, listTypes } from './type-registry.js';
+
+/**
+ * 操作日志（审计/调试用），保留最近 MAX_LOG_SIZE 条
+ */
+const MAX_LOG_SIZE = 500;
+
+export class MemoryEngine {
+  /**
+   * @param {import('./memory-index.js').MemoryIndex} index
+   * @param {import('./storage-adapter.js').StorageAdapter} storage
+   * @param {import('./ttl-manager.js').TTLManager} ttlManager
+   * @param {object} config - { tenant, userId }
+   */
+  constructor(index, storage, ttlManager, config = {}) {
+    this.index = index;
+    this.storage = storage;
+    this.ttlManager = ttlManager;
+    this.tenant = config.tenant || 'default';
+    this.userId = config.userId || 'shared';
+
+    // 操作日志（ring buffer）
+    this._opLog = [];
+    // 累计统计
+    this._stats = {
+      rememberCalls: 0,
+      recallCalls: 0,
+      forgetCalls: 0,
+      rememberErrors: 0,
+      recallErrors: 0,
+      forgetErrors: 0,
+      totalEvictions: 0,
+      totalDedups: 0,
+    };
+  }
+
+  /**
+   * 记录操作日志
+   */
+  _log(op, detail) {
+    this._opLog.push({ op, detail, ts: new Date().toISOString() });
+    if (this._opLog.length > MAX_LOG_SIZE) {
+      this._opLog.splice(0, this._opLog.length - MAX_LOG_SIZE);
+    }
+  }
+
+  /**
+   * 获取引擎运行统计
+   */
+  getStats() {
+    const indexStats = this.index.getStats();
+    return {
+      ...this._stats,
+      ...indexStats,
+      tenant: this.tenant,
+      userId: this.userId,
+      recentOps: this._opLog.slice(-20),
+    };
+  }
+
+  /**
+   * 拼接完整 key：{tenant}:{user}:{type}:{key}
+   */
+  _fullKey(type, key) {
+    return `${this.tenant}:${this.userId}:${type}:${key}`;
+  }
+
+  /**
+   * 从 user-config 加载 tenant 和 userId
+   */
+  async loadIdentity(userConfigPath) {
+    try {
+      const { readFile } = await import('node:fs/promises');
+      const raw = await readFile(userConfigPath, 'utf-8');
+      const config = JSON.parse(raw);
+      this.tenant = config.company_english || config.companyName || 'default';
+      this.userId = config.identity?.user_id || 'shared';
+    } catch {
+      // 配置文件不存在时用默认值
+    }
+  }
+
+  // ─── Remember ───
+
+  /**
+   * 写入一条记忆
+   * @param {object} request - { key, value, type, ttl_seconds, dedup_window_sec, confidence }
+   * @returns {object} { success, unchanged, evicted_count, error }
+   */
+  async remember(request) {
+    try {
+      this._stats.rememberCalls++;
+      const resolved = resolveType(request);
+      const fullKey = this._fullKey(resolved.type, resolved.key);
+      const now = new Date();
+
+      // 去重检查
+      const existing = this.index.get(fullKey);
+      if (existing && resolved.dedupWindowSec > 0) {
+        const createdMs = new Date(existing.createdAt).getTime();
+        const windowMs = resolved.dedupWindowSec * 1000;
+        if (now.getTime() - createdMs < windowMs) {
+          // 去重窗口内：同 key 同值 → 跳过
+          if (existing.value === resolved.value) {
+            this._stats.totalDedups++;
+            this._log('remember', { key: resolved.key, type: resolved.type, result: 'dedup' });
+            return { success: true, unchanged: true, evictedCount: 0, error: '' };
+          }
+          // 同 key 异值 → 更新（不跳过）
+        }
+      }
+
+      // 计算过期时间
+      const expiresAt = resolved.ttlSeconds > 0
+        ? new Date(now.getTime() + resolved.ttlSeconds * 1000).toISOString()
+        : null;
+
+      // 构建记忆条目
+      const entry = {
+        key: fullKey,
+        _originalKey: resolved.key,
+        value: resolved.value,
+        type: resolved.type,
+        confidence: resolved.confidence,
+        createdAt: existing ? existing.createdAt : now.toISOString(),
+        updatedAt: now.toISOString(),
+        expiresAt,
+        lastAccessAt: now.toISOString(),
+        accessCount: (existing?.accessCount || 0) + 1,
+        protected: resolved.protected,
+      };
+
+      // 容量检查 + 淘汰
+      let evictedCount = 0;
+      const currentCount = this.index.getTypeCount(resolved.type);
+      const maxEntries = resolved.maxEntries;
+      if (!existing && currentCount >= maxEntries) {
+        evictedCount = await this._evict(resolved.type, resolved.evictPolicy, currentCount - maxEntries + 1);
+        this._stats.totalEvictions += evictedCount;
+      }
+
+      // 写入索引
+      this.index.set(fullKey, entry);
+
+      // 持久化
+      await this._persistType(resolved.type);
+
+      this._log('remember', { key: resolved.key, type: resolved.type, result: existing ? 'updated' : 'created', evicted: evictedCount });
+      return { success: true, unchanged: false, evictedCount, error: '' };
+    } catch (err) {
+      this._stats.rememberErrors++;
+      this._log('remember', { key: request.key, type: request.type, result: 'error', error: err.message });
+      return { success: false, unchanged: false, evictedCount: 0, error: err.message };
+    }
+  }
+
+  // ─── Recall ───
+
+  /**
+   * 读取记忆
+   * @param {object} request - { key, prefix, type, limit }
+   * @returns {object} { success, entries, error }
+   */
+  async recall(request) {
+    try {
+      this._stats.recallCalls++;
+      const limit = request.limit || 10;
+      let results = [];
+
+      if (request.key) {
+        // 精确匹配
+        const type = request.type || 'entity_cache';
+        const fullKey = this._fullKey(type, request.key);
+
+        let entry = this.index.get(fullKey);
+
+        // 如果精确 key 找不到，遍历所有已注册类型查找
+        if (!entry) {
+          for (const t of listTypes()) {
+            const tryKey = this._fullKey(t.type, request.key);
+            entry = this.index.get(tryKey);
+            if (entry) break;
+          }
+        }
+
+        if (entry) {
+          // TTL lazy check
+          if (this.ttlManager.checkAndExpire(entry.key)) {
+            await this._persistType(entry.type);
+            results = [];
+          } else {
+            // 更新访问信息
+            entry.lastAccessAt = new Date().toISOString();
+            entry.accessCount = (entry.accessCount || 0) + 1;
+            this.index.set(entry.key, entry);
+
+            results = [{
+              key: entry._originalKey || request.key,
+              value: entry.value,
+              type: entry.type,
+              confidence: entry.confidence,
+              createdAt: entry.createdAt,
+              expiresAt: entry.expiresAt || '',
+            }];
+          }
+        }
+      } else if (request.prefix) {
+        // 前缀匹配
+        const type = request.type || '';
+        const prefix = type
+          ? this._fullKey(type, request.prefix)
+          : `${this.tenant}:${this.userId}:${request.prefix}`;
+
+        const matches = this.index.getByPrefix(prefix.endsWith(':') ? prefix : prefix + ':', {
+          type: request.type || null,
+          limit,
+        });
+
+        // 也尝试不含尾冒号的前缀
+        if (matches.length === 0) {
+          const altMatches = this.index.getByPrefix(prefix, {
+            type: request.type || null,
+            limit,
+          });
+          results = altMatches.map(e => ({
+            key: e._originalKey || e.key,
+            value: e.value,
+            type: e.type,
+            confidence: e.confidence,
+            createdAt: e.createdAt,
+            expiresAt: e.expiresAt || '',
+          }));
+        } else {
+          results = matches.map(e => ({
+            key: e._originalKey || e.key,
+            value: e.value,
+            type: e.type,
+            confidence: e.confidence,
+            createdAt: e.createdAt,
+            expiresAt: e.expiresAt || '',
+          }));
+        }
+
+        // 更新访问信息
+        for (const r of results) {
+          for (const [k, v] of this.index.entries) {
+            if (v._originalKey === r.key && v.type === r.type) {
+              v.lastAccessAt = new Date().toISOString();
+              v.accessCount = (v.accessCount || 0) + 1;
+              break;
+            }
+          }
+        }
+      }
+
+      this._log('recall', { key: request.key || request.prefix, type: request.type, results: results.length });
+      return { success: true, entries: results, error: '' };
+    } catch (err) {
+      this._stats.recallErrors++;
+      this._log('recall', { key: request.key || request.prefix, result: 'error', error: err.message });
+      return { success: false, entries: [], error: err.message };
+    }
+  }
+
+  // ─── Forget ───
+
+  /**
+   * 删除记忆
+   * @param {object} request - { key, prefix, type }
+   * @returns {object} { success, deleted_count, error }
+   */
+  async forget(request) {
+    try {
+      this._stats.forgetCalls++;
+      let deletedCount = 0;
+      const dirtyTypes = new Set();
+
+      if (request.key) {
+        // 精确删除
+        const type = request.type || 'entity_cache';
+        const fullKey = this._fullKey(type, request.key);
+        const entry = this.index.delete(fullKey);
+        if (entry) {
+          deletedCount = 1;
+          dirtyTypes.add(entry.type);
+        }
+      } else if (request.prefix) {
+        // 前缀批量删除
+        const type = request.type || '';
+        const prefix = type
+          ? this._fullKey(type, request.prefix)
+          : `${this.tenant}:${this.userId}:${request.prefix}`;
+
+        const matches = this.index.getByPrefix(prefix.endsWith(':') ? prefix : prefix + ':', {
+          type: request.type || null,
+          limit: 100000,
+        });
+
+        for (const match of matches) {
+          const fullKey = match._fullKey || match.key;
+          const entry = this.index.delete(fullKey);
+          if (entry) {
+            deletedCount++;
+            dirtyTypes.add(entry.type);
+          }
+        }
+      }
+
+      // 持久化受影响的 type
+      for (const type of dirtyTypes) {
+        await this._persistType(type);
+      }
+
+      this._log('forget', { key: request.key || request.prefix, type: request.type, deleted: deletedCount });
+      return { success: true, deletedCount, error: '' };
+    } catch (err) {
+      this._stats.forgetErrors++;
+      this._log('forget', { key: request.key || request.prefix, result: 'error', error: err.message });
+      return { success: false, deletedCount: 0, error: err.message };
+    }
+  }
+
+  // ─── 内部方法 ───
+
+  /**
+   * 淘汰指定类型的条目
+   * @param {string} type
+   * @param {string} policy - 'lru' | 'oldest' | 'compress'
+   * @param {number} count - 要淘汰的条目数
+   * @returns {number} 实际淘汰的条目数
+   */
+  async _evict(type, policy, count) {
+    const candidates = this.index.getCandidatesForEviction(type, policy, count);
+    let evicted = 0;
+
+    for (const key of candidates) {
+      const entry = this.index.delete(key);
+      if (entry) evicted++;
+    }
+
+    if (evicted > 0) {
+      await this._persistType(type);
+    }
+
+    return evicted;
+  }
+
+  /**
+   * 持久化指定类型到文件（O(1) 通过 per-type 索引）
+   */
+  async _persistType(type) {
+    const entries = this.index.getEntriesByType(type);
+    await this.storage.saveType(type, entries);
+  }
+}
+
+export default MemoryEngine;

--- a/services/state-manager/lib/memory-index.js
+++ b/services/state-manager/lib/memory-index.js
@@ -1,0 +1,347 @@
+/**
+ * 记忆索引（MemoryIndex）— 内存前缀索引 + TTL 过期表 + 容量计数器
+ *
+ * 前缀索引：按 key 的 `:` 分割段构建嵌套 Map，支持 O(k) 前缀查询
+ * TTL 过期表：按过期时间排序的数组，Active Sweep 只扫描即将过期的条目
+ * 容量计数器：per-type 计数，超限触发 LRU 淘汰
+ */
+
+export class MemoryIndex {
+  constructor() {
+    // 前缀索引：嵌套 Map
+    // "acme:user1:entity_cache:crm_user:self" →
+    //   trie.acme.user1.entity_cache.crm_user.self = entry
+    this.trie = new Map();
+
+    // 全量 key → entry 的扁平 Map（用于精确查找）
+    this.entries = new Map();
+
+    // per-type entries Map（避免 _persistType 全量遍历）
+    // type → Map<fullKey, entry>
+    this.entriesByType = new Map();
+
+    // TTL 过期表：{ expiresAt, key } 按时间排序
+    this.ttlIndex = [];
+
+    // per-type 容量计数
+    this.typeCounts = new Map();
+
+    // 是否需要重排 TTL 过期表
+    this._ttlSorted = true;
+  }
+
+  /**
+   * 插入或更新一条记忆
+   */
+  set(fullKey, entry) {
+    const old = this.entries.get(fullKey);
+
+    // 更新扁平 Map
+    this.entries.set(fullKey, entry);
+
+    // 更新 per-type Map
+    const type = entry.type;
+    if (!this.entriesByType.has(type)) {
+      this.entriesByType.set(type, new Map());
+    }
+    this.entriesByType.get(type).set(fullKey, entry);
+
+    // 更新前缀索引
+    this._insertTrie(fullKey, entry);
+
+    // 更新 TTL 过期表
+    if (old && old.expiresAt) {
+      // 移除旧的 TTL 记录
+      this.ttlIndex = this.ttlIndex.filter(t => t.key !== fullKey);
+    }
+    if (entry.expiresAt) {
+      this.ttlIndex.push({ expiresAt: entry.expiresAt, key: fullKey });
+      this._ttlSorted = false;
+    }
+
+    // 更新容量计数
+    if (!old) {
+      this.typeCounts.set(type, (this.typeCounts.get(type) || 0) + 1);
+    }
+  }
+
+  /**
+   * 精确查找
+   */
+  get(fullKey) {
+    return this.entries.get(fullKey) || null;
+  }
+
+  /**
+   * 前缀查找
+   * @param {string} prefix - 如 "acme:user1:entity_cache:"
+   * @param {object} opts - { type, limit }
+   * @returns {object[]} 匹配的 entry 列表，按 createdAt 倒序
+   */
+  getByPrefix(prefix, opts = {}) {
+    const segments = prefix.split(':').filter(Boolean);
+    let node = this.trie;
+
+    // 沿前缀段逐层深入
+    for (const seg of segments) {
+      if (!node.has(seg)) return [];
+      node = node.get(seg);
+    }
+
+    // 收集该节点下所有叶子
+    const results = [];
+    this._collectLeaves(node, results);
+
+    // 按 type 过滤
+    let filtered = opts.type
+      ? results.filter(e => e.type === opts.type)
+      : results;
+
+    // 按 confidence 过滤（< 0.3 的不返回）
+    filtered = filtered.filter(e => e.confidence >= 0.3);
+
+    // TTL lazy check：过期的不返回
+    const now = Date.now();
+    filtered = filtered.filter(e => {
+      if (!e.expiresAt) return true;
+      return new Date(e.expiresAt).getTime() > now;
+    });
+
+    // 按 createdAt 倒序
+    filtered.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+
+    // 限制条数
+    if (opts.limit && opts.limit > 0) {
+      filtered = filtered.slice(0, opts.limit);
+    }
+
+    return filtered;
+  }
+
+  /**
+   * 删除一条记忆
+   */
+  delete(fullKey) {
+    const entry = this.entries.get(fullKey);
+    if (!entry) return null;
+
+    // 移除扁平 Map
+    this.entries.delete(fullKey);
+
+    // 移除 per-type Map
+    const typeMap = this.entriesByType.get(entry.type);
+    if (typeMap) typeMap.delete(fullKey);
+
+    // 移除前缀索引
+    this._deleteTrie(fullKey);
+
+    // 移除 TTL 记录
+    this.ttlIndex = this.ttlIndex.filter(t => t.key !== fullKey);
+
+    // 更新容量计数
+    this.typeCounts.set(entry.type, Math.max(0, (this.typeCounts.get(entry.type) || 1) - 1));
+
+    return entry;
+  }
+
+  /**
+   * 批量删除（按前缀 + type）
+   * @returns {number} 删除条数
+   */
+  deleteByPrefix(prefix, type = null) {
+    const matches = this.getByPrefix(prefix, { type, limit: 100000 });
+    let count = 0;
+    for (const entry of matches) {
+      this.delete(entry._fullKey || this._findFullKey(entry));
+      count++;
+    }
+    return count;
+  }
+
+  /**
+   * 获取指定类型的条目数
+   */
+  getTypeCount(type) {
+    return this.typeCounts.get(type) || 0;
+  }
+
+  /**
+   * 获取已过期的条目 key 列表
+   * @param {Date} now - 当前时间
+   * @returns {string[]} 已过期但未被清理的 key
+   */
+  getExpiredKeys(now = new Date()) {
+    this._ensureTtlSorted();
+
+    const nowMs = now.getTime();
+    const expired = [];
+
+    // TTL 过期表按时间排序，二分查找过期分界点
+    for (const item of this.ttlIndex) {
+      if (new Date(item.expiresAt).getTime() <= nowMs) {
+        const entry = this.entries.get(item.key);
+        // 跳过 protected 条目
+        if (entry && !entry.protected) {
+          expired.push(item.key);
+        }
+      } else {
+        break; // 排序了，后面的都不会过期
+      }
+    }
+
+    return expired;
+  }
+
+  /**
+   * 获取指定类型中最旧/最久未访问的条目（LRU/oldest 淘汰用）
+   * @param {string} type
+   * @param {string} policy - 'lru' | 'oldest' | 'compress'
+   * @param {number} count - 要淘汰的条目数
+   * @returns {string[]} 要淘汰的 key 列表
+   */
+  getCandidatesForEviction(type, policy, count) {
+    const entries = [];
+    for (const [key, entry] of this.entries) {
+      if (entry.type === type && !entry.protected) {
+        entries.push({ key, entry });
+      }
+    }
+
+    if (policy === 'oldest') {
+      entries.sort((a, b) => new Date(a.entry.createdAt) - new Date(b.entry.createdAt));
+    } else if (policy === 'lru') {
+      entries.sort((a, b) => new Date(a.entry.lastAccessAt || a.entry.createdAt) - new Date(b.entry.lastAccessAt || b.entry.createdAt));
+    } else if (policy === 'compress') {
+      // compress：同 key 前缀的只保留最新的
+      // 返回非最新的同 key 条目
+      const seen = new Map();
+      const toEvict = [];
+      entries.sort((a, b) => new Date(b.entry.createdAt) - new Date(a.entry.createdAt));
+      for (const e of entries) {
+        const shortKey = e.entry._originalKey || e.key;
+        if (seen.has(shortKey)) {
+          toEvict.push(e.key);
+        } else {
+          seen.set(shortKey, e.key);
+        }
+      }
+      return toEvict.slice(0, count);
+    }
+
+    return entries.slice(0, count).map(e => e.key);
+  }
+
+  /**
+   * 获取指定类型的所有条目 Map（O(1)，避免全量遍历）
+   * @param {string} type
+   * @returns {Map<string, object>}
+   */
+  getEntriesByType(type) {
+    return this.entriesByType.get(type) || new Map();
+  }
+
+  /**
+   * 获取引擎统计信息
+   */
+  getStats() {
+    const typeStats = {};
+    for (const [type, count] of this.typeCounts) {
+      typeStats[type] = {
+        count,
+        protected: [...(this.entriesByType.get(type) || [])].filter(([, e]) => e.protected).length,
+      };
+    }
+    return {
+      totalEntries: this.entries.size,
+      ttlIndexSize: this.ttlIndex.length,
+      types: typeStats,
+    };
+  }
+
+  /**
+   * 批量重建索引（从 StorageAdapter 加载后调用）
+   */
+  rebuild(allEntries) {
+    this.trie.clear();
+    this.entries.clear();
+    this.entriesByType.clear();
+    this.ttlIndex = [];
+    this.typeCounts.clear();
+    this._ttlSorted = true;
+
+    for (const [type, typeEntries] of allEntries) {
+      for (const [fullKey, entry] of typeEntries) {
+        this.set(fullKey, entry);
+      }
+    }
+  }
+
+  // ─── 内部方法 ───
+
+  _insertTrie(fullKey, entry) {
+    const segments = fullKey.split(':');
+    let node = this.trie;
+    for (const seg of segments) {
+      if (!node.has(seg)) {
+        node.set(seg, new Map());
+      }
+      node = node.get(seg);
+    }
+    // 最深层的 Map 存 entry（用特殊 key）
+    node.set('__entry__', entry);
+  }
+
+  _deleteTrie(fullKey) {
+    const segments = fullKey.split(':');
+    let node = this.trie;
+    const path = [this.trie];
+
+    for (const seg of segments) {
+      if (!node.has(seg)) return;
+      node = node.get(seg);
+      path.push(node);
+    }
+
+    // 删除叶子 entry
+    node.delete('__entry__');
+
+    // 回溯清理空分支（可选优化，MVP 不做）
+  }
+
+  _collectLeaves(node, results) {
+    if (node.has('__entry__')) {
+      const entry = node.get('__entry__');
+      results.push({ ...entry, _fullKey: this._reconstructKey(entry) });
+    }
+    for (const [key, child] of node) {
+      if (key !== '__entry__' && child instanceof Map) {
+        this._collectLeaves(child, results);
+      }
+    }
+  }
+
+  _reconstructKey(entry) {
+    // 从 entry 的 metadata 重建 fullKey
+    // 这是一个简化实现：遍历 entries Map 反查
+    for (const [k, v] of this.entries) {
+      if (v === entry) return k;
+    }
+    return '';
+  }
+
+  _findFullKey(entry) {
+    for (const [k, v] of this.entries) {
+      if (v.createdAt === entry.createdAt && v.type === entry.type) return k;
+    }
+    return '';
+  }
+
+  _ensureTtlSorted() {
+    if (!this._ttlSorted) {
+      this.ttlIndex.sort((a, b) => new Date(a.expiresAt) - new Date(b.expiresAt));
+      this._ttlSorted = true;
+    }
+  }
+}
+
+export default MemoryIndex;

--- a/services/state-manager/lib/storage-adapter.js
+++ b/services/state-manager/lib/storage-adapter.js
@@ -1,0 +1,111 @@
+/**
+ * 存储适配器（StorageAdapter）— JSON file per type 持久化存储
+ *
+ * 每种记忆类型一个 JSON 文件，原子写入（write tmp → rename）。
+ * 文件格式版本化，便于未来迁移。
+ */
+
+import { readFile, writeFile, mkdir, rename, unlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const FILE_VERSION = 1;
+const MEMORY_TYPES = ['entity_cache', 'action_log', 'user_correction', 'commitment', 'session_summary'];
+
+export class StorageAdapter {
+  constructor(dataDir) {
+    this.dataDir = dataDir;
+    // Promise 队列锁：每个 type 一条串行链，避免并发写同一文件
+    this._writeChains = new Map();
+  }
+
+  /**
+   * 获取指定类型的文件路径
+   */
+  _filePath(type) {
+    return join(this.dataDir, `memory_${type}.json`);
+  }
+
+  /**
+   * 读取指定类型的所有条目
+   * @returns {Map<string, object>} key → entry
+   */
+  async loadType(type) {
+    const filePath = this._filePath(type);
+    try {
+      const raw = await readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      if (parsed.version !== FILE_VERSION) {
+        // 未来版本迁移点
+      }
+      return new Map(Object.entries(parsed.entries || {}));
+    } catch {
+      return new Map();
+    }
+  }
+
+  /**
+   * 写入指定类型的所有条目（原子写）
+   * 使用 Promise 链保证同一 type 的写操作串行执行
+   * @param {string} type
+   * @param {Map<string, object>} entries
+   */
+  async saveType(type, entries) {
+    // Promise 链：新写入排在上一次写入之后，天然串行
+    const prev = this._writeChains.get(type) || Promise.resolve();
+    const next = prev.then(async () => {
+      const filePath = this._filePath(type);
+      await mkdir(dirname(filePath), { recursive: true });
+
+      const data = {
+        version: FILE_VERSION,
+        updatedAt: new Date().toISOString(),
+        entryCount: entries.size,
+        entries: Object.fromEntries(entries),
+      };
+
+      // 原子写：先写临时文件，再 rename
+      const tmpPath = filePath + '.tmp';
+      await writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+      await rename(tmpPath, filePath);
+    }).catch(err => {
+      console.error(`[StorageAdapter] saveType(${type}) error:`, err.message);
+    });
+    this._writeChains.set(type, next);
+    return next;
+  }
+
+  /**
+   * 加载所有记忆类型的条目
+   * @returns {Map<string, Map<string, object>>} type → (key → entry)
+   */
+  async loadAll() {
+    const result = new Map();
+    for (const type of MEMORY_TYPES) {
+      result.set(type, await this.loadType(type));
+    }
+    return result;
+  }
+
+  /**
+   * 等待所有进行中的写操作完成（优雅停机用）
+   */
+  async waitForPendingWrites() {
+    const pending = [...this._writeChains.values()];
+    await Promise.allSettled(pending);
+  }
+
+  /**
+   * 删除指定类型的存储文件（用于测试或重置）
+   */
+  async deleteType(type) {
+    const filePath = this._filePath(type);
+    try {
+      await unlink(filePath);
+    } catch {
+      // 文件不存在，忽略
+    }
+  }
+}
+
+export default StorageAdapter;

--- a/services/state-manager/lib/task-machine.js
+++ b/services/state-manager/lib/task-machine.js
@@ -1,0 +1,416 @@
+/**
+ * TaskMachine — Task State Machine
+ *
+ * Manages the lifecycle of multi-step tasks:
+ *   pending → running → done / failed / cancelled / timed_out
+ *
+ * Core value: lets agents track "which step a long task has reached",
+ * instead of relying on LLM memory to chain multi-step flows.
+ *
+ * Persistence: task_state.json (atomic write)
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+// Valid state transitions
+const VALID_TRANSITIONS = {
+  pending:    ['running', 'cancelled'],
+  running:    ['done', 'failed', 'cancelled', 'timed_out', 'pending'],
+  done:       [],           // terminal state
+  failed:     ['pending'],  // can retry
+  cancelled:  ['pending'],  // can restore
+  timed_out:  ['pending', 'running'],  // can retry or continue
+};
+
+const VALID_STATES = Object.keys(VALID_TRANSITIONS);
+
+export class TaskMachine {
+  /**
+   * @param {string} dataDir - Data directory
+   * @param {object} opts
+   * @param {number} opts.checkIntervalMs - Timeout check interval (default 60000ms)
+   */
+  constructor(dataDir, opts = {}) {
+    this.filePath = `${dataDir}/task_state.json`;
+    this.tasks = new Map();           // taskId → task
+    this.checkIntervalMs = opts.checkIntervalMs || 60000;
+    this._timer = null;
+    this._dirty = false;
+
+    // Statistics
+    this._stats = {
+      totalCreated: 0,
+      totalCompleted: 0,
+      totalFailed: 0,
+      totalTimedOut: 0,
+    };
+  }
+
+  // ─── Lifecycle ───
+
+  async initialize() {
+    await this._load();
+    this.startTimeoutChecker();
+    console.log(`[TaskMachine] initialized: ${this.tasks.size} tasks loaded`);
+  }
+
+  startTimeoutChecker() {
+    if (this._timer) return;
+    this._timer = setInterval(() => this._checkTimeouts(), this.checkIntervalMs);
+    if (this._timer.unref) this._timer.unref();
+  }
+
+  stop() {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  async shutdown() {
+    this.stop();
+    if (this._dirty) await this._save();
+  }
+
+  // ─── Create Task ───
+
+  /**
+   * @param {object} request
+   * @param {string} request.task_id - Task ID (optional, auto-generated)
+   * @param {string} request.name - Task name
+   * @param {string} request.description - Task description
+   * @param {string} request.assignee - Assignee
+   * @param {string} request.due_date - Due date ISO 8601
+   * @param {string[]} request.steps - Initial step list
+   * @param {string} request.priority - high / medium / low
+   * @param {object} request.metadata - Additional data
+   * @returns {object} { success, task_id, error }
+   */
+  async createTask(request) {
+    try {
+      const taskId = request.task_id || `task_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+      if (this.tasks.has(taskId)) {
+        return { success: false, task_id: taskId, error: `Task "${taskId}" already exists` };
+      }
+
+      const now = new Date().toISOString();
+      const task = {
+        task_id: taskId,
+        name: request.name || '',
+        description: request.description || '',
+        assignee: request.assignee || '',
+        state: 'pending',
+        priority: request.priority || 'medium',
+        due_date: request.due_date || null,
+        steps: (request.steps || []).map((s, i) => ({
+          step_id: `step_${i}`,
+          name: typeof s === 'string' ? s : s.name,
+          state: 'pending',
+          completed_at: null,
+          notes: typeof s === 'string' ? '' : (s.notes || ''),
+        })),
+        current_step: null,
+        metadata: request.metadata || {},
+        created_at: now,
+        updated_at: now,
+        state_history: [{ state: 'pending', at: now, reason: 'created' }],
+      };
+
+      this.tasks.set(taskId, task);
+      this._stats.totalCreated++;
+      this._dirty = true;
+      await this._save();
+
+      return { success: true, task_id: taskId, error: '' };
+    } catch (err) {
+      return { success: false, task_id: '', error: err.message };
+    }
+  }
+
+  // ─── Update Task State ───
+
+  /**
+   * @param {object} request
+   * @param {string} request.task_id
+   * @param {string} request.new_state
+   * @param {string} request.reason - Reason for state change
+   * @returns {object} { success, old_state, new_state, error }
+   */
+  async updateTask(request) {
+    try {
+      const task = this.tasks.get(request.task_id);
+      if (!task) {
+        return { success: false, old_state: '', new_state: '', error: `Task "${request.task_id}" not found` };
+      }
+
+      const oldState = task.state;
+      const newState = request.new_state;
+
+      // Validate state transition
+      if (!VALID_STATES.includes(newState)) {
+        return { success: false, old_state: oldState, new_state: '', error: `Invalid state "${newState}"` };
+      }
+
+      const allowed = VALID_TRANSITIONS[oldState] || [];
+      if (!allowed.includes(newState)) {
+        return {
+          success: false,
+          old_state: oldState,
+          new_state: '',
+          error: `Transition from "${oldState}" to "${newState}" not allowed, allowed: ${allowed.join(', ')}`,
+        };
+      }
+
+      const now = new Date().toISOString();
+      task.state = newState;
+      task.updated_at = now;
+      task.state_history.push({ state: newState, at: now, reason: request.reason || '' });
+
+      // Terminal state statistics
+      if (newState === 'done') this._stats.totalCompleted++;
+      if (newState === 'failed') this._stats.totalFailed++;
+      if (newState === 'timed_out') this._stats.totalTimedOut++;
+
+      this._dirty = true;
+      await this._save();
+
+      return { success: true, old_state: oldState, new_state: newState, error: '' };
+    } catch (err) {
+      return { success: false, old_state: '', new_state: '', error: err.message };
+    }
+  }
+
+  // ─── Add/Update Step ───
+
+  /**
+   * @param {object} request
+   * @param {string} request.task_id
+   * @param {string} request.step_id - Step ID (optional when adding new)
+   * @param {string} request.name - Step name
+   * @param {string} request.state - pending / running / done / skipped
+   * @param {string} request.notes - Notes
+   * @returns {object} { success, step_id, error }
+   */
+  async updateStep(request) {
+    try {
+      const task = this.tasks.get(request.task_id);
+      if (!task) {
+        return { success: false, step_id: '', error: `Task "${request.task_id}" not found` };
+      }
+
+      let step = null;
+      if (request.step_id) {
+        step = task.steps.find(s => s.step_id === request.step_id);
+      }
+
+      const now = new Date().toISOString();
+
+      if (step) {
+        // Update existing step
+        if (request.state) step.state = request.state;
+        if (request.notes) step.notes = request.notes;
+        if (request.name) step.name = request.name;
+        if (request.state === 'done') step.completed_at = now;
+
+        // Auto-advance current_step
+        if (request.state === 'done') {
+          const nextPending = task.steps.find(s => s.state === 'pending');
+          task.current_step = nextPending ? nextPending.step_id : null;
+        }
+      } else {
+        // Add new step
+        const stepId = request.step_id || `step_${task.steps.length}`;
+        step = {
+          step_id: stepId,
+          name: request.name || '',
+          state: request.state || 'pending',
+          completed_at: request.state === 'done' ? now : null,
+          notes: request.notes || '',
+        };
+        task.steps.push(step);
+      }
+
+      task.updated_at = now;
+      this._dirty = true;
+      await this._save();
+
+      return { success: true, step_id: step.step_id, error: '' };
+    } catch (err) {
+      return { success: false, step_id: '', error: err.message };
+    }
+  }
+
+  // ─── Query Tasks ───
+
+  /**
+   * @param {string} taskId
+   * @returns {object} { success, task, error }
+   */
+  getTask(taskId) {
+    const task = this.tasks.get(taskId);
+    if (!task) {
+      return { success: false, task: null, error: `Task "${taskId}" not found` };
+    }
+    return { success: true, task: this._formatTask(task), error: '' };
+  }
+
+  /**
+   * @param {object} filter - { state, assignee, priority, due_before, due_after, limit }
+   * @returns {object} { success, tasks, total, error }
+   */
+  listTasks(filter = {}) {
+    let results = [...this.tasks.values()];
+
+    if (filter.state) {
+      const states = filter.state.split(',');
+      results = results.filter(t => states.includes(t.state));
+    }
+    if (filter.assignee) {
+      results = results.filter(t => t.assignee === filter.assignee);
+    }
+    if (filter.priority) {
+      results = results.filter(t => t.priority === filter.priority);
+    }
+    if (filter.due_before) {
+      const before = new Date(filter.due_before);
+      results = results.filter(t => t.due_date && new Date(t.due_date) <= before);
+    }
+    if (filter.due_after) {
+      const after = new Date(filter.due_after);
+      results = results.filter(t => t.due_date && new Date(t.due_date) >= after);
+    }
+
+    // Sort by priority + creation time
+    const priorityOrder = { high: 0, medium: 1, low: 2 };
+    results.sort((a, b) => {
+      const pa = priorityOrder[a.priority] ?? 1;
+      const pb = priorityOrder[b.priority] ?? 1;
+      if (pa !== pb) return pa - pb;
+      return new Date(b.created_at) - new Date(a.created_at);
+    });
+
+    const total = results.length;
+    const limit = filter.limit || 50;
+    results = results.slice(0, limit);
+
+    return {
+      success: true,
+      tasks: results.map(t => this._formatTask(t)),
+      total,
+      error: '',
+    };
+  }
+
+  /**
+   * Get task state machine statistics
+   */
+  getStats() {
+    const stateCounts = {};
+    for (const state of VALID_STATES) {
+      stateCounts[state] = 0;
+    }
+    for (const task of this.tasks.values()) {
+      stateCounts[task.state] = (stateCounts[task.state] || 0) + 1;
+    }
+
+    return {
+      totalTasks: this.tasks.size,
+      stateCounts,
+      ...this._stats,
+    };
+  }
+
+  // ─── Timeout Detection ───
+
+  async _checkTimeouts() {
+    const now = new Date();
+    let changed = false;
+
+    for (const [taskId, task] of this.tasks) {
+      // Only check pending and running tasks
+      if (task.state !== 'pending' && task.state !== 'running') continue;
+      if (!task.due_date) continue;
+
+      const due = new Date(task.due_date);
+      if (now > due) {
+        // Timed out
+        task.state = 'timed_out';
+        task.updated_at = now.toISOString();
+        task.state_history.push({
+          state: 'timed_out',
+          at: now.toISOString(),
+          reason: `Past due date ${task.due_date}`,
+        });
+        this._stats.totalTimedOut++;
+        changed = true;
+
+        console.log(`[TaskMachine] task "${taskId}" timed out (due: ${task.due_date})`);
+      }
+    }
+
+    if (changed) {
+      this._dirty = true;
+      await this._save();
+    }
+  }
+
+  // ─── Internal Methods ───
+
+  _formatTask(task) {
+    const totalSteps = task.steps.length;
+    const doneSteps = task.steps.filter(s => s.state === 'done').length;
+    return {
+      task_id: task.task_id,
+      name: task.name,
+      description: task.description,
+      assignee: task.assignee,
+      state: task.state,
+      priority: task.priority,
+      due_date: task.due_date || '',
+      current_step: task.current_step || '',
+      steps: task.steps,
+      progress: totalSteps > 0 ? Math.round((doneSteps / totalSteps) * 100) : 0,
+      metadata: task.metadata,
+      created_at: task.created_at,
+      updated_at: task.updated_at,
+      state_history: task.state_history,
+    };
+  }
+
+  async _load() {
+    try {
+      const raw = await readFile(this.filePath, 'utf-8');
+      const data = JSON.parse(raw);
+      if (data.tasks && typeof data.tasks === 'object') {
+        for (const [id, task] of Object.entries(data.tasks)) {
+          this.tasks.set(id, task);
+        }
+      }
+    } catch {
+      // File does not exist, start from empty
+    }
+  }
+
+  async _save() {
+    try {
+      await mkdir(dirname(this.filePath), { recursive: true });
+      const data = {
+        version: 1,
+        updatedAt: new Date().toISOString(),
+        taskCount: this.tasks.size,
+        tasks: Object.fromEntries(this.tasks),
+      };
+      const tmpPath = this.filePath + '.tmp';
+      await writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+      const { rename } = await import('node:fs/promises');
+      await rename(tmpPath, this.filePath);
+      this._dirty = false;
+    } catch (err) {
+      console.error('[TaskMachine] save error:', err.message);
+    }
+  }
+}
+
+export default TaskMachine;

--- a/services/state-manager/lib/ttl-manager.js
+++ b/services/state-manager/lib/ttl-manager.js
@@ -1,0 +1,130 @@
+/**
+ * 过期管理器（TTLManager）— 记忆过期管理
+ *
+ * 双策略（Redis 同款）：
+ * 1. Lazy check：Recall 时检查过期，过期则删除
+ * 2. Active sweep：每 60 秒扫描 TTL 过期表，批量清理
+ *
+ * 参考：https://stackharbor.com/en/knowledge-base/redis-key-expiration-patterns/
+ */
+
+export class TTLManager {
+  /**
+   * @param {import('./memory-index.js').MemoryIndex} index
+   * @param {import('./storage-adapter.js').StorageAdapter} storage
+   * @param {object} opts
+   * @param {number} opts.sweepIntervalMs - 扫描间隔（默认 60000ms）
+   */
+  constructor(index, storage, opts = {}) {
+    this.index = index;
+    this.storage = storage;
+    this.sweepIntervalMs = opts.sweepIntervalMs || 60000;
+    this._timer = null;
+    this._sweeping = false;
+  }
+
+  /**
+   * 启动定时扫描
+   */
+  start() {
+    if (this._timer) return;
+    this._timer = setInterval(() => this._sweep(), this.sweepIntervalMs);
+    // 不阻止进程退出
+    if (this._timer.unref) this._timer.unref();
+  }
+
+  /**
+   * 停止定时扫描
+   */
+  stop() {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  /**
+   * 检查单条记忆是否过期（Lazy check，Recall 时调用）
+   * @returns {boolean} true=已过期并已删除，false=未过期
+   */
+  checkAndExpire(fullKey) {
+    const entry = this.index.get(fullKey);
+    if (!entry) return true; // 不存在视为"过期"
+
+    if (!entry.expiresAt) return false; // 永不过期
+
+    const now = Date.now();
+    const expiresMs = new Date(entry.expiresAt).getTime();
+
+    if (expiresMs <= now) {
+      // 过期了，删除（protected 不删）
+      if (!entry.protected) {
+        this.index.delete(fullKey);
+        // 标记需要持久化
+        this._markDirty(entry.type);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * 主动扫描过期条目（Active sweep）
+   */
+  async _sweep() {
+    if (this._sweeping) return;
+    this._sweeping = true;
+
+    try {
+      const now = new Date();
+      const expiredKeys = this.index.getExpiredKeys(now);
+
+      if (expiredKeys.length === 0) return;
+
+      // 按 type 分组，批量删除后批量持久化
+      const dirtyTypes = new Set();
+
+      for (const key of expiredKeys) {
+        const entry = this.index.get(key);
+        if (entry) {
+          dirtyTypes.add(entry.type);
+        }
+        this.index.delete(key);
+      }
+
+      // 持久化受影响的 type 文件
+      for (const type of dirtyTypes) {
+        await this._persistType(type);
+      }
+
+      // 自适应：如果过期条目占比 > 25%，立即再扫一轮（Redis 同款逻辑）
+      const totalWithTTL = this.index.ttlIndex.length;
+      if (totalWithTTL > 0 && expiredKeys.length / totalWithTTL > 0.25) {
+        setImmediate(() => this._sweep());
+      }
+    } catch (err) {
+      // 扫描失败不影响服务
+      console.error('[TTLManager] sweep error:', err.message);
+    } finally {
+      this._sweeping = false;
+    }
+  }
+
+  /**
+   * 持久化指定类型的所有条目到文件（O(1) 通过 per-type 索引）
+   */
+  async _persistType(type) {
+    const entries = this.index.getEntriesByType(type);
+    await this.storage.saveType(type, entries);
+  }
+
+  _markDirty(type) {
+    // 简易脏标记：下次 sweep 时持久化
+    // 对于 MVP，Recall 触发的删除会在下次 sweep 时持久化
+    // 这意味着最多 60 秒的窗口内，进程崩溃可能导致已删除条目复活
+    // 可接受：下次 Recall 仍会 lazy check
+  }
+}
+
+export default TTLManager;

--- a/services/state-manager/lib/type-registry.js
+++ b/services/state-manager/lib/type-registry.js
@@ -1,0 +1,113 @@
+/**
+ * TypeRegistry — Default parameter configuration for five memory types
+ *
+ * Each memory type has different TTL, dedup window, confidence, capacity limit,
+ * and eviction policy. Remember calls use defaults from this registry when
+ * parameters are unspecified. To add a new memory type, simply add an entry
+ * here — no code changes needed.
+ */
+
+const SECONDS = {
+  MINUTE: 60,
+  HOUR: 3600,
+  DAY: 86400,
+  WEEK: 7 * 86400,
+  MONTH: 30 * 86400,
+};
+
+const TYPE_REGISTRY = {
+  entity_cache: {
+    defaultTTL: SECONDS.WEEK,
+    dedupWindow: 0,
+    defaultConfidence: 1.0,
+    maxEntries: 200,
+    evictPolicy: 'lru',
+    description: 'Query result cache (CRM IDs, project details, etc. — expensive query results)',
+    label: 'Entity Cache',
+  },
+  action_log: {
+    defaultTTL: SECONDS.WEEK,
+    dedupWindow: SECONDS.DAY,
+    defaultConfidence: 1.0,
+    maxEntries: 1000,
+    evictPolicy: 'oldest',
+    description: 'Action log (todo creation, kanban writes, etc. — write operation records for idempotent dedup)',
+    label: 'Action Log',
+  },
+  user_correction: {
+    defaultTTL: 0,
+    dedupWindow: 0,
+    defaultConfidence: 0.9,
+    maxEntries: 100,
+    evictPolicy: 'compress',
+    description: 'User correction (user-initiated fixes to agent behavior — highest-value memory)',
+    label: 'User Correction',
+  },
+  commitment: {
+    defaultTTL: SECONDS.MONTH,
+    dedupWindow: 0,
+    defaultConfidence: 1.0,
+    maxEntries: 100,
+    evictPolicy: 'lru',
+    description: 'Commitment (future tasks the user mentioned they will do)',
+    label: 'Commitment',
+  },
+  session_summary: {
+    defaultTTL: SECONDS.MONTH,
+    dedupWindow: 0,
+    defaultConfidence: 1.0,
+    maxEntries: 50,
+    evictPolicy: 'oldest',
+    description: 'Session summary (key decisions and pending items at the end of each session)',
+    label: 'Session Summary',
+  },
+};
+
+/**
+ * Resolve Remember request parameters, filling in defaults
+ * @param {object} request - { key, value, type, ttl_seconds, dedup_window_sec, confidence }
+ * @returns {object} resolved - complete parameters with defaults filled in
+ */
+export function resolve(request) {
+  const type = request.type || 'entity_cache';
+  const registry = TYPE_REGISTRY[type];
+
+  if (!registry) {
+    throw new Error(`Unknown memory type "${type}", available types: ${Object.keys(TYPE_REGISTRY).join(', ')}`);
+  }
+
+  const ttlSeconds = request.ttl_seconds === -1
+    ? 0  // -1 means never expire
+    : (request.ttl_seconds || registry.defaultTTL);
+
+  return {
+    key: request.key,
+    value: request.value,
+    type,
+    ttlSeconds,
+    dedupWindowSec: request.dedup_window_sec || registry.dedupWindow,
+    confidence: request.confidence || registry.defaultConfidence,
+    maxEntries: registry.maxEntries,
+    evictPolicy: registry.evictPolicy,
+    protected: (request.confidence || registry.defaultConfidence) >= 0.9 && ttlSeconds === 0,
+  };
+}
+
+/**
+ * Get the registry config for a specific type
+ */
+export function getTypeConfig(type) {
+  return TYPE_REGISTRY[type] || null;
+}
+
+/**
+ * List all available types
+ */
+export function listTypes() {
+  return Object.entries(TYPE_REGISTRY).map(([type, config]) => ({
+    type,
+    ...config,
+  }));
+}
+
+export default TYPE_REGISTRY;

--- a/services/state-manager/package.json
+++ b/services/state-manager/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "octobus-state-manager",
+  "displayName": "State Manager",
+  "version": "0.2.0",
+  "description": "Agent State Manager — Memory Engine + Distillation + Task State Machine + Event Log",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "state-manager": "bin/state-service.js"
+  },
+  "dependencies": {
+    "@chaitin-ai/octobus-sdk": "^0.5.0",
+    "js-yaml": "^4.1.0"
+  }
+}

--- a/services/state-manager/proto/state.proto
+++ b/services/state-manager/proto/state.proto
@@ -1,0 +1,582 @@
+syntax = "proto3";
+package state.manager.v1;
+
+// Agent State Manager
+// OctoBus service package: state-manager -> Agent State Manager
+// Provides: project config, weekly buffer, meeting tracking, user config, memory engine, distillation engine, task state machine, event log, general storage
+service StateManagerService {
+  // ====== Project Config ======
+  // Get project config by key
+  rpc GetProject(GetProjectRequest) returns (GetProjectResponse);
+  // List all projects
+  rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse);
+  // Match project by keywords
+  rpc MatchProject(MatchProjectRequest) returns (MatchProjectResponse);
+
+  // ====== Weekly Pending Buffer (migrated to memory engine, internally delegates to Remember/Recall/Forget) ======
+  // Add a pending weekly summary item -> Remember(type=commitment, key=weekly_item:...)
+  rpc AddPendingItem(AddPendingItemRequest) returns (AddPendingItemResponse);
+  // Get all pending sync items -> Recall(prefix=weekly_item:, type=commitment)
+  rpc GetPendingItems(GetPendingItemsRequest) returns (GetPendingItemsResponse);
+  // Clear pending buffer -> Forget(prefix=weekly_item:, type=commitment)
+  rpc ClearPending(ClearPendingRequest) returns (ClearPendingResponse);
+
+  // ====== Meeting Tracking (migrated to memory engine, internally delegates to Remember/Recall/Forget) ======
+  // Register a meeting -> Remember(type=commitment, key=meeting:{eventId})
+  rpc RegisterMeeting(RegisterMeetingRequest) returns (RegisterMeetingResponse);
+  // Get pending meetings -> Recall(prefix=meeting:, type=commitment) + filtering
+  rpc GetPendingMeetings(GetPendingMeetingsRequest) returns (GetPendingMeetingsResponse);
+  // Update meeting state -> Recall + Remember update
+  rpc UpdateMeetingState(UpdateMeetingStateRequest) returns (UpdateMeetingStateResponse);
+
+  // ====== User Config ======
+  // Read user personal config (identity/kanban/CRM/defaults)
+  rpc GetUserConfig(GetUserConfigRequest) returns (GetUserConfigResponse);
+
+  // ====== Agent Memory ======
+  // Write a memory entry
+  rpc Remember(RememberRequest) returns (RememberResponse);
+  // Read memory (exact match or prefix match)
+  rpc Recall(RecallRequest) returns (RecallResponse);
+  // Delete memory
+  rpc Forget(ForgetRequest) returns (ForgetResponse);
+  // Get memory engine runtime statistics
+  rpc GetMemoryStats(GetMemoryStatsRequest) returns (GetMemoryStatsResponse);
+
+  // ====== Distillation Engine ======
+  // Manually trigger a full distillation pass
+  rpc Distill(DistillRequest) returns (DistillResponse);
+  // Get distillation statistics
+  rpc GetDistillStats(GetDistillStatsRequest) returns (GetDistillStatsResponse);
+
+  // ====== Task State Machine ======
+  // Create a task
+  rpc CreateTask(CreateTaskRequest) returns (CreateTaskResponse);
+  // Update task state
+  rpc UpdateTask(UpdateTaskRequest) returns (UpdateTaskResponse);
+  // Add/update a step
+  rpc UpdateStep(UpdateStepRequest) returns (UpdateStepResponse);
+  // Get a single task
+  rpc GetTask(GetTaskRequest) returns (GetTaskResponse);
+  // List tasks (with filtering)
+  rpc ListTasks(ListTasksRequest) returns (ListTasksResponse);
+  // Get task statistics
+  rpc GetTaskStats(GetTaskStatsRequest) returns (GetTaskStatsResponse);
+
+  // ====== Event Log ======
+  // Log an event
+  rpc LogEvent(LogEventRequest) returns (LogEventResponse);
+  // Query events
+  rpc QueryEvents(QueryEventsRequest) returns (QueryEventsResponse);
+  // Get event log statistics
+  rpc GetEventStats(GetEventStatsRequest) returns (GetEventStatsResponse);
+
+  // ====== General KV ======
+  rpc GetState(GetStateRequest) returns (GetStateResponse);
+  rpc SetState(SetStateRequest) returns (SetStateResponse);
+}
+
+// ====== Project Config ======
+
+message GetProjectRequest {
+  string key = 1;  // Project key (e.g. yidong_ai_plus)
+}
+
+message ProjectConfig {
+  string key = 1;
+  string name = 2;
+  string node_id = 3;
+  string customer = 4;
+  repeated string keywords = 5;
+  string detail_folder = 6;
+  string background = 7;      // Customer background (pinned info)
+}
+
+message GetProjectResponse {
+  bool success = 1;
+  ProjectConfig project = 2;
+  string error = 3;
+}
+
+message ListProjectsRequest {}
+
+message ListProjectsResponse {
+  bool success = 1;
+  repeated ProjectConfig projects = 2;
+  string error = 3;
+}
+
+message MatchProjectRequest {
+  string text = 1;  // Text to match (e.g. calendar title or note content)
+}
+
+message MatchProjectResponse {
+  bool success = 1;
+  ProjectConfig project = 2;  // Matched project (may be empty)
+  float confidence = 3;       // Match confidence 0-1
+  string error = 4;
+}
+
+// ====== Weekly Pending Buffer ======
+
+message AddPendingItemRequest {
+  string summary = 1;     // One-line summary (max 30 chars)
+  string category = 2;    // Category: Communication / Documentation / Bidding / POC & Others
+  string date = 3;        // Date YYYY-MM-DD
+}
+
+message AddPendingItemResponse {
+  bool success = 1;
+  int32 pending_count = 2;  // Current pending total
+  string error = 3;
+}
+
+message GetPendingItemsRequest {}
+
+message PendingItem {
+  string summary = 1;
+  string category = 2;
+  string date = 3;
+}
+
+message GetPendingItemsResponse {
+  bool success = 1;
+  repeated PendingItem items = 2;
+  string error = 3;
+}
+
+message ClearPendingRequest {}
+
+message ClearPendingResponse {
+  bool success = 1;
+  int32 cleared_count = 2;  // Number of entries cleared
+  string error = 3;
+}
+
+// ====== Meeting Tracking ======
+
+message RegisterMeetingRequest {
+  string event_id = 1;     // Calendar event ID
+  string summary = 2;      // Meeting title
+  string start_time = 3;   // ISO time
+  string end_time = 4;     // ISO time
+  repeated string attendees = 5;
+}
+
+message RegisterMeetingResponse {
+  bool success = 1;
+  bool is_new = 2;         // Whether newly registered (false = already exists)
+  string error = 3;
+}
+
+message GetPendingMeetingsRequest {
+  int32 grace_hours = 1;   // Hours past end time to be considered pending (default 24)
+}
+
+message MeetingInfo {
+  string event_id = 1;
+  string summary = 2;
+  string start_time = 3;
+  string end_time = 4;
+  repeated string attendees = 5;
+  string state = 6;        // registered / notes_submitted / doc_created / reminded
+}
+
+message GetPendingMeetingsResponse {
+  bool success = 1;
+  repeated MeetingInfo meetings = 2;
+  string error = 3;
+}
+
+message UpdateMeetingStateRequest {
+  string event_id = 1;
+  string new_state = 2;    // notes_submitted / doc_created / reminded
+}
+
+message UpdateMeetingStateResponse {
+  bool success = 1;
+  string error = 2;
+}
+
+// ====== User Config ======
+
+message GetUserConfigRequest {}
+
+message KanbanFieldConfig {
+  string start_date = 1;        // field ID for Start Date
+  string end_date = 2;          // field ID for Due Date
+  string task_type = 3;         // field ID for Task Type
+  string task_desc = 4;         // field ID for Task Description
+  string sales = 5;             // field ID for Sales
+  string owner = 6;             // field ID for Owner
+  string notes = 7;             // field ID for Description
+  string customer_l1 = 8;       // field ID for Customer Tier
+  string customer_l2 = 9;       // field ID for Sub-department
+  string status = 10;           // field ID for Status
+  string presale = 11;          // field ID for Pre-sales
+  string crm_link = 12;         // field ID for CRM Project Link
+}
+
+message KanbanOptionConfig {
+  string id = 1;
+  string name = 2;
+}
+
+message KanbanTaskTypeConfig {
+  repeated KanbanOptionConfig communication = 1;   // Communication
+  repeated KanbanOptionConfig documentation = 2;   // Documentation
+  repeated KanbanOptionConfig bidding = 3;          // Bidding
+  repeated KanbanOptionConfig poc = 4;              // POC & Others
+}
+
+message KanbanStatusConfig {
+  repeated KanbanOptionConfig completed = 1;        // Done
+  repeated KanbanOptionConfig in_progress = 2;      // In Progress
+}
+
+message KanbanCustomerConfig {
+  repeated KanbanOptionConfig customers = 1;
+}
+
+message KanbanConfig {
+  string base_id = 1;
+  string table_id = 2;
+  string instance = 3;                             // OctoBus instance name (e.g. "aitable-instance")
+  KanbanFieldConfig fields = 4;
+  KanbanTaskTypeConfig task_types = 5;
+  KanbanStatusConfig statuses = 6;
+  KanbanCustomerConfig customers = 7;
+}
+
+message IdentityConfig {
+  string user_id = 1;              // Login name (e.g. "user01")
+  string display_name = 2;         // Display name (e.g. "Alice")
+  string role = 3;                 // Role (e.g. "Pre-sales")
+  string crm_user_id = 4;          // CRM system user ID (look up via ListUsers on first use)
+  string default_sales_user_id = 5;// Default sales userId (e.g. "sales01")
+  string default_sales_name = 6;   // Default sales name (e.g. "Bob")
+  string team = 7;                 // Team name (e.g. "Enterprise Pre-sales")
+}
+
+message OctoBusInstanceConfig {
+  string aitable = 1;     // e.g. "aitable-instance"
+  string doc = 2;         // e.g. "doc-instance"
+  string calendar = 3;    // e.g. "calendar-instance"
+  string todo = 4;        // e.g. "todo-instance"
+  string message = 5;     // e.g. "message-instance"
+  string crm = 6;         // e.g. "crm-instance"
+  string state = 7;       // e.g. "state-instance"
+}
+
+message UserConfig {
+  IdentityConfig identity = 1;
+  KanbanConfig kanban = 2;
+  OctoBusInstanceConfig instances = 3;
+  string knowledge_file = 4;       // Product knowledge file path (e.g. "/opt/knowledge/company-products.md")
+  string company_name = 5;         // Company name (e.g. "Acme Corp")
+  string company_english = 6;      // Company English name (e.g. "Acme")
+}
+
+message GetUserConfigResponse {
+  bool success = 1;
+  UserConfig config = 2;
+  string error = 3;
+}
+
+// ====== Agent Memory ======
+
+message RememberRequest {
+  string key = 1;                // Memory key (e.g. "crm_user:self")
+  string value = 2;              // JSON string
+  string type = 3;               // entity_cache | action_log | user_correction | commitment | session_summary
+  int32 ttl_seconds = 4;         // 0=use type default, -1=never expire
+  int32 dedup_window_sec = 5;    // 0=use type default
+  double confidence = 6;         // 0=use type default
+}
+
+message RememberResponse {
+  bool success = 1;
+  bool unchanged = 2;            // Dedup hit, not actually written
+  int32 evicted_count = 3;       // Entries evicted due to capacity
+  string error = 4;
+}
+
+message RecallRequest {
+  string key = 1;                // Exact match (mutually exclusive with prefix)
+  string prefix = 2;             // Prefix match
+  string type = 3;               // Filter by type
+  int32 limit = 4;               // Max entries to return, default 10
+}
+
+message MemoryEntry {
+  string key = 1;
+  string value = 2;              // JSON string
+  string type = 3;
+  double confidence = 4;
+  string created_at = 5;         // ISO 8601
+  string expires_at = 6;         // ISO 8601, empty=never expire
+}
+
+message RecallResponse {
+  bool success = 1;
+  repeated MemoryEntry entries = 2;
+  string error = 3;
+}
+
+message ForgetRequest {
+  string key = 1;                // Exact delete (mutually exclusive with prefix)
+  string prefix = 2;             // Batch prefix delete
+  string type = 3;               // Filter by type
+}
+
+message ForgetResponse {
+  bool success = 1;
+  int32 deleted_count = 2;
+  string error = 3;
+}
+
+// ====== General KV ======
+
+message GetStateRequest {
+  string key = 1;
+}
+
+message GetStateResponse {
+  bool success = 1;
+  string value = 2;       // JSON string
+  string error = 3;
+}
+
+message SetStateRequest {
+  string key = 1;
+  string value = 2;       // JSON string
+}
+
+message SetStateResponse {
+  bool success = 1;
+  string error = 2;
+}
+
+// ====== Memory Engine Statistics ======
+
+message GetMemoryStatsRequest {}
+
+message TypeStats {
+  int32 count = 1;
+  int32 protected_count = 2;
+}
+
+message GetMemoryStatsResponse {
+  bool success = 1;
+  int32 total_entries = 2;
+  map<string, TypeStats> type_stats = 3;
+  int64 remember_calls = 4;
+  int64 recall_calls = 5;
+  int64 forget_calls = 6;
+  int64 total_evictions = 7;
+  int64 total_dedups = 8;
+  string tenant = 9;
+  string user_id = 10;
+  string error = 11;
+}
+
+// ====== Distillation Engine ======
+
+message DistillRequest {}
+
+message DistillSummary {
+  int32 compressed = 1;
+  int32 created = 2;
+  int32 deleted = 3;
+  string reason = 4;
+}
+
+message DistillResponse {
+  bool success = 1;
+  DistillSummary action_log = 2;
+  DistillSummary session_summary = 3;
+  int32 corrections_upgraded = 4;
+  int32 corrections_demoted = 5;
+  string error = 6;
+}
+
+message GetDistillStatsRequest {}
+
+message GetDistillStatsResponse {
+  bool success = 1;
+  int32 total_runs = 2;
+  string last_run_at = 3;
+  int64 action_log_compressed = 4;
+  int64 session_summary_compressed = 5;
+  int64 corrections_upgraded = 6;
+  string error = 7;
+}
+
+// ====== Task State Machine ======
+
+message TaskStep {
+  string step_id = 1;
+  string name = 2;
+  string state = 3;          // pending / running / done / skipped
+  string completed_at = 4;
+  string notes = 5;
+}
+
+message StateHistoryEntry {
+  string state = 1;
+  string at = 2;
+  string reason = 3;
+}
+
+message TaskInfo {
+  string task_id = 1;
+  string name = 2;
+  string description = 3;
+  string assignee = 4;
+  string state = 5;
+  string priority = 6;
+  string due_date = 7;
+  string current_step = 8;
+  repeated TaskStep steps = 9;
+  int32 progress = 10;       // 0-100 completion percentage
+  string created_at = 11;
+  string updated_at = 12;
+  repeated StateHistoryEntry state_history = 13;
+}
+
+message CreateTaskRequest {
+  string task_id = 1;         // Optional, auto-generated
+  string name = 2;
+  string description = 3;
+  string assignee = 4;
+  string due_date = 5;        // ISO 8601
+  repeated string steps = 6;
+  string priority = 7;        // high / medium / low
+}
+
+message CreateTaskResponse {
+  bool success = 1;
+  string task_id = 2;
+  string error = 3;
+}
+
+message UpdateTaskRequest {
+  string task_id = 1;
+  string new_state = 2;      // pending / running / done / failed / cancelled / timed_out
+  string reason = 3;
+}
+
+message UpdateTaskResponse {
+  bool success = 1;
+  string old_state = 2;
+  string new_state = 3;
+  string error = 4;
+}
+
+message UpdateStepRequest {
+  string task_id = 1;
+  string step_id = 2;        // Optional, adds new step if omitted
+  string name = 3;
+  string state = 4;          // pending / running / done / skipped
+  string notes = 5;
+}
+
+message UpdateStepResponse {
+  bool success = 1;
+  string step_id = 2;
+  string error = 3;
+}
+
+message GetTaskRequest {
+  string task_id = 1;
+}
+
+message GetTaskResponse {
+  bool success = 1;
+  TaskInfo task = 2;
+  string error = 3;
+}
+
+message ListTasksRequest {
+  string state = 1;          // Comma-separated, e.g. "pending,running"
+  string assignee = 2;
+  string priority = 3;
+  string due_before = 4;     // ISO 8601
+  string due_after = 5;
+  int32 limit = 6;
+}
+
+message ListTasksResponse {
+  bool success = 1;
+  repeated TaskInfo tasks = 2;
+  int32 total = 3;
+  string error = 4;
+}
+
+message GetTaskStatsRequest {}
+
+message GetTaskStatsResponse {
+  bool success = 1;
+  int32 total_tasks = 2;
+  map<string, int32> state_counts = 3;
+  int64 total_created = 4;
+  int64 total_completed = 5;
+  int64 total_failed = 6;
+  int64 total_timed_out = 7;
+  string error = 8;
+}
+
+// ====== Event Log ======
+
+message LogEventRequest {
+  string event_type = 1;     // e.g. agent.remember, loader.triggered
+  string actor = 2;          // Triggered by
+  string description = 3;
+  string data = 4;           // JSON string
+  string level = 5;          // info / warning / error
+}
+
+message LogEventResponse {
+  bool success = 1;
+  string event_id = 2;
+  string error = 3;
+}
+
+message EventInfo {
+  string event_id = 1;
+  string event_type = 2;
+  string actor = 3;
+  string description = 4;
+  string data = 5;           // JSON string
+  string level = 6;
+  string timestamp = 7;
+}
+
+message QueryEventsRequest {
+  string event_type = 1;     // Comma-separated
+  string actor = 2;
+  string level = 3;
+  string since = 4;          // ISO 8601
+  string until = 5;
+  string search = 6;         // Keyword search
+  int32 limit = 7;
+}
+
+message QueryEventsResponse {
+  bool success = 1;
+  repeated EventInfo events = 2;
+  int32 total = 3;
+  string error = 4;
+}
+
+message GetEventStatsRequest {}
+
+message GetEventStatsResponse {
+  bool success = 1;
+  int32 total_events = 2;
+  int64 total_logged = 3;
+  int64 total_rotated = 4;
+  string oldest_event = 5;
+  string newest_event = 6;
+  string error = 7;
+}

--- a/services/state-manager/secret.schema.json
+++ b/services/state-manager/secret.schema.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "properties": {}
+}

--- a/services/state-manager/service.json
+++ b/services/state-manager/service.json
@@ -1,0 +1,12 @@
+{
+  "schema": "chaitin.octobus.service.v1",
+  "name": "state-manager",
+  "displayName": "Agent State Manager",
+  "description": "Persistent memory, cognitive distillation, task tracking, and audit logging for stateless AI agents — Memory Engine, Distillation Engine, Task State Machine, and Event Log.",
+  "proto": {
+    "roots": ["proto"],
+    "files": ["proto/state.proto"]
+  },
+  "configSchema": "config.schema.json",
+  "secretSchema": "secret.schema.json"
+}


### PR DESCRIPTION
## 概述

新增 OctoBus 服务包 `state-manager`，为 AI 智能体提供持久化的状态管理能力。解决了智能体"每次对话从零开始"的核心痛点——有了状态层之后，智能体可以记住过往上下文、追踪任务进度、自动压缩历史信息。

## 核心模块

| 模块 | 功能 | 应用价值 |
|------|------|---------|
| **记忆引擎** (Memory Engine) | Remember/Recall/Forget，支持 TTL 过期和类型化存储 | 智能体可以跨会话记住客户信息、项目背景、用户偏好 |
| **蒸馏引擎** (Distillation Engine) | 自动压缩低优先级/过期记忆，防止无限膨胀 | 长期运行不卡顿，记忆库不会因为对话轮次增多而爆满 |
| **任务状态机** (Task State Machine) | 结构化任务生命周期：pending→running→done/failed | 智能体承诺的待办事项可以被追踪和复查，不会"说了就忘" |
| **事件日志** (Event Log) | 追加式事件记录，支持时间范围查询 | 完整的操作审计轨迹，出问题时可以回溯每一步 |
| **类型注册表** (Type Registry) | 可扩展的记忆类型系统（缓存/日志/用户纠正/待办承诺/会话摘要） | 不同类型有不同 TTL 和蒸馏策略，灵活适配业务场景 |
| **TTL 管理器** (TTL Manager) | 自动过期清理，基于 Redis 风格的时间窗口 | 敏感信息不永久留存，合规友好 |
| **存储适配器** (Storage Adapter) | JSON 文件持久化 + 原子写入 | 零外部依赖，部署简单 |

## RPC 接口（28个方法）

- **项目上下文**：GetProject、ListProjects、MatchProject — 智能体自动识别当前在谈哪个项目
- **会议追踪**：RegisterMeeting、UpdateMeetingState、GetPendingMeetings — 不遗漏任何客户会议
- **任务管理**：CreateTask、UpdateTask、GetTask、ListTasks — 智能体的承诺可追踪
- **事件日志**：LogEvent、QueryEvents — 完整操作审计
- **记忆管理**：Remember、Recall、Forget、Distill、GetMemoryStats — 跨会话记忆
- **状态KV**：GetState、SetState — 通用键值存储
- **周报同步**：AddPendingItem、GetPendingItems、ClearPending — 自动汇总写入周报
- **用户配置**：GetUserConfig — 个人身份和集成设置

## 配置设计

- `config/user-config.example.json`：新用户只需要编辑一个 JSON 文件，填入身份信息、看板字段映射、服务实例名即可
- `config.schema.json`：服务级配置（端口、数据目录）
- `secret.schema.json`：无需密钥（state-manager 是对内服务）

## 设计决策

- **单一用户配置文件**：降低部署门槛，新人只需改一个文件
- **类型化记忆**：每种记忆类型有独立的 TTL 和蒸馏策略，不是一刀切
- **按需蒸馏**：`Distill` RPC 由调用方主动触发，压缩旧记忆的同时保留高优先级条目
- **状态机防抖**：Task 状态转换有合法规则校验，防止非法跳转（如直接从 pending 跳到 done）

## 应用价值

- **智能体不再失忆**：跨会话保留上下文，客户聊到一半断了也不丢信息
- **任务可追踪**：智能体说"我帮你建个待办"之后，这个承诺被记录、可查询、可验证
- **记忆自动瘦身**：蒸馏引擎防止记忆无限膨胀，长期运行成本可控
- **标准化状态层**：6 个智能体共用一套状态管理，不是每个 agent 自己维护状态

## 代码量

- 15 个文件，约 3700 行（bin/ 主逻辑 844 行 + proto 582 行 + 6 个 lib 模块 + 配置文件）

Signed-off-by: jianhua.wang <jianhua.wang@chaitin.com>