### PR TITLE
feat(admin): add GET /admin/v1/services/:id/schema endpoint

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -118,6 +118,7 @@ func (s *Server) Handler() http.Handler {
 	e.GET("/admin/v1/services/:service_id", s.echoServicePath)
 	e.PATCH("/admin/v1/services/:service_id", s.echoServicePath)
 	e.DELETE("/admin/v1/services/:service_id", s.echoServicePath)
+	e.GET("/admin/v1/services/:service_id/schema", s.echoServiceSchema)
 	e.GET("/admin/v1/instances", s.echoInstances)
 	e.POST("/admin/v1/instances", s.echoInstances)
 	e.GET("/admin/v1/instances/:instance_id", s.echoInstancePath)
@@ -889,6 +890,67 @@ func (s *Server) handleServicePath(w http.ResponseWriter, r *http.Request, servi
 func (s *Server) echoServicePath(c *echo.Context) error {
 	s.handleServicePath(c.Response(), c.Request(), c.Param("service_id"))
 	return nil
+}
+
+func (s *Server) echoServiceSchema(c *echo.Context) error {
+	s.handleServiceSchema(c.Response(), c.Request(), c.Param("service_id"))
+	return nil
+}
+
+// handleServiceSchema returns the JSON Schema documents a service declares for
+// its instance config and secret, so management clients (e.g. fde-admin) can
+// render typed config forms instead of asking users to hand-write JSON. Only the
+// schema documents are returned — never the daemon-side file paths. A null field
+// means the service declared no such schema. Schemas are JSON Schema Draft
+// 2020-12 and carry structure only (no instance secret values).
+func (s *Server) handleServiceSchema(w http.ResponseWriter, r *http.Request, serviceID string) {
+	if serviceID == "" {
+		writeError(w, http.StatusNotFound, "unknown service route")
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	svc, err := s.Store.GetService(r.Context(), serviceID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	configSchema, err := readSchemaContent(svc.ConfigSchemaPath)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	secretSchema, err := readSchemaContent(svc.SecretSchemaPath)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"service_id": serviceID,
+		"config":     configSchema,
+		"secret":     secretSchema,
+	})
+}
+
+// readSchemaContent reads a schema file declared by a service manifest. An empty
+// path means the service declared no such schema and yields nil (serialized as
+// null). The path is daemon-absolute (resolved at import time); only the file
+// content is returned, never the path. The content is validated as JSON so
+// clients never receive a truncated or corrupt schema document.
+func readSchemaContent(path string) (json.RawMessage, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read schema file: %w", err)
+	}
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("schema file is not valid JSON")
+	}
+	return json.RawMessage(data), nil
 }
 
 func (s *Server) restartEnabledServiceInstances(ctx context.Context, serviceID string) ([]string, []string) {

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -78,6 +78,62 @@ func TestStatus(t *testing.T) {
 	}
 }
 
+func TestServiceSchema(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	st, err := store.Open(filepath.Join(dataDir, "octobus.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	// The daemon stores schema paths as daemon-absolute paths at import time, so
+	// write the schema file to the test data dir and reference it absolutely.
+	configSchemaPath := filepath.Join(dataDir, "config.schema.json")
+	const configSchema = `{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","required":["token"],"properties":{"token":{"type":"string","minLength":3},"mode":{"enum":["dev","prod"],"default":"dev"}},"additionalProperties":false}`
+	if err := os.WriteFile(configSchemaPath, []byte(configSchema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Service declares a config schema but no secret schema.
+	if err := st.UpsertService(ctx, domain.Service{
+		ID: "echo", Name: "Echo", PackageSource: "fixture", PackageArtifactPath: "pkg",
+		PackageSHA256: "pkgsha", DescriptorPath: "desc", DescriptorSHA256: "descsha",
+		DescriptorVersion: "descsha", NodeEntry: "echo", ConfigSchemaPath: configSchemaPath,
+		Methods: []domain.Method{{FullName: "echo.v1.EchoService/Echo", Unary: true}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv := &Server{Store: st, Supervisor: supervisor.New(dataDir, st)}
+
+	body := serveAdmin(t, srv, http.MethodGet, "/admin/v1/services/echo/schema", nil, http.StatusOK)
+
+	var resp struct {
+		ServiceID string          `json:"service_id"`
+		Config    json.RawMessage `json:"config"`
+		Secret    json.RawMessage `json:"secret"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal schema response: %v body=%s", err, body)
+	}
+	if resp.ServiceID != "echo" {
+		t.Fatalf("service_id=%q body=%s", resp.ServiceID, body)
+	}
+	if !bytes.Contains(resp.Config, []byte(`"token"`)) || !bytes.Contains(resp.Config, []byte(`"default"`)) {
+		t.Fatalf("config schema content missing expected keys: %s", resp.Config)
+	}
+	// No secret schema declared -> null.
+	if !bytes.Equal(bytes.TrimSpace(resp.Secret), []byte("null")) {
+		t.Fatalf("secret schema should be null: %s", resp.Secret)
+	}
+	// The daemon-side absolute path must never appear in the response body.
+	if bytes.Contains(body, []byte(configSchemaPath)) {
+		t.Fatalf("schema response leaked daemon path: %s", body)
+	}
+
+	// Unknown service -> 404.
+	serveAdmin(t, srv, http.MethodGet, "/admin/v1/services/missing/schema", nil, http.StatusNotFound)
+}
+
 func TestNewHTTPServerSetsTimeouts(t *testing.T) {
 	server := NewHTTPServer("127.0.0.1:0", http.NotFoundHandler())
 	if server.ReadHeaderTimeout != 5*time.Second {


### PR DESCRIPTION
Expose a service's config and secret JSON Schema documents so management clients (the CLI, future UIs) can render typed config forms instead of asking users to hand-write JSON and rely on validation errors.

- GET /admin/v1/services/:id/schema returns {service_id, config, secret}; a null field means the service declared no such schema
- only the schema document content is returned, never the daemon-side path
- schema content is validated as JSON before returning
- consistent with existing "describe-the-structure" endpoints: catalog exposes method input/output types, and the service object already exposes ConfigSchemaPath

OctoBus still only validates config/secret against these schemas; exposing them does not change the pass-through semantics. The secret schema carries structure (type/required/enum) only, never instance secret values.