### PR TITLE
fix(import): ignore npm pack metadata lines

### DIFF
--- a/internal/packageimport/importer.go
+++ b/internal/packageimport/importer.go
@@ -1464,7 +1464,7 @@ func npmPackArtifactName(output string) (string, error) {
 	lines := strings.Split(output, "\n")
 	for index := len(lines) - 1; index >= 0; index-- {
 		line := strings.TrimSpace(lines[index])
-		if strings.HasSuffix(strings.ToLower(line), ".tgz") {
+		if !strings.ContainsAny(line, " \t") && strings.HasSuffix(strings.ToLower(line), ".tgz") {
 			return filepath.Base(line), nil
 		}
 	}

--- a/internal/packageimport/importer_test.go
+++ b/internal/packageimport/importer_test.go
@@ -1506,7 +1506,7 @@ func TestNpmPackOutputAndErrorBranches(t *testing.T) {
 case "$NPM_FAKE_MODE" in
 empty) exit 0 ;;
 fail) printf 'boom\n' >&2; exit 7 ;;
-*) printf 'notice before\npkg-1.0.0.tgz\nnpm notice\n' ;;
+*) printf 'notice before\npkg-1.0.0.tgz\nnpm notice filename: misleading.tgz\nnpm notice\n' ;;
 esac
 `, 0o755)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))


### PR DESCRIPTION
npm v11 emits metadata such as `npm notice filename: package.tgz` after the bare artifact filename. Tighten the parser introduced in #497 to accept only a single whitespace-free `.tgz` token, and add a regression test for the metadata line.\n\nTests: `go test ./internal/packageimport`\n\nUnblocks #432.