### PR TITLE
ci: enforce service package L2 pull request gate

### DIFF
--- a/.github/workflows/service-l2-gate.yml
+++ b/.github/workflows/service-l2-gate.yml
@@ -1,0 +1,43 @@
+name: Service L2 gate
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  service-l2-gate:
+    name: service-l2-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Test service gate tooling
+        run: node --test services/tests/service-pr-gate.test.mjs services/tests/validate-service-package.test.mjs
+
+      - name: Run focused L2 service gate
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node services/scripts/service-pr-gate.mjs --base "$BASE_SHA" --head "$HEAD_SHA"

--- a/docs/design/technical/service-l2-batch.md
+++ b/docs/design/technical/service-l2-batch.md
@@ -47,6 +47,6 @@ node scripts/service-l2-batch.mjs --concurrency 3 --publish
 - `--force`：忽略相同 head/gate 的本地结果并重跑。
 - `--keep-worktrees`：保留 PR worktree，用于调试。
 - `--exclude <number>`：额外排除 PR。
-- `--dry-run`：只获取和分类，不执行门禁。
+- `--dry-run`：只获取和分类，不执行门禁，也不读写正式结果缓存。
 
 建议先执行 2–3 个代表性 PR 校准资源和评论格式，再运行全量并发布。测试阶段和发布阶段分开，避免脚本错误向 90+ 个 PR 批量写入错误结果。

--- a/docs/design/technical/service-l2-batch.md
+++ b/docs/design/technical/service-l2-batch.md
@@ -1,0 +1,52 @@
+# Service L2 批量审计
+
+`scripts/service-l2-batch.mjs` 用 PR #494 的门禁版本批量检查已有开放 PR。默认排除 #494，默认只落盘结果；只有显式传入 `--publish` 才会更新 GitHub 评论和标签。
+
+## 隔离、并发和缓存
+
+- 每个 PR 使用 GitHub `pull/<number>/merge` ref，验证的是当前 main 与 PR 的实际合并结果。
+- 每个 PR 使用独立 detached worktree，避免构建产物相互污染。
+- npm 下载使用共享 cache。
+- `services/package.json` 与 lockfile 内容相同的 PR 共用一个只读 `node_modules` 依赖池。依赖池只安装一次，worktree 通过符号链接读取；禁止多个 PR 并发写同一个 `node_modules`。
+- Go 使用共享 `GOMODCACHE` 和 `GOCACHE`，但每个 worktree 独立生成 `bin/octobus`。
+- 默认并发 3。构建和 Node 测试都可能占用较多 CPU/内存，不建议按 PR 数量无限并发。
+
+## 状态
+
+- `l2:passed`：完整门禁通过。
+- `l2:failed`：实际执行门禁失败。
+- `l2:blocked`：Draft、冲突或 GitHub 无 merge ref，未执行。
+- `l2:not-applicable`：不是单 Service 实现 PR。
+
+标签互斥。评论包含隐藏 marker、PR head SHA 和 gate SHA；重复执行会更新原评论，PR head 未变化时复用本地结果。
+
+## 使用
+
+先对少量 PR 执行但不发布：
+
+```bash
+node scripts/service-l2-batch.mjs --pr 483 --pr 488 --concurrency 2
+```
+
+查看并确认 `<state-dir>/summary.json` 后发布：
+
+```bash
+node scripts/service-l2-batch.mjs --pr 483 --pr 488 --publish
+```
+
+全量开放 PR：
+
+```bash
+node scripts/service-l2-batch.mjs --concurrency 3
+node scripts/service-l2-batch.mjs --concurrency 3 --publish
+```
+
+常用选项：
+
+- `--state-dir <path>`：持久化 worktree、cache、日志和结果；长期批处理应使用有足够空间的目录。
+- `--force`：忽略相同 head/gate 的本地结果并重跑。
+- `--keep-worktrees`：保留 PR worktree，用于调试。
+- `--exclude <number>`：额外排除 PR。
+- `--dry-run`：只获取和分类，不执行门禁。
+
+建议先执行 2–3 个代表性 PR 校准资源和评论格式，再运行全量并发布。测试阶段和发布阶段分开，避免脚本错误向 90+ 个 PR 批量写入错误结果。

--- a/docs/design/technical/services-package-quality.md
+++ b/docs/design/technical/services-package-quality.md
@@ -165,7 +165,7 @@ npm test -- --service-dir <service-dir>
 npm test -- --coverage --service-dir <service-dir>
 ```
 
-coverage 模式默认要求 branch、function 和 line 都达到 90%。该门禁用于高风险服务、实质改动服务
+coverage 模式默认要求 branch、function 和 line 都达到 80%。该门禁用于高风险服务、实质改动服务
 和阶段性质量抽样；全量 service package 的基础门禁仍是 validate/test/pack check。
 
 ## Package 内容门禁
@@ -208,7 +208,7 @@ secret 写入 evidence。
 
 修改 `services/` 的 pull request 由 `service-l2-gate` 自动分类。只修改一个 service root 的
 PR 必须通过以下 L2 自动门禁：focused structure validation、该 service 的 Node test、branch /
-function / line 90% coverage、最终 npm pack 内容检查、OctoBus build 和 service smoke。
+function / line 80% coverage、最终 npm pack 内容检查、OctoBus build 和 service smoke。
 
 Service PR 可以同时提交由 registry 生成流程维护的根 `services/package.json`、根 wrapper 和
 dispatcher，但不能混入第二个 service、runtime、SDK、Docker、example 或其他 services

--- a/docs/design/technical/services-package-quality.md
+++ b/docs/design/technical/services-package-quality.md
@@ -165,7 +165,7 @@ npm test -- --service-dir <service-dir>
 npm test -- --coverage --service-dir <service-dir>
 ```
 
-coverage 模式默认要求 branch、function 和 line 都达到 80%。该门禁用于高风险服务、实质改动服务
+coverage 模式默认要求 branch、function 和 line 都达到 90%。PR L2 门禁会显式使用 80%。该门禁用于高风险服务、实质改动服务
 和阶段性质量抽样；全量 service package 的基础门禁仍是 validate/test/pack check。
 
 ## Package 内容门禁

--- a/docs/design/technical/services-package-quality.md
+++ b/docs/design/technical/services-package-quality.md
@@ -204,6 +204,33 @@ secret 写入 evidence。
 
 ## 常用门禁
 
+### Pull request L2 门禁
+
+修改 `services/` 的 pull request 由 `service-l2-gate` 自动分类。只修改一个 service root 的
+PR 必须通过以下 L2 自动门禁：focused structure validation、该 service 的 Node test、branch /
+function / line 90% coverage、最终 npm pack 内容检查、OctoBus build 和 service smoke。
+
+Service PR 可以同时提交由 registry 生成流程维护的根 `services/package.json`、根 wrapper 和
+dispatcher，但不能混入第二个 service、runtime、SDK、Docker、example 或其他 services
+infrastructure 修改。删除 service 和修改共享基础设施需要独立的 infrastructure review。
+
+本门禁把“L2”严格限定为 mock 自动验证：focused test 负责厂商协议成功/失败路径，smoke 负责
+import、instance、catalog、runtime 和 Connect 链路。smoke 不证明真实厂商设备兼容性。真实设备
+型号、版本、验证截图和写操作清理证据仍由 reviewer 在 PR 中人工确认，属于 L3 证据。
+smoke 报告分别输出 `chain_ok` 和 `business_success`；通用 mock 无法为所有厂商构造成功响应，
+因此业务 HTTP 失败可以不阻断链路检查，但会显式显示，不能作为业务成功证据。
+
+本地执行与查看计划：
+
+```bash
+npm --prefix services run pr:gate -- --base origin/main --head HEAD
+npm --prefix services run pr:gate -- --base origin/main --head HEAD --dry-run
+```
+
+仓库启用该工作流后，应在 GitHub branch protection 中把 `service-l2-gate` 设为 required check。
+该 workflow 对所有 PR 产生稳定结果，没有 service 实现变更时快速成功，避免 required check 因
+path filter 永久 pending。Actions workflow 本身不能修改 branch protection。
+
 services package 修改后按风险选择以下门禁：
 
 ```bash

--- a/scripts/service-l2-batch.mjs
+++ b/scripts/service-l2-batch.mjs
@@ -141,6 +141,12 @@ async function execute(command, args, options) {
   });
 }
 
+function preflightGate(worktree) {
+  const result = run("node", ["services/scripts/service-pr-gate.mjs", "--base", "HEAD^1", "--head", "HEAD", "--dry-run", "--skip-install", "--skip-smoke"], { cwd: worktree, allowFailure: true });
+  const output = `${result.stdout || ""}\n${result.stderr || ""}`;
+  return { code: result.status ?? 1, output, noService: output.includes("no service implementation changed") };
+}
+
 function summarizeLog(logPath) {
   const text = fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : "";
   const lines = text.split(/\r?\n/).filter((line) => /^(error:|✖|ℹ Error:|service gate:|service gate L2 candidates:)/.test(line));
@@ -166,6 +172,19 @@ async function auditPR(repoRoot, options, pr, gateSHA) {
   let result;
   try {
     overlayGate(repoRoot, worktree);
+    const preflight = preflightGate(worktree);
+    if (preflight.noService) {
+      result = { number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA,
+        status: "not-applicable", reason: "该 PR 不包含单 Service 实现改动，L2 不适用。",
+        summary: "service gate: no service implementation changed; L2 service checks are not applicable", startedAt };
+      return finish(result, options);
+    }
+    if (preflight.code !== 0) {
+      result = { number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA,
+        status: "failed", reason: "L2 静态范围或包结构预检失败。",
+        summary: preflight.output.split(/\r?\n/).filter((line) => line.startsWith("error:")).slice(-30).join("\n").slice(0, 6000), startedAt };
+      return finish(result, options);
+    }
     const fingerprint = attachDependencyPool(worktree, options, env);
     const code = await execute("node", ["services/scripts/service-pr-gate.mjs", "--base", "HEAD^1", "--head", "HEAD", "--skip-install"], { cwd: worktree, env, logPath });
     const summary = summarizeLog(logPath);

--- a/scripts/service-l2-batch.mjs
+++ b/scripts/service-l2-batch.mjs
@@ -58,6 +58,7 @@ function resultPath(options, number) { return path.join(options.stateDir, "resul
 export function readCached(options, pr, gateSHA) {
   if (options.dryRun || options.force || !fs.existsSync(resultPath(options, pr.number))) return null;
   const cached = JSON.parse(fs.readFileSync(resultPath(options, pr.number), "utf8"));
+  if (cached.status === "blocked") return null;
   return cached.headSHA === pr.headRefOid && cached.gateSHA === gateSHA ? cached : null;
 }
 

--- a/scripts/service-l2-batch.mjs
+++ b/scripts/service-l2-batch.mjs
@@ -53,8 +53,8 @@ function listPRs(options, repoRoot) {
 }
 
 function resultPath(options, number) { return path.join(options.stateDir, "results", `${number}.json`); }
-function readCached(options, pr, gateSHA) {
-  if (options.force || !fs.existsSync(resultPath(options, pr.number))) return null;
+export function readCached(options, pr, gateSHA) {
+  if (options.dryRun || options.force || !fs.existsSync(resultPath(options, pr.number))) return null;
   const cached = JSON.parse(fs.readFileSync(resultPath(options, pr.number), "utf8"));
   return cached.headSHA === pr.headRefOid && cached.gateSHA === gateSHA ? cached : null;
 }
@@ -78,14 +78,14 @@ function prepareWorktree(repoRoot, options, pr, mergeRef) {
   return worktree;
 }
 
-function overlayGate(repoRoot, worktree) {
+export function overlayGate(repoRoot, worktree, gateSHA) {
   for (const file of [
     "services/scripts/service-pr-gate.mjs", "services/scripts/run-tests.mjs",
     "services/scripts/validate-service-package.mjs", "scripts/service-package-smoke.mjs",
   ]) {
-    const source = path.join(repoRoot, file);
-    if (!fs.existsSync(source)) throw new Error(`gate file is missing: ${file}`);
-    const content = fs.readFileSync(source);
+    const shown = git(["show", `${gateSHA}:${file}`], repoRoot, { allowFailure: true });
+    if (shown.status !== 0) throw new Error(`gate file is missing at ${gateSHA}: ${file}`);
+    const content = shown.stdout;
     const target = path.join(worktree, file);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, content);
@@ -137,7 +137,18 @@ async function execute(command, args, options) {
   return await new Promise((resolve) => {
     const output = fs.openSync(options.logPath, "w");
     const child = spawn(command, args, { cwd: options.cwd, env: options.env, stdio: ["ignore", output, output] });
-    child.on("close", (code) => { fs.closeSync(output); resolve(code ?? 1); });
+    let closed = false;
+    const finish = (code) => {
+      if (closed) return;
+      closed = true;
+      fs.closeSync(output);
+      resolve(code);
+    };
+    child.on("error", (error) => {
+      fs.appendFileSync(options.logPath, `error: failed to start ${command}: ${error.message}\n`);
+      finish(1);
+    });
+    child.on("close", (code) => finish(code ?? 1));
   });
 }
 
@@ -160,7 +171,6 @@ async function auditPR(repoRoot, options, pr, gateSHA) {
   if (pr.isDraft) return finish({ number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA, status: "blocked", reason: "PR 当前为 Draft，未执行 L2。", startedAt }, options);
   const mergeRef = fetchMergeRef(repoRoot, options, pr);
   if (!mergeRef) return finish({ number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA, status: "blocked", reason: "GitHub 未生成 merge ref；PR 与当前 main 冲突或暂不可合并。", startedAt }, options);
-  if (options.dryRun) return finish({ number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA, status: "not-applicable", reason: "dry-run：尚未执行。", startedAt }, options);
   const worktree = prepareWorktree(repoRoot, options, pr, mergeRef);
   const logPath = path.join(options.stateDir, "logs", `pr-${pr.number}.log`);
   fs.mkdirSync(path.dirname(logPath), { recursive: true });
@@ -171,8 +181,16 @@ async function auditPR(repoRoot, options, pr, gateSHA) {
   };
   let result;
   try {
-    overlayGate(repoRoot, worktree);
+    overlayGate(repoRoot, worktree, gateSHA);
     const preflight = preflightGate(worktree);
+    if (options.dryRun) {
+      return {
+        number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA,
+        status: preflight.code === 0 ? "not-applicable" : "failed",
+        reason: preflight.code === 0 ? "dry-run：静态范围分类通过，未执行完整 L2。" : "dry-run：静态范围分类失败，未执行完整 L2。",
+        summary: preflight.output.trim().slice(-6000), startedAt, finishedAt: new Date().toISOString(), executed: false,
+      };
+    }
     if (preflight.noService) {
       result = { number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA,
         status: "not-applicable", reason: "该 PR 不包含单 Service 实现改动，L2 不适用。",

--- a/scripts/service-l2-batch.mjs
+++ b/scripts/service-l2-batch.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const LABELS = {
+  passed: { name: "l2:passed", color: "1f883d", description: "Service L2 自动门禁通过" },
+  failed: { name: "l2:failed", color: "d1242f", description: "Service L2 自动门禁未通过" },
+  blocked: { name: "l2:blocked", color: "bf8700", description: "Service L2 检查被 Draft、冲突或基础条件阻塞" },
+  "not-applicable": { name: "l2:not-applicable", color: "6e7781", description: "不适用 Service L2 门禁" },
+};
+const MARKER = "<!-- octobus-service-l2-batch -->";
+
+function parseArgs(argv) {
+  const options = {
+    repo: "chaitin/OctoBus", exclude: new Set([494]), concurrency: 3,
+    publish: false, dryRun: false, keepWorktrees: false, force: false,
+    prNumbers: [], stateDir: path.join(os.tmpdir(), "octobus-service-l2-batch"),
+    gateRef: "origin/ci/service-l2-gate",
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--repo") options.repo = required(argv, ++i, arg);
+    else if (arg === "--gate-ref") options.gateRef = required(argv, ++i, arg);
+    else if (arg === "--state-dir") options.stateDir = path.resolve(required(argv, ++i, arg));
+    else if (arg === "--concurrency") options.concurrency = positiveInteger(required(argv, ++i, arg), arg);
+    else if (arg === "--pr") options.prNumbers.push(positiveInteger(required(argv, ++i, arg), arg));
+    else if (arg === "--exclude") options.exclude.add(positiveInteger(required(argv, ++i, arg), arg));
+    else if (arg === "--publish") options.publish = true;
+    else if (arg === "--dry-run") options.dryRun = true;
+    else if (arg === "--keep-worktrees") options.keepWorktrees = true;
+    else if (arg === "--force") options.force = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function required(argv, index, flag) { if (!argv[index]) throw new Error(`${flag} requires a value`); return argv[index]; }
+function positiveInteger(value, flag) { const n = Number(value); if (!Number.isInteger(n) || n < 1) throw new Error(`${flag} requires a positive integer`); return n; }
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { cwd: options.cwd, env: options.env, encoding: "utf8", stdio: options.stdio ?? "pipe" });
+  if ((result.status ?? 1) !== 0 && !options.allowFailure) throw new Error(`${command} ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+  return result;
+}
+function git(args, cwd, options = {}) { return run("git", args, { cwd, ...options }); }
+function gh(args, cwd, options = {}) { return run("gh", args, { cwd, ...options }); }
+
+function listPRs(options, repoRoot) {
+  if (options.prNumbers.length) return options.prNumbers.map((number) => JSON.parse(gh(["pr", "view", String(number), "-R", options.repo, "--json", "number,title,url,isDraft,headRefOid,mergeable,mergeStateStatus"], repoRoot).stdout));
+  return JSON.parse(gh(["pr", "list", "-R", options.repo, "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefOid,mergeable,mergeStateStatus"], repoRoot).stdout);
+}
+
+function resultPath(options, number) { return path.join(options.stateDir, "results", `${number}.json`); }
+function readCached(options, pr, gateSHA) {
+  if (options.force || !fs.existsSync(resultPath(options, pr.number))) return null;
+  const cached = JSON.parse(fs.readFileSync(resultPath(options, pr.number), "utf8"));
+  return cached.headSHA === pr.headRefOid && cached.gateSHA === gateSHA ? cached : null;
+}
+
+function writeResult(options, result) {
+  fs.mkdirSync(path.dirname(resultPath(options, result.number)), { recursive: true });
+  fs.writeFileSync(resultPath(options, result.number), `${JSON.stringify(result, null, 2)}\n`);
+}
+
+function fetchMergeRef(repoRoot, options, pr) {
+  const ref = `refs/l2-audit/pr-${pr.number}`;
+  const fetched = git(["fetch", "--force", "origin", `pull/${pr.number}/merge:${ref}`], repoRoot, { allowFailure: true });
+  return fetched.status === 0 ? ref : null;
+}
+
+function prepareWorktree(repoRoot, options, pr, mergeRef) {
+  const worktree = path.join(options.stateDir, "worktrees", `pr-${pr.number}`);
+  if (fs.existsSync(worktree)) git(["worktree", "remove", "--force", worktree], repoRoot, { allowFailure: true });
+  fs.mkdirSync(path.dirname(worktree), { recursive: true });
+  git(["worktree", "add", "--detach", worktree, mergeRef], repoRoot);
+  return worktree;
+}
+
+function overlayGate(repoRoot, worktree) {
+  for (const file of [
+    "services/scripts/service-pr-gate.mjs", "services/scripts/run-tests.mjs",
+    "services/scripts/validate-service-package.mjs", "scripts/service-package-smoke.mjs",
+  ]) {
+    const source = path.join(repoRoot, file);
+    if (!fs.existsSync(source)) throw new Error(`gate file is missing: ${file}`);
+    const content = fs.readFileSync(source);
+    const target = path.join(worktree, file);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+  }
+}
+
+function dependencyFingerprint(worktree) {
+  const files = ["services/package.json", "services/package-lock.json", "services/npm-shrinkwrap.json"]
+    .map((file) => path.join(worktree, file)).filter(fs.existsSync);
+  const hash = crypto.createHash("sha256");
+  for (const file of files) hash.update(fs.readFileSync(file));
+  return hash.digest("hex").slice(0, 20);
+}
+
+function withLock(lockPath, action) {
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  for (;;) {
+    try {
+      const fd = fs.openSync(lockPath, "wx");
+      try { return action(); } finally { fs.closeSync(fd); fs.unlinkSync(lockPath); }
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+    }
+  }
+}
+
+function attachDependencyPool(worktree, options, env) {
+  const fingerprint = dependencyFingerprint(worktree);
+  const pool = path.join(options.stateDir, "dependency-pool", fingerprint);
+  const modules = path.join(pool, "node_modules");
+  withLock(`${pool}.lock`, () => {
+    if (!fs.existsSync(modules)) {
+      fs.mkdirSync(pool, { recursive: true });
+      for (const file of ["package.json", "package-lock.json", "npm-shrinkwrap.json"]) {
+        const source = path.join(worktree, "services", file);
+        if (fs.existsSync(source)) fs.copyFileSync(source, path.join(pool, file));
+      }
+      run("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund"], { cwd: pool, env });
+    }
+  });
+  const target = path.join(worktree, "services", "node_modules");
+  if (fs.existsSync(target)) fs.rmSync(target, { recursive: true, force: true });
+  fs.symlinkSync(modules, target, "dir");
+  return fingerprint;
+}
+
+async function execute(command, args, options) {
+  return await new Promise((resolve) => {
+    const output = fs.openSync(options.logPath, "w");
+    const child = spawn(command, args, { cwd: options.cwd, env: options.env, stdio: ["ignore", output, output] });
+    child.on("close", (code) => { fs.closeSync(output); resolve(code ?? 1); });
+  });
+}
+
+function summarizeLog(logPath) {
+  const text = fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : "";
+  const lines = text.split(/\r?\n/).filter((line) => /^(error:|✖|ℹ Error:|service gate:|service gate L2 candidates:)/.test(line));
+  return (lines.length ? lines : text.split(/\r?\n/).filter(Boolean).slice(-20)).slice(-30).join("\n").slice(0, 6000);
+}
+
+async function auditPR(repoRoot, options, pr, gateSHA) {
+  const cached = readCached(options, pr, gateSHA);
+  if (cached) return cached;
+  const startedAt = new Date().toISOString();
+  if (pr.isDraft) return finish({ number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA, status: "blocked", reason: "PR 当前为 Draft，未执行 L2。", startedAt }, options);
+  const mergeRef = fetchMergeRef(repoRoot, options, pr);
+  if (!mergeRef) return finish({ number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA, status: "blocked", reason: "GitHub 未生成 merge ref；PR 与当前 main 冲突或暂不可合并。", startedAt }, options);
+  if (options.dryRun) return finish({ number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA, status: "not-applicable", reason: "dry-run：尚未执行。", startedAt }, options);
+  const worktree = prepareWorktree(repoRoot, options, pr, mergeRef);
+  const logPath = path.join(options.stateDir, "logs", `pr-${pr.number}.log`);
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  const env = { ...process.env,
+    npm_config_cache: path.join(options.stateDir, "cache", "npm"),
+    GOMODCACHE: path.join(options.stateDir, "cache", "gomod"),
+    GOCACHE: path.join(options.stateDir, "cache", "gobuild"),
+  };
+  let result;
+  try {
+    overlayGate(repoRoot, worktree);
+    const fingerprint = attachDependencyPool(worktree, options, env);
+    const code = await execute("node", ["services/scripts/service-pr-gate.mjs", "--base", "HEAD^1", "--head", "HEAD", "--skip-install"], { cwd: worktree, env, logPath });
+    const summary = summarizeLog(logPath);
+    const noService = summary.includes("no service implementation changed");
+    result = { number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA, dependencyFingerprint: fingerprint,
+      status: code === 0 ? (noService ? "not-applicable" : "passed") : "failed",
+      reason: code === 0 ? (noService ? "该 PR 不包含单 Service 实现改动，L2 不适用。" : "完整 L2 自动门禁通过。") : "L2 自动门禁执行失败。",
+      summary, logPath, startedAt };
+  } catch (error) {
+    result = { number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA, status: "failed", reason: `审计器异常：${error.message}`, summary: summarizeLog(logPath), logPath, startedAt };
+  } finally {
+    if (!options.keepWorktrees) git(["worktree", "remove", "--force", worktree], repoRoot, { allowFailure: true });
+  }
+  return finish(result, options);
+}
+
+function finish(result, options) { result.finishedAt = new Date().toISOString(); writeResult(options, result); return result; }
+
+function commentBody(result) {
+  const label = LABELS[result.status].name;
+  return `${MARKER}\n## Service L2 自动检查结果：${label}\n\n- 状态：**${result.status}**\n- PR head：\`${result.headSHA}\`\n- 门禁版本：\`${result.gateSHA}\`\n- 结论：${result.reason}\n\n${result.summary ? `### 关键输出\n\n\`\`\`text\n${result.summary}\n\`\`\`\n\n` : ""}L2 只验证包结构、mock 测试、80% line/branch/function coverage、打包、构建和 OctoBus smoke 链路；真实设备兼容性仍需人工检查作者提供的脱敏证据。`;
+}
+
+function ensureLabels(repoRoot, options) {
+  for (const label of Object.values(LABELS)) gh(["label", "create", label.name, "-R", options.repo, "--color", label.color, "--description", label.description, "--force"], repoRoot);
+}
+
+function publishResult(repoRoot, options, result) {
+  const comments = JSON.parse(gh(["api", `repos/${options.repo}/issues/${result.number}/comments`, "--paginate"], repoRoot).stdout);
+  const existing = comments.find((comment) => comment.body?.includes(MARKER));
+  const body = commentBody(result);
+  if (existing) gh(["api", "--method", "PATCH", `repos/${options.repo}/issues/comments/${existing.id}`, "--field", `body=${body}`], repoRoot);
+  else gh(["pr", "comment", String(result.number), "-R", options.repo, "--body", body], repoRoot);
+  const remove = Object.values(LABELS).map((label) => label.name).filter((name) => name !== LABELS[result.status].name);
+  const args = ["pr", "edit", String(result.number), "-R", options.repo, "--add-label", LABELS[result.status].name];
+  for (const label of remove) args.push("--remove-label", label);
+  gh(args, repoRoot);
+}
+
+async function mapLimit(items, limit, worker) {
+  const results = new Array(items.length); let next = 0;
+  async function runWorker() { for (;;) { const index = next++; if (index >= items.length) return; results[index] = await worker(items[index]); } }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, runWorker)); return results;
+}
+
+export async function main(argv = process.argv.slice(2), repoRoot = path.resolve(import.meta.dirname, "..")) {
+  const options = parseArgs(argv);
+  fs.mkdirSync(options.stateDir, { recursive: true });
+  git(["fetch", "origin", "main", "ci/service-l2-gate"], repoRoot);
+  const gateSHA = git(["rev-parse", options.gateRef], repoRoot).stdout.trim();
+  const prs = listPRs(options, repoRoot).filter((pr) => !options.exclude.has(pr.number));
+  console.error(`L2 batch: ${prs.length} PRs, concurrency=${options.concurrency}, publish=${options.publish}`);
+  const results = await mapLimit(prs, options.concurrency, async (pr) => {
+    const result = await auditPR(repoRoot, options, pr, gateSHA);
+    console.error(`#${pr.number} ${result.status}: ${result.reason}`);
+    return result;
+  });
+  if (options.publish) { ensureLabels(repoRoot, options); for (const result of results) publishResult(repoRoot, options, result); }
+  const counts = Object.fromEntries(Object.keys(LABELS).map((status) => [status, results.filter((r) => r.status === status).length]));
+  fs.writeFileSync(path.join(options.stateDir, "summary.json"), `${JSON.stringify({ gateSHA, counts, results }, null, 2)}\n`);
+  console.log(JSON.stringify({ gateSHA, counts, stateDir: options.stateDir }, null, 2));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  main().catch((error) => { console.error(error.stack || error.message); process.exitCode = 1; });
+}

--- a/scripts/service-l2-batch.mjs
+++ b/scripts/service-l2-batch.mjs
@@ -12,6 +12,8 @@ const LABELS = {
   "not-applicable": { name: "l2:not-applicable", color: "6e7781", description: "不适用 Service L2 门禁" },
 };
 const MARKER = "<!-- octobus-service-l2-batch -->";
+const LOCK_STALE_MS = 30 * 60 * 1000;
+const LOCK_WAIT_MS = 35 * 60 * 1000;
 
 function parseArgs(argv) {
   const options = {
@@ -100,15 +102,48 @@ function dependencyFingerprint(worktree) {
   return hash.digest("hex").slice(0, 20);
 }
 
-function withLock(lockPath, action) {
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid < 1) return false;
+  try { process.kill(pid, 0); return true; }
+  catch (error) { return error.code === "EPERM"; }
+}
+
+function lockIsStale(lockPath, staleMs, now) {
+  try {
+    const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+    return now - lock.createdAt > staleMs || !processIsAlive(lock.pid);
+  } catch {
+    return now - fs.statSync(lockPath).mtimeMs > staleMs;
+  }
+}
+
+export function withLock(lockPath, action, { staleMs = LOCK_STALE_MS, waitMs = LOCK_WAIT_MS } = {}) {
   fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const startedAt = Date.now();
+  let fd;
   for (;;) {
     try {
-      const fd = fs.openSync(lockPath, "wx");
-      try { return action(); } finally { fs.closeSync(fd); fs.unlinkSync(lockPath); }
+      fd = fs.openSync(lockPath, "wx");
+      break;
     } catch (error) {
       if (error.code !== "EEXIST") throw error;
+      if (lockIsStale(lockPath, staleMs, Date.now())) {
+        try { fs.unlinkSync(lockPath); } catch (unlinkError) { if (unlinkError.code !== "ENOENT") throw unlinkError; }
+        continue;
+      }
+      if (Date.now() - startedAt >= waitMs) throw new Error(`timed out waiting for dependency lock: ${lockPath}`);
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+    }
+  }
+  const owner = { pid: process.pid, createdAt: Date.now(), token: crypto.randomUUID() };
+  fs.writeFileSync(fd, JSON.stringify(owner));
+  try { return action(); } finally {
+    fs.closeSync(fd);
+    try {
+      const current = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+      if (current.token === owner.token) fs.unlinkSync(lockPath);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
     }
   }
 }
@@ -117,14 +152,18 @@ function attachDependencyPool(worktree, options, env) {
   const fingerprint = dependencyFingerprint(worktree);
   const pool = path.join(options.stateDir, "dependency-pool", fingerprint);
   const modules = path.join(pool, "node_modules");
+  const complete = path.join(pool, ".install-complete");
   withLock(`${pool}.lock`, () => {
-    if (!fs.existsSync(modules)) {
+    if (!fs.existsSync(modules) || !fs.existsSync(complete)) {
+      fs.rmSync(modules, { recursive: true, force: true });
+      fs.rmSync(complete, { force: true });
       fs.mkdirSync(pool, { recursive: true });
       for (const file of ["package.json", "package-lock.json", "npm-shrinkwrap.json"]) {
         const source = path.join(worktree, "services", file);
         if (fs.existsSync(source)) fs.copyFileSync(source, path.join(pool, file));
       }
       run("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund"], { cwd: pool, env });
+      fs.writeFileSync(complete, `${fingerprint}\n`);
     }
   });
   const target = path.join(worktree, "services", "node_modules");
@@ -195,12 +234,6 @@ async function auditPR(repoRoot, options, pr, gateSHA) {
       result = { number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA,
         status: "not-applicable", reason: "该 PR 不包含单 Service 实现改动，L2 不适用。",
         summary: "service gate: no service implementation changed; L2 service checks are not applicable", startedAt };
-      return finish(result, options);
-    }
-    if (preflight.code !== 0) {
-      result = { number: pr.number, title: pr.title, headSHA: pr.headRefOid, gateSHA,
-        status: "failed", reason: "L2 静态范围或包结构预检失败。",
-        summary: preflight.output.split(/\r?\n/).filter((line) => line.startsWith("error:")).slice(-30).join("\n").slice(0, 6000), startedAt };
       return finish(result, options);
     }
     const fingerprint = attachDependencyPool(worktree, options, env);

--- a/scripts/service-l2-batch.test.mjs
+++ b/scripts/service-l2-batch.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { readCached } from "./service-l2-batch.mjs";
+
+test("dry-run never reuses or accepts the formal result cache", () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "octobus-l2-cache-"));
+  const options = { stateDir, dryRun: false, force: false };
+  const pr = { number: 1, headRefOid: "head" };
+  const resultDir = path.join(stateDir, "results");
+  fs.mkdirSync(resultDir, { recursive: true });
+  fs.writeFileSync(path.join(resultDir, "1.json"), JSON.stringify({ headSHA: "head", gateSHA: "gate", executed: false }));
+  assert.deepEqual(readCached(options, pr, "gate"), { headSHA: "head", gateSHA: "gate", executed: false });
+  assert.equal(readCached({ ...options, dryRun: true }, pr, "gate"), null);
+});

--- a/scripts/service-l2-batch.test.mjs
+++ b/scripts/service-l2-batch.test.mjs
@@ -17,6 +17,18 @@ test("dry-run never reuses or accepts the formal result cache", () => {
   assert.equal(readCached({ ...options, dryRun: true }, pr, "gate"), null);
 });
 
+test("blocked results are retried because draft and mergeability can change", () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "octobus-l2-cache-"));
+  const options = { stateDir, dryRun: false, force: false };
+  const pr = { number: 1, headRefOid: "head" };
+  const resultDir = path.join(stateDir, "results");
+  fs.mkdirSync(resultDir, { recursive: true });
+  fs.writeFileSync(path.join(resultDir, "1.json"), JSON.stringify({
+    headSHA: "head", gateSHA: "gate", status: "blocked",
+  }));
+  assert.equal(readCached(options, pr, "gate"), null);
+});
+
 test("dependency lock reclaims a lock owned by a dead process", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "octobus-l2-lock-"));
   const lockPath = path.join(dir, "pool.lock");

--- a/scripts/service-l2-batch.test.mjs
+++ b/scripts/service-l2-batch.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { readCached } from "./service-l2-batch.mjs";
+import { readCached, withLock } from "./service-l2-batch.mjs";
 
 test("dry-run never reuses or accepts the formal result cache", () => {
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "octobus-l2-cache-"));
@@ -15,4 +15,29 @@ test("dry-run never reuses or accepts the formal result cache", () => {
   fs.writeFileSync(path.join(resultDir, "1.json"), JSON.stringify({ headSHA: "head", gateSHA: "gate", executed: false }));
   assert.deepEqual(readCached(options, pr, "gate"), { headSHA: "head", gateSHA: "gate", executed: false });
   assert.equal(readCached({ ...options, dryRun: true }, pr, "gate"), null);
+});
+
+test("dependency lock reclaims a lock owned by a dead process", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "octobus-l2-lock-"));
+  const lockPath = path.join(dir, "pool.lock");
+  fs.writeFileSync(lockPath, JSON.stringify({ pid: 2147483647, createdAt: Date.now(), token: "dead" }));
+  let called = false;
+  withLock(lockPath, () => { called = true; }, { staleMs: 60_000, waitMs: 100 });
+  assert.equal(called, true);
+  assert.equal(fs.existsSync(lockPath), false);
+});
+
+test("dependency lock has a bounded wait", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "octobus-l2-lock-"));
+  const lockPath = path.join(dir, "pool.lock");
+  fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, createdAt: Date.now(), token: "live" }));
+  assert.throws(() => withLock(lockPath, () => {}, { staleMs: 60_000, waitMs: 1 }), /timed out waiting/);
+});
+
+test("dependency lock propagates action errors and releases the lock", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "octobus-l2-lock-"));
+  const lockPath = path.join(dir, "pool.lock");
+  const error = Object.assign(new Error("action failed"), { code: "EEXIST" });
+  assert.throws(() => withLock(lockPath, () => { throw error; }), /action failed/);
+  assert.equal(fs.existsSync(lockPath), false);
 });

--- a/scripts/service-package-smoke.mjs
+++ b/scripts/service-package-smoke.mjs
@@ -46,9 +46,9 @@ try {
   for (const [index, serviceDir] of selectedServiceDirs.entries()) {
     const result = await smokeService({ index, serviceDir, addr, mockBaseURL: mock.baseURL });
     evidence.push(result);
-    const status = result.ok ? "ok" : "failed";
+    const status = result.chain_ok ? "chain-ok" : "chain-failed";
     console.error(`[${index + 1}/${selectedServiceDirs.length}] ${status} ${serviceDir} ${result.method ?? ""} http=${result.http_status ?? ""} mock_hits=${result.mock_hits}`);
-    if (!result.ok) {
+    if (!result.chain_ok) {
       failed = true;
       if (!options.continueOnError) {
         break;
@@ -70,8 +70,9 @@ const summary = {
   octobus_addr: addr,
   mock_upstream: mock.baseURL,
   service_count: evidence.length,
-  ok_count: evidence.filter((item) => item.ok).length,
-  failed_count: evidence.filter((item) => !item.ok).length,
+  chain_ok_count: evidence.filter((item) => item.chain_ok).length,
+  chain_failed_count: evidence.filter((item) => !item.chain_ok).length,
+  business_success_count: evidence.filter((item) => item.business_success).length,
   evidence,
 };
 process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
@@ -93,7 +94,8 @@ async function smokeService({ index, serviceDir, addr, mockBaseURL }) {
     instance_id: instanceID,
     capset_id: capsetID,
     runtime_mode: manifest.runtime?.mode ?? "long-running",
-    ok: false,
+    chain_ok: false,
+    business_success: false,
     mock_hits: 0,
   };
 
@@ -132,7 +134,8 @@ async function smokeService({ index, serviceDir, addr, mockBaseURL }) {
     result.http_status = response.status;
     result.response_summary = summarizeBody(body);
     result.mock_hits = mock.hitCount - beforeHits;
-    result.ok = isAcceptableConnectResult(response.status, body);
+    result.business_success = response.status >= 200 && response.status < 300;
+    result.chain_ok = isAcceptableConnectResult(response.status, body);
   } catch (error) {
     result.error = error instanceof Error ? error.message : String(error);
     result.mock_hits = mock.hitCount - beforeHits;

--- a/scripts/service-package-smoke.mjs
+++ b/scripts/service-package-smoke.mjs
@@ -135,7 +135,7 @@ async function smokeService({ index, serviceDir, addr, mockBaseURL }) {
     result.response_summary = summarizeBody(body);
     result.mock_hits = mock.hitCount - beforeHits;
     result.business_success = response.status >= 200 && response.status < 300;
-    result.chain_ok = isAcceptableConnectResult(response.status, body);
+    result.chain_ok = result.mock_hits > 0 && isAcceptableConnectResult(response.status, body);
   } catch (error) {
     result.error = error instanceof Error ? error.message : String(error);
     result.mock_hits = mock.hitCount - beforeHits;

--- a/services/package.json
+++ b/services/package.json
@@ -213,6 +213,7 @@
   ],
   "scripts": {
     "validate": "node scripts/validate-service-package.mjs",
+    "pr:gate": "node scripts/service-pr-gate.mjs",
     "test": "node scripts/run-tests.mjs",
     "coverage:all": "node scripts/run-coverage-all.mjs",
     "import:check": "node scripts/import-check-all.mjs",

--- a/services/scripts/run-tests.mjs
+++ b/services/scripts/run-tests.mjs
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-const DEFAULT_COVERAGE_THRESHOLD = 90;
+const DEFAULT_COVERAGE_THRESHOLD = 80;
 
 function parseArgs(argv) {
   const opts = {

--- a/services/scripts/run-tests.mjs
+++ b/services/scripts/run-tests.mjs
@@ -82,9 +82,9 @@ function existingTestFiles(root, patterns) {
 }
 
 export function buildNodeTestArgs(root, opts) {
-  const tests = existingTestFiles(root, [
-    { dir: "tests", re: /\.test\.mjs$/ },
-  ]);
+  const tests = opts.serviceDir == null
+    ? existingTestFiles(root, [{ dir: "tests", re: /\.test\.mjs$/ }])
+    : [];
 
   if (opts.serviceDir != null) {
     tests.push(...existingTestFiles(root, [
@@ -104,7 +104,7 @@ export function buildNodeTestArgs(root, opts) {
     args.push(`--test-coverage-lines=${opts.coverageLines ?? DEFAULT_COVERAGE_THRESHOLD}`);
     if (opts.serviceDir != null) {
       const serviceDir = opts.serviceDir.replaceAll(path.win32.sep, path.posix.sep);
-      args.push(`--test-coverage-include=${serviceDir}/**/*.js`);
+      args.push(`--test-coverage-include=${serviceDir}/src/**/*.js`);
       args.push(`--test-coverage-exclude=${serviceDir}/node_modules/**`);
     }
   }

--- a/services/scripts/run-tests.mjs
+++ b/services/scripts/run-tests.mjs
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-const DEFAULT_COVERAGE_THRESHOLD = 80;
+const DEFAULT_COVERAGE_THRESHOLD = 90;
 
 function parseArgs(argv) {
   const opts = {

--- a/services/scripts/service-pr-gate.mjs
+++ b/services/scripts/service-pr-gate.mjs
@@ -88,7 +88,7 @@ export function plannedCommands(serviceDirs, { skipSmoke = false, skipInstall = 
   if (!skipInstall) commands.push(["npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund"], "services"]);
   for (const serviceDir of serviceDirs) {
     commands.push(["node", ["scripts/validate-service-package.mjs", "--service-dir", serviceDir], "services"]);
-    commands.push(["node", ["scripts/run-tests.mjs", "--service-dir", serviceDir, "--coverage"], "services"]);
+    commands.push(["node", ["scripts/run-tests.mjs", "--service-dir", serviceDir, "--coverage", "--coverage-threshold=80"], "services"]);
   }
   commands.push(["npm", ["run", "pack:check"], "services"]);
   if (!skipSmoke) {

--- a/services/scripts/service-pr-gate.mjs
+++ b/services/scripts/service-pr-gate.mjs
@@ -92,7 +92,7 @@ export function plannedCommands(serviceDirs, { skipSmoke = false, skipInstall = 
   }
   commands.push(["npm", ["run", "pack:check"], "services"]);
   if (!skipSmoke) {
-    commands.push(["task", ["build"], "."]);
+    commands.push(["bash", ["./scripts/build-octobus.sh", "bin/octobus"], "."]);
     for (const serviceDir of serviceDirs) {
       commands.push(["node", ["scripts/service-package-smoke.mjs", "--service-dir", serviceDir, "--fail-fast"], "."]);
     }

--- a/services/scripts/service-pr-gate.mjs
+++ b/services/scripts/service-pr-gate.mjs
@@ -18,6 +18,7 @@ export function parseArgs(argv) {
     head: "HEAD",
     dryRun: false,
     skipSmoke: false,
+    skipInstall: false,
     changedFiles: null,
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -30,6 +31,7 @@ export function parseArgs(argv) {
     else if (arg.startsWith("--changed-files=")) options.changedFiles = arg.slice(16).split(",").filter(Boolean);
     else if (arg === "--dry-run") options.dryRun = true;
     else if (arg === "--skip-smoke") options.skipSmoke = true;
+    else if (arg === "--skip-install") options.skipInstall = true;
     else throw new Error(`unknown argument: ${arg}`);
   }
   return options;
@@ -81,9 +83,9 @@ export function classifyChanges(files, repoRoot) {
   return { errors, serviceDirs: [...serviceDirs].sort(), touchesCore, touchesServiceInfrastructure };
 }
 
-export function plannedCommands(serviceDirs, { skipSmoke = false } = {}) {
+export function plannedCommands(serviceDirs, { skipSmoke = false, skipInstall = false } = {}) {
   const commands = [];
-  commands.push(["npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund"], "services"]);
+  if (!skipInstall) commands.push(["npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund"], "services"]);
   for (const serviceDir of serviceDirs) {
     commands.push(["node", ["scripts/validate-service-package.mjs", "--service-dir", serviceDir], "services"]);
     commands.push(["node", ["scripts/run-tests.mjs", "--service-dir", serviceDir, "--coverage"], "services"]);

--- a/services/scripts/service-pr-gate.mjs
+++ b/services/scripts/service-pr-gate.mjs
@@ -44,6 +44,7 @@ function requiredValue(argv, index, flag) {
 
 export function classifyChanges(files, repoRoot) {
   const errors = [];
+  const forbiddenFiles = [];
   const serviceDirs = new Set();
   let touchesCore = false;
   let touchesServiceInfrastructure = false;
@@ -51,7 +52,7 @@ export function classifyChanges(files, repoRoot) {
   for (const file of files) {
     const normalized = file.replaceAll(path.win32.sep, "/");
     if (FORBIDDEN_FILE_RE.test(normalized)) {
-      errors.push(`forbidden generated, binary, evidence, or secret-like file: ${normalized}`);
+      forbiddenFiles.push(normalized);
     }
     if (CORE_PREFIXES.some((prefix) => normalized.startsWith(prefix))) touchesCore = true;
     if (!normalized.startsWith("services/")) continue;
@@ -68,6 +69,11 @@ export function classifyChanges(files, repoRoot) {
 
   if (serviceDirs.size > 1) {
     errors.push(`service PR must change exactly one service root; found: ${[...serviceDirs].sort().join(", ")}`);
+  }
+  if (serviceDirs.size > 0) {
+    for (const file of forbiddenFiles) {
+      errors.push(`forbidden generated, binary, evidence, or secret-like file: ${file}`);
+    }
   }
   if (serviceDirs.size > 0 && touchesCore) {
     errors.push("service PR must not mix a service implementation with runtime, SDK, examples, tests, npm, or Docker changes");

--- a/services/scripts/service-pr-gate.mjs
+++ b/services/scripts/service-pr-gate.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const SERVICE_DIR_RE = /^[a-z0-9][a-z0-9-]*__[a-z0-9][a-z0-9._-]*$/;
+const SHARED_SERVICE_FILES = new Set([
+  "services/package.json",
+  "services/bin/octobus-tentacles.js",
+]);
+const SHARED_WRAPPER_RE = /^services\/bin\/[^/]+\.js$/;
+const FORBIDDEN_FILE_RE = /(?:^|\/)(?:node_modules|coverage|\.env)(?:\/|$)|\.(?:tgz|tar\.gz|zip|log|png|jpe?g|gif|webp)$/i;
+const CORE_PREFIXES = ["cmd/", "internal/", "sdk/", "tests/", "examples/", "npm/", "docker/"];
+
+export function parseArgs(argv) {
+  const options = {
+    base: process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : "origin/main",
+    head: "HEAD",
+    dryRun: false,
+    skipSmoke: false,
+    changedFiles: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--base") options.base = requiredValue(argv, ++index, arg);
+    else if (arg.startsWith("--base=")) options.base = arg.slice(7);
+    else if (arg === "--head") options.head = requiredValue(argv, ++index, arg);
+    else if (arg.startsWith("--head=")) options.head = arg.slice(7);
+    else if (arg === "--changed-files") options.changedFiles = requiredValue(argv, ++index, arg).split(",").filter(Boolean);
+    else if (arg.startsWith("--changed-files=")) options.changedFiles = arg.slice(16).split(",").filter(Boolean);
+    else if (arg === "--dry-run") options.dryRun = true;
+    else if (arg === "--skip-smoke") options.skipSmoke = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function requiredValue(argv, index, flag) {
+  if (!argv[index]) throw new Error(`${flag} requires a value`);
+  return argv[index];
+}
+
+export function classifyChanges(files, repoRoot) {
+  const errors = [];
+  const serviceDirs = new Set();
+  let touchesCore = false;
+  let touchesServiceInfrastructure = false;
+
+  for (const file of files) {
+    const normalized = file.replaceAll(path.win32.sep, "/");
+    if (FORBIDDEN_FILE_RE.test(normalized)) {
+      errors.push(`forbidden generated, binary, evidence, or secret-like file: ${normalized}`);
+    }
+    if (CORE_PREFIXES.some((prefix) => normalized.startsWith(prefix))) touchesCore = true;
+    if (!normalized.startsWith("services/")) continue;
+
+    const relative = normalized.slice("services/".length);
+    const first = relative.split("/", 1)[0];
+    if (SERVICE_DIR_RE.test(first)) {
+      serviceDirs.add(first);
+      continue;
+    }
+    if (SHARED_SERVICE_FILES.has(normalized) || SHARED_WRAPPER_RE.test(normalized)) continue;
+    touchesServiceInfrastructure = true;
+  }
+
+  if (serviceDirs.size > 1) {
+    errors.push(`service PR must change exactly one service root; found: ${[...serviceDirs].sort().join(", ")}`);
+  }
+  if (serviceDirs.size > 0 && touchesCore) {
+    errors.push("service PR must not mix a service implementation with runtime, SDK, examples, tests, npm, or Docker changes");
+  }
+  if (serviceDirs.size > 0 && touchesServiceInfrastructure) {
+    errors.push("service PR contains non-whitelisted shared services infrastructure changes; split them into a prerequisite PR");
+  }
+  for (const serviceDir of serviceDirs) {
+    if (!fs.existsSync(path.join(repoRoot, "services", serviceDir, "service.json"))) {
+      errors.push(`changed service ${serviceDir} is deleted or has no service.json; removals require an infrastructure review`);
+    }
+  }
+  return { errors, serviceDirs: [...serviceDirs].sort(), touchesCore, touchesServiceInfrastructure };
+}
+
+export function plannedCommands(serviceDirs, { skipSmoke = false } = {}) {
+  const commands = [];
+  commands.push(["npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund"], "services"]);
+  for (const serviceDir of serviceDirs) {
+    commands.push(["node", ["scripts/validate-service-package.mjs", "--service-dir", serviceDir], "services"]);
+    commands.push(["node", ["scripts/run-tests.mjs", "--service-dir", serviceDir, "--coverage"], "services"]);
+  }
+  commands.push(["npm", ["run", "pack:check"], "services"]);
+  if (!skipSmoke) {
+    commands.push(["task", ["build"], "."]);
+    for (const serviceDir of serviceDirs) {
+      commands.push(["node", ["scripts/service-package-smoke.mjs", "--service-dir", serviceDir, "--fail-fast"], "."]);
+    }
+  }
+  return commands;
+}
+
+function gitChangedFiles(repoRoot, base, head) {
+  const mergeBase = runCapture("git", ["merge-base", base, head], repoRoot).trim();
+  return runCapture("git", ["diff", "--name-only", "--diff-filter=ACDMRTUXB", `${mergeBase}...${head}`], repoRoot)
+    .split(/\r?\n/).filter(Boolean);
+}
+
+function runCapture(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, encoding: "utf8" });
+  if ((result.status ?? 1) !== 0) throw new Error(`${command} ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+  return result.stdout;
+}
+
+function runCommand(command, args, cwd) {
+  console.error(`+ (cd ${cwd} && ${command} ${args.join(" ")})`);
+  const result = spawnSync(command, args, { cwd, stdio: "inherit" });
+  if ((result.status ?? 1) !== 0) throw new Error(`${command} ${args.join(" ")} failed with status ${result.status ?? 1}`);
+}
+
+export function main(argv = process.argv.slice(2), repoRoot = path.resolve(import.meta.dirname, "../..")) {
+  const options = parseArgs(argv);
+  const files = options.changedFiles ?? gitChangedFiles(repoRoot, options.base, options.head);
+  const classification = classifyChanges(files, repoRoot);
+  console.error(`service gate changed files: ${files.length}`);
+  if (classification.errors.length) {
+    for (const error of classification.errors) console.error(`error: ${error}`);
+    return 1;
+  }
+  if (classification.serviceDirs.length === 0) {
+    console.error("service gate: no service implementation changed; L2 service checks are not applicable");
+    return 0;
+  }
+  console.error(`service gate L2 candidates: ${classification.serviceDirs.join(", ")}`);
+  const commands = plannedCommands(classification.serviceDirs, options);
+  if (options.dryRun) {
+    for (const [command, args, cwd] of commands) console.log(`(cd ${cwd} && ${command} ${args.join(" ")})`);
+    return 0;
+  }
+  for (const [command, args, cwd] of commands) runCommand(command, args, path.resolve(repoRoot, cwd));
+  console.error("service gate: L2 automated checks passed (device verification remains a human review item)");
+  return 0;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  try { process.exitCode = main(); }
+  catch (error) { console.error(`error: ${error.message}`); process.exitCode = 1; }
+}

--- a/services/tests/service-pr-gate.test.mjs
+++ b/services/tests/service-pr-gate.test.mjs
@@ -66,7 +66,7 @@ test("plans focused validation, coverage, packaging, build, and smoke", () => {
     "node scripts/validate-service-package.mjs --service-dir vendor__product_v1",
     "node scripts/run-tests.mjs --service-dir vendor__product_v1 --coverage --coverage-threshold=80",
     "npm run pack:check",
-    "task build",
+    "bash ./scripts/build-octobus.sh bin/octobus",
     "node scripts/service-package-smoke.mjs --service-dir vendor__product_v1 --fail-fast",
   ]);
 });
@@ -74,7 +74,7 @@ test("plans focused validation, coverage, packaging, build, and smoke", () => {
 test("can reuse a prepared dependency pool", () => {
   const commands = plannedCommands(["vendor__product_v1"], { skipInstall: true, skipSmoke: true });
   assert.equal(commands.some(([command, args]) => command === "npm" && args[0] === "install"), false);
-  assert.equal(commands.some(([command, args]) => command === "task" && args[0] === "build"), false);
+  assert.equal(commands.some(([command, args]) => command === "bash" && args[0] === "./scripts/build-octobus.sh"), false);
 });
 
 test("parses CI and local execution options", () => {

--- a/services/tests/service-pr-gate.test.mjs
+++ b/services/tests/service-pr-gate.test.mjs
@@ -71,12 +71,19 @@ test("plans focused validation, coverage, packaging, build, and smoke", () => {
   ]);
 });
 
+test("can reuse a prepared dependency pool", () => {
+  const commands = plannedCommands(["vendor__product_v1"], { skipInstall: true, skipSmoke: true });
+  assert.equal(commands.some(([command, args]) => command === "npm" && args[0] === "install"), false);
+  assert.equal(commands.some(([command, args]) => command === "task" && args[0] === "build"), false);
+});
+
 test("parses CI and local execution options", () => {
-  assert.deepEqual(parseArgs(["--base", "origin/dev", "--head=abc", "--dry-run", "--skip-smoke", "--changed-files=a,b"]), {
+  assert.deepEqual(parseArgs(["--base", "origin/dev", "--head=abc", "--dry-run", "--skip-smoke", "--skip-install", "--changed-files=a,b"]), {
     base: "origin/dev",
     head: "abc",
     dryRun: true,
     skipSmoke: true,
+    skipInstall: true,
     changedFiles: ["a", "b"],
   });
 });

--- a/services/tests/service-pr-gate.test.mjs
+++ b/services/tests/service-pr-gate.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { classifyChanges, parseArgs, plannedCommands } from "../scripts/service-pr-gate.mjs";
+
+function repoFixture(serviceDirs = ["vendor__product_v1"]) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "octobus-service-pr-gate-"));
+  for (const serviceDir of serviceDirs) {
+    fs.mkdirSync(path.join(root, "services", serviceDir), { recursive: true });
+    fs.writeFileSync(path.join(root, "services", serviceDir, "service.json"), "{}\n");
+  }
+  return root;
+}
+
+test("classifies a focused service PR and allows generated registry files", () => {
+  const root = repoFixture();
+  const result = classifyChanges([
+    "services/vendor__product_v1/src/client.js",
+    "services/vendor__product_v1/test/client.test.js",
+    "services/bin/vendor-product.js",
+    "services/bin/octobus-tentacles.js",
+    "services/package.json",
+  ], root);
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.serviceDirs, ["vendor__product_v1"]);
+});
+
+test("rejects multi-service and mixed core changes", () => {
+  const root = repoFixture(["vendor__one", "vendor__two"]);
+  const result = classifyChanges([
+    "services/vendor__one/src/one.js",
+    "services/vendor__two/src/two.js",
+    "internal/protocol/gateway.go",
+  ], root);
+  assert.match(result.errors.join("\n"), /exactly one service root/);
+  assert.match(result.errors.join("\n"), /must not mix/);
+});
+
+test("rejects package pollution, infrastructure changes, and service removal", () => {
+  const root = repoFixture();
+  const result = classifyChanges([
+    "services/vendor__product_v1/evidence.png",
+    "services/scripts/custom-runtime.mjs",
+    "services/vendor__deleted/src/client.js",
+  ], root);
+  assert.match(result.errors.join("\n"), /forbidden generated/);
+  assert.match(result.errors.join("\n"), /non-whitelisted shared/);
+  assert.match(result.errors.join("\n"), /deleted or has no service.json/);
+});
+
+test("does not apply L2 service checks to a core-only PR", () => {
+  const root = repoFixture();
+  const result = classifyChanges(["internal/store/store.go", "README.md"], root);
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.serviceDirs, []);
+  assert.equal(result.touchesCore, true);
+});
+
+test("plans focused validation, coverage, packaging, build, and smoke", () => {
+  const commands = plannedCommands(["vendor__product_v1"]);
+  assert.deepEqual(commands.map(([command, args]) => `${command} ${args.join(" ")}`), [
+    "npm install --ignore-scripts --no-audit --no-fund",
+    "node scripts/validate-service-package.mjs --service-dir vendor__product_v1",
+    "node scripts/run-tests.mjs --service-dir vendor__product_v1 --coverage",
+    "npm run pack:check",
+    "task build",
+    "node scripts/service-package-smoke.mjs --service-dir vendor__product_v1 --fail-fast",
+  ]);
+});
+
+test("parses CI and local execution options", () => {
+  assert.deepEqual(parseArgs(["--base", "origin/dev", "--head=abc", "--dry-run", "--skip-smoke", "--changed-files=a,b"]), {
+    base: "origin/dev",
+    head: "abc",
+    dryRun: true,
+    skipSmoke: true,
+    changedFiles: ["a", "b"],
+  });
+});

--- a/services/tests/service-pr-gate.test.mjs
+++ b/services/tests/service-pr-gate.test.mjs
@@ -59,6 +59,13 @@ test("does not apply L2 service checks to a core-only PR", () => {
   assert.equal(result.touchesCore, true);
 });
 
+test("does not enforce service package pollution rules on a non-service PR", () => {
+  const root = repoFixture();
+  const result = classifyChanges(["docs/architecture.png", "artifacts/debug.log"], root);
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.serviceDirs, []);
+});
+
 test("plans focused validation, coverage, packaging, build, and smoke", () => {
   const commands = plannedCommands(["vendor__product_v1"]);
   assert.deepEqual(commands.map(([command, args]) => `${command} ${args.join(" ")}`), [

--- a/services/tests/service-pr-gate.test.mjs
+++ b/services/tests/service-pr-gate.test.mjs
@@ -64,7 +64,7 @@ test("plans focused validation, coverage, packaging, build, and smoke", () => {
   assert.deepEqual(commands.map(([command, args]) => `${command} ${args.join(" ")}`), [
     "npm install --ignore-scripts --no-audit --no-fund",
     "node scripts/validate-service-package.mjs --service-dir vendor__product_v1",
-    "node scripts/run-tests.mjs --service-dir vendor__product_v1 --coverage",
+    "node scripts/run-tests.mjs --service-dir vendor__product_v1 --coverage --coverage-threshold=80",
     "npm run pack:check",
     "task build",
     "node scripts/service-package-smoke.mjs --service-dir vendor__product_v1 --fail-fast",

--- a/services/tests/validate-service-package.test.mjs
+++ b/services/tests/validate-service-package.test.mjs
@@ -546,9 +546,9 @@ test("builds test runner args for root and service tests", () => {
   assert.deepEqual(args, [
     "--test",
     "--experimental-test-coverage",
-    "--test-coverage-branches=80",
-    "--test-coverage-functions=80",
-    "--test-coverage-lines=80",
+    "--test-coverage-branches=90",
+    "--test-coverage-functions=90",
+    "--test-coverage-lines=90",
     "--test-coverage-include=vendor__svc/src/**/*.js",
     "--test-coverage-exclude=vendor__svc/node_modules/**",
     path.join("vendor__svc", "test", "svc.test.js"),

--- a/services/tests/validate-service-package.test.mjs
+++ b/services/tests/validate-service-package.test.mjs
@@ -549,9 +549,8 @@ test("builds test runner args for root and service tests", () => {
     "--test-coverage-branches=90",
     "--test-coverage-functions=90",
     "--test-coverage-lines=90",
-    "--test-coverage-include=vendor__svc/**/*.js",
+    "--test-coverage-include=vendor__svc/src/**/*.js",
     "--test-coverage-exclude=vendor__svc/node_modules/**",
-    path.join("tests", "root.test.mjs"),
     path.join("vendor__svc", "test", "svc.test.js"),
   ]);
 

--- a/services/tests/validate-service-package.test.mjs
+++ b/services/tests/validate-service-package.test.mjs
@@ -546,9 +546,9 @@ test("builds test runner args for root and service tests", () => {
   assert.deepEqual(args, [
     "--test",
     "--experimental-test-coverage",
-    "--test-coverage-branches=90",
-    "--test-coverage-functions=90",
-    "--test-coverage-lines=90",
+    "--test-coverage-branches=80",
+    "--test-coverage-functions=80",
+    "--test-coverage-lines=80",
     "--test-coverage-include=vendor__svc/src/**/*.js",
     "--test-coverage-exclude=vendor__svc/node_modules/**",
     path.join("vendor__svc", "test", "svc.test.js"),


### PR DESCRIPTION
## Summary

- Add a required `service-l2-gate` workflow for pull requests.
- Automatically classify changed files and reject multi-service, mixed-scope, deleted-service, and forbidden-artifact changes.
- Run focused service validation, mock tests, 80% line/function/branch coverage, npm pack checks, OctoBus build, and runtime smoke checks for single-service PRs.
- Fix focused test execution so `--service-dir` does not run repository-wide tests.
- Restrict focused coverage to service `src/**/*.js`, excluding test files from the coverage denominator.
- Distinguish smoke `chain_ok` from `business_success`; generic mock responses are not treated as business verification.
- Document the L2 automated gate and retain real-device evidence as a human-reviewed L3 requirement.

## Testing

- `node --test services/tests/service-pr-gate.test.mjs services/tests/validate-service-package.test.mjs`
- `node services/scripts/service-pr-gate.mjs --changed-files=services/first__epss-v1/src/first-epss-v1.js`
  - focused validation passed
  - focused tests passed
  - line coverage: 100%
  - branch coverage: 91.67%
  - function coverage: 100%
  - npm pack dry-run passed
  - OctoBus build passed
  - service smoke chain passed
- Negative coverage checks correctly reject services below the 80% branch/function/line thresholds.
- `git diff --check`

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.

