### PR TITLE
fix: preserve Hillstone request and endpoint compatibility

### DIFF
--- a/services/hillstone__waf_v5-5-r12/config.schema.json
+++ b/services/hillstone__waf_v5-5-r12/config.schema.json
@@ -5,10 +5,10 @@
   "properties": {
     "host": { "type": "string", "minLength": 1 },
     "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 443 },
-    "protocol": { "type": "string", "enum": ["http", "https"], "default": "https" },
+    "protocol": { "type": "string", "enum": ["https", "http"], "default": "https" },
     "timeoutMs": { "type": "integer", "minimum": 1, "maximum": 120000, "default": 5000 },
     "skipTlsVerify": { "type": "boolean", "default": false },
     "lang": { "type": "string", "default": "zh_CN" }
   },
-  "required": ["host", "protocol"]
+  "required": ["host"]
 }

--- a/services/hillstone__waf_v5-5-r12/src/client.js
+++ b/services/hillstone__waf_v5-5-r12/src/client.js
@@ -16,18 +16,20 @@ function baseUrl(ctx) {
   const host = String(ctx?.bindings?.host || '').trim();
   if (!host) throw invalidArgument('host is required');
   if (/[/\\@?#\s]/.test(host)) throw invalidArgument('host must be a hostname or IP address');
-  const protocol = String(ctx?.bindings?.protocol || 'https').toLowerCase();
+  const configuredProtocol = String(ctx?.bindings?.protocol || '').toLowerCase();
+  const parseProtocol = configuredProtocol || 'https';
+  const protocol = configuredProtocol || (/^(?:127\.0\.0\.1|localhost|\[::1\])(?::\d+)?$/i.test(host) ? 'http' : 'https');
   if (protocol !== 'https' && protocol !== 'http') throw invalidArgument('protocol must be http or https');
   let parsed;
   try {
-    parsed = new URL(`${protocol}://${host}`);
+    parsed = new URL(`${parseProtocol}://${host}`);
   } catch {
     throw invalidArgument('host must be a hostname or IP address');
   }
   if (!parsed.hostname || parsed.username || parsed.password) throw invalidArgument('host must be a hostname or IP address');
   const port = Number(parsed.port || ctx?.bindings?.port || (protocol === 'https' ? 443 : 80));
   if (!Number.isInteger(port) || port < 1 || port > 65535) throw invalidArgument('port must be between 1 and 65535');
-  return `${protocol}://${parsed.hostname.includes(':') ? `[${parsed.hostname}]` : parsed.hostname}:${port}`;
+  return `${protocol}://${parsed.hostname}:${port}`;
 }
 
 function timeoutMs(ctx) {
@@ -50,7 +52,7 @@ function shouldSkipTlsVerify(ctx) {
 
 function mapPayload(input) {
   if (!input) return {};
-  if (input.request && typeof input.request === 'object' && input.request.fields) return structToPlain(input.request);
+  if (input.request && typeof input.request === 'object') return input.request.fields ? structToPlain(input.request) : input.request;
   if (input.fields && typeof input.fields === 'object') return structToPlain(input);
   if (input.payload && typeof input.payload === 'object' && input.payload.fields) return structToPlain(input.payload);
   return input;
@@ -215,7 +217,7 @@ async function login(ctx, input = {}) {
   validateLoginSource(source);
   if (source.apiToken) {
     const payload = await send(ctx, 'POST', '/rest/api/login', { body: { api_token: source.apiToken } });
-    return normalizeSession(payload, source.username);
+    return normalizeSession({ ...payload, phpSessionId: payload?.__meta?.phpSessionId || '' }, source.username);
   }
   const payload = await send(ctx, 'POST', '/rest/api/login', {
     body: {

--- a/services/hillstone__waf_v5-5-r12/test/hillstone-waf-v5-5-r12.test.js
+++ b/services/hillstone__waf_v5-5-r12/test/hillstone-waf-v5-5-r12.test.js
@@ -260,15 +260,15 @@ test('all public RPC handlers reach their documented upstream endpoint', async (
 
 test('handlers support the SDK 0.6 single-context ABI', async () => {
   const fetch = createFetchMock();
-  fetch.queueJson({ result: [{ token: 'token-1', username: 'hillstone' }], success: true });
   fetch.queueJson({ result: [], success: true });
   const result = await handlers[METHOD_LIST_WEBSITES_FULL]({
-    request: {},
+    request: { token: 'request-token', username: 'request-user' },
     config: { host: 'waf.local', protocol: 'https', port: 443, fetch },
     secret: { username: 'hillstone', password: 'secret' },
   });
   assert.equal(result.success, true);
-  fetch.assertCall(1, 'GET', '/rest/api/website');
+  fetch.assertCall(0, 'GET', '/rest/api/website');
+  assert.equal(fetch.calls[0].init.headers['X-Auth-Token'], 'request-token');
 });
 
 test('cookie values are encoded and multiple Set-Cookie values preserve PHP session', async () => {
@@ -323,10 +323,24 @@ test('HTTP, network, timeout, response size, and upstream errors are sanitized',
 
 test('API token login sends only the configured token', async () => {
   const fetch = createFetchMock();
-  fetch.queueJson({ token: 'session-token', username: 'api', success: true });
+  fetch.queueJson({ token: 'session-token', username: 'api', success: true }, 200, { 'set-cookie': 'PHPSESSID=api-session; Secure' });
   const result = await handlers[METHOD_LOGIN_FULL]({}, buildCtx({ bindings: { fetch }, secrets: { username: '', password: '', apiToken: 'api-secret' } }));
   assert.deepEqual(JSON.parse(fetch.calls[0].init.body), { api_token: 'api-secret' });
   assert.equal(result.result[0].token, 'session-token');
+  assert.equal(result.result[0].phpSessionId, 'api-session');
+});
+
+test('embedded ports, local smoke defaults, and IPv6 hosts produce valid URLs', async () => {
+  for (const [bindings, expected] of [
+    [{ host: 'waf.example:8443', protocol: 'https' }, 'https://waf.example:8443/rest/api/sysinfo'],
+    [{ host: '127.0.0.1:4567' }, 'http://127.0.0.1:4567/rest/api/sysinfo'],
+    [{ host: '[::1]:8443', protocol: 'https' }, 'https://[::1]:8443/rest/api/sysinfo'],
+  ]) {
+    const fetch = createFetchMock();
+    fetch.queueJson({ success: true });
+    await send({ bindings: { ...bindings, fetch } }, 'GET', '/rest/api/sysinfo');
+    assert.equal(fetch.calls[0].url, expected);
+  }
 });
 
 test('payload conversion and session normalization cover protobuf shapes', () => {


### PR DESCRIPTION
Follow-up to #396 after four valid post-merge monkeyscan findings.\n\n- unwrap ordinary SDK 0.6 `ctx.request` objects so request fields are preserved and config/secrets cannot become an upstream body\n- retain `PHPSESSID` returned by API-token login\n- keep `protocol` optional for existing instances while defaulting non-local endpoints to HTTPS\n- generate valid URLs for embedded ports and IPv6 literals\n- add regression tests for all four paths\n\nValidation: focused Service L2 gate passes with 24/24 tests, 97.15% line / 81.02% branch / 96.61% function coverage, package validation/pack/build, and Connect/gRPC/MCP smoke all reaching the mock upstream.