### PR TITLE
在 Dockerfile 中增加 GOPROXY 变量，并设置 ARG 允许在编译命令中传参，来设置私有代理

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:26.04 AS builder
 
+ARG GOPROXY=https://proxy.golang.org,direct
 ENV DEBIAN_FRONTEND=noninteractive \
-	GOTOOLCHAIN=auto
+	GOTOOLCHAIN=auto \
+	GOPROXY=${GOPROXY}
 WORKDIR /src
 
 RUN apt-get update \


### PR DESCRIPTION
背景：

在本地或 CI 中编译 Docker 镜像时，默认使用 go mod 官方源，导致编译速度慢容易失败。

解决方法：

在 Dockerfile 中新增 GOPROXY 环境变量，并允许在编译命令中设置参数进行覆盖。

编译命令举例


docker buildx build \
  --platform linux/amd64,linux/arm64 \
  --build-arg GOPROXY=http://goproxy.xxx,direct \
  --push -t octobus:latest -f docker/Dockerfile .