### PR TITLE
fix(import): parse npm pack JSON output

### DIFF
--- a/internal/packageimport/importer.go
+++ b/internal/packageimport/importer.go
@@ -992,14 +992,14 @@ func skipDiscoveryDir(name string) bool {
 }
 
 func (i *Importer) packNPM(ctx context.Context, spec, staging string) (preparedSource, error) {
-	cmd := exec.CommandContext(ctx, "npm", "pack", spec, "--pack-destination", staging)
-	var out strings.Builder
-	cmd.Stdout = &out
-	cmd.Stderr = &out
+	cmd := exec.CommandContext(ctx, "npm", "pack", spec, "--pack-destination", staging, "--json")
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return preparedSource{}, fmt.Errorf("npm pack %s: %w: %s", spec, err, strings.TrimSpace(out.String()))
+		return preparedSource{}, fmt.Errorf("npm pack %s: %w: %s", spec, err, strings.TrimSpace(stderr.String()))
 	}
-	packed, err := npmPackArtifactName(out.String())
+	packed, err := npmPackArtifactName(stdout.String())
 	if err != nil {
 		return preparedSource{}, err
 	}
@@ -1449,11 +1449,15 @@ func npmPack(ctx context.Context, dir, destination string) (string, error) {
 	if err := os.MkdirAll(destination, 0o755); err != nil {
 		return "", err
 	}
-	out, err := runNPMOutput(ctx, dir, []string{"pack", "--pack-destination", destination})
-	if err != nil {
-		return "", err
+	cmd := exec.CommandContext(ctx, "npm", "pack", "--pack-destination", destination, "--json")
+	cmd.Dir = dir
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("npm pack: %w: %s", err, strings.TrimSpace(stderr.String()))
 	}
-	packed, err := npmPackArtifactName(out)
+	packed, err := npmPackArtifactName(stdout.String())
 	if err != nil {
 		return "", err
 	}
@@ -1461,14 +1465,19 @@ func npmPack(ctx context.Context, dir, destination string) (string, error) {
 }
 
 func npmPackArtifactName(output string) (string, error) {
-	lines := strings.Split(output, "\n")
-	for index := len(lines) - 1; index >= 0; index-- {
-		line := strings.TrimSpace(lines[index])
-		if !strings.ContainsAny(line, " \t") && strings.HasSuffix(strings.ToLower(line), ".tgz") {
-			return filepath.Base(line), nil
-		}
+	if strings.TrimSpace(output) == "" {
+		return "", errors.New("npm pack did not produce a .tgz artifact")
 	}
-	return "", errors.New("npm pack did not produce a .tgz artifact")
+	var packed []struct {
+		Filename string `json:"filename"`
+	}
+	if err := json.Unmarshal([]byte(output), &packed); err != nil {
+		return "", fmt.Errorf("parse npm pack JSON output: %w", err)
+	}
+	if len(packed) != 1 || !strings.HasSuffix(strings.ToLower(packed[0].Filename), ".tgz") {
+		return "", errors.New("npm pack did not produce a .tgz artifact")
+	}
+	return filepath.Base(packed[0].Filename), nil
 }
 
 func runNPM(ctx context.Context, dir string, args []string) error {

--- a/internal/packageimport/importer_test.go
+++ b/internal/packageimport/importer_test.go
@@ -1506,7 +1506,9 @@ func TestNpmPackOutputAndErrorBranches(t *testing.T) {
 case "$NPM_FAKE_MODE" in
 empty) exit 0 ;;
 fail) printf 'boom\n' >&2; exit 7 ;;
-*) printf 'notice before\npkg-1.0.0.tgz\nnpm notice filename: misleading.tgz\nnpm notice\n' ;;
+invalid) printf 'not json\n' ;;
+missing) printf '[{}]\n' ;;
+*) printf 'npm notice filename: misleading.tgz\n' >&2; printf '[{"filename":"pkg-1.0.0.tgz"}]\n' ;;
 esac
 `, 0o755)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -1524,6 +1526,16 @@ esac
 	t.Setenv("NPM_FAKE_MODE", "empty")
 	if _, err := npmPack(context.Background(), t.TempDir(), filepath.Join(t.TempDir(), "packed")); err == nil || !strings.Contains(err.Error(), "did not produce") {
 		t.Fatalf("expected empty npm pack output error, got %v", err)
+	}
+
+	t.Setenv("NPM_FAKE_MODE", "invalid")
+	if _, err := npmPack(context.Background(), t.TempDir(), filepath.Join(t.TempDir(), "packed")); err == nil || !strings.Contains(err.Error(), "parse npm pack JSON output") {
+		t.Fatalf("expected invalid npm pack JSON error, got %v", err)
+	}
+
+	t.Setenv("NPM_FAKE_MODE", "missing")
+	if _, err := npmPack(context.Background(), t.TempDir(), filepath.Join(t.TempDir(), "packed")); err == nil || !strings.Contains(err.Error(), "did not produce") {
+		t.Fatalf("expected missing npm pack filename error, got %v", err)
 	}
 
 	t.Setenv("NPM_FAKE_MODE", "fail")


### PR DESCRIPTION
Use npm pack structured JSON output instead of parsing human-readable notices. Stdout is parsed as a single package result with a `.tgz` filename, while stderr remains diagnostic-only. Tests cover stderr notices, valid JSON, invalid JSON, missing filenames, empty output, and command failures.\n\nTests:\n- `go test ./internal/packageimport`\n- `go test ./internal/...`\n\nUnblocks #432.