### PR TITLE
Make backend unary timeout configurable

### DIFF
--- a/internal/protocol/gateway.go
+++ b/internal/protocol/gateway.go
@@ -1514,7 +1514,7 @@ func (g *Gateway) invokeRaw(ctx context.Context, item store.ExposedMethod, req [
 	if strings.HasPrefix(item.Instance.ListenAddr, "bufconn:") {
 		return nil, status.Error(codes.Unavailable, "backend instance uses unsupported in-memory listener")
 	}
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, backendUnaryTimeout())
 	defer cancel()
 	conn, err := g.backendConn(item)
 	if err != nil {
@@ -1526,6 +1526,18 @@ func (g *Gateway) invokeRaw(ctx context.Context, item store.ExposedMethod, req [
 		return nil, err
 	}
 	return out.Bytes(), nil
+}
+
+func backendUnaryTimeout() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("OCTOBUS_BACKEND_UNARY_TIMEOUT"))
+	if raw == "" {
+		return 30 * time.Second
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil || timeout <= 0 {
+		return 30 * time.Second
+	}
+	return timeout
 }
 
 func (g *Gateway) newBackendStream(ctx context.Context, item store.ExposedMethod) (grpc.ClientStream, error) {

--- a/internal/protocol/gateway_test.go
+++ b/internal/protocol/gateway_test.go
@@ -50,6 +50,28 @@ type memoryAccessLogger struct {
 	err     error
 }
 
+func TestBackendUnaryTimeout(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{name: "default", value: "", want: 30 * time.Second},
+		{name: "override", value: " 2m ", want: 2 * time.Minute},
+		{name: "malformed", value: "not-a-duration", want: 30 * time.Second},
+		{name: "zero", value: "0s", want: 30 * time.Second},
+		{name: "negative", value: "-1s", want: 30 * time.Second},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OCTOBUS_BACKEND_UNARY_TIMEOUT", test.value)
+			if got := backendUnaryTimeout(); got != test.want {
+				t.Fatalf("backendUnaryTimeout() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func (l *memoryAccessLogger) Append(record accesslog.Record) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()


### PR DESCRIPTION
## Summary

- Keep the existing 30-second backend unary deadline as the default.
- Allow operators to override it with `OCTOBUS_BACKEND_UNARY_TIMEOUT` using Go duration syntax, such as `2m`.
- Fall back to 30 seconds for empty, malformed, zero, or negative values.

## Motivation

Backend unary requests can legitimately take longer than 30 seconds. The current hard-coded deadline returns `DeadlineExceeded` even when the caller permits a longer request. This change makes only that backend deadline configurable while preserving current behavior by default.

## Tests

- `go test ./internal/protocol -run "^TestBackendUnaryTimeout$" -count=1`
- `go test ./internal/protocol -count=1`
- `TMPDIR=/private/tmp task all`