### PR TITLE
Stop supervisor processes on daemon shutdown

### DIFF
--- a/cmd/octobus/main.go
+++ b/cmd/octobus/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"octobus/internal/accesslog"
 	"octobus/internal/admin"
@@ -134,6 +135,7 @@ func serve(opts serveOptions) error {
 			logger.Info("daemon_shutdown_started")
 			grpcServer.GracefulStop()
 			_ = gateway.Close()
+			shutdownSupervisor(logger, sup)
 			logger.Info("daemon_shutdown_done")
 			return err
 		}
@@ -142,10 +144,19 @@ func serve(opts serveOptions) error {
 		_ = publicServer.Shutdown(context.Background())
 		grpcServer.GracefulStop()
 		_ = gateway.Close()
+		shutdownSupervisor(logger, sup)
 		<-serverErr
 		logger.Info("daemon_shutdown_done")
 	}
 	return nil
+}
+
+func shutdownSupervisor(logger *slog.Logger, sup *supervisor.Supervisor) {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := sup.Shutdown(shutdownCtx); err != nil {
+		logger.Warn("daemon_supervisor_shutdown_failed", "error", err)
+	}
 }
 
 func logStartupInventory(ctx context.Context, logger *slog.Logger, st *store.Store) error {

--- a/cmd/octobus/main.go
+++ b/cmd/octobus/main.go
@@ -63,10 +63,11 @@ func newServeCommand(addr *string) *cobra.Command {
 }
 
 type serveOptions struct {
-	dataDir string
-	addr    string
-	stderr  io.Writer
-	logger  *slog.Logger
+	dataDir          string
+	addr             string
+	stderr           io.Writer
+	logger           *slog.Logger
+	startupInventory func(context.Context, *slog.Logger, *store.Store) error
 }
 
 func serve(opts serveOptions) error {
@@ -104,11 +105,24 @@ func serve(opts serveOptions) error {
 	defer stop()
 	logger.Info("recover_enabled_started")
 	recovered, err := sup.RecoverEnabled(ctx)
+	supervisorShutdownNeeded := true
+	shutdownSupervisorOnce := func() {
+		if !supervisorShutdownNeeded {
+			return
+		}
+		supervisorShutdownNeeded = false
+		shutdownSupervisor(logger, sup)
+	}
+	defer shutdownSupervisorOnce()
 	if err != nil {
 		logger.Warn("recover_enabled_failed", "error", err)
 	}
 	logger.Info("recover_enabled_done", "count", recovered)
-	if err := logStartupInventory(ctx, logger, st); err != nil {
+	startupInventory := logStartupInventory
+	if opts.startupInventory != nil {
+		startupInventory = opts.startupInventory
+	}
+	if err := startupInventory(ctx, logger, st); err != nil {
 		return err
 	}
 	adminServer := &admin.Server{Store: st, Importer: &packageimport.Importer{DataDir: dataDir, Store: st}, Supervisor: sup, Gateway: gateway, AccessLogPath: filepath.Join(dataDir, accesslog.FileName), Logger: logger}
@@ -135,7 +149,7 @@ func serve(opts serveOptions) error {
 			logger.Info("daemon_shutdown_started")
 			grpcServer.GracefulStop()
 			_ = gateway.Close()
-			shutdownSupervisor(logger, sup)
+			shutdownSupervisorOnce()
 			logger.Info("daemon_shutdown_done")
 			return err
 		}
@@ -144,7 +158,7 @@ func serve(opts serveOptions) error {
 		_ = publicServer.Shutdown(context.Background())
 		grpcServer.GracefulStop()
 		_ = gateway.Close()
-		shutdownSupervisor(logger, sup)
+		shutdownSupervisorOnce()
 		<-serverErr
 		logger.Info("daemon_shutdown_done")
 	}

--- a/cmd/octobus/main_test.go
+++ b/cmd/octobus/main_test.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -18,7 +21,19 @@ import (
 	"octobus/internal/cli"
 	"octobus/internal/domain"
 	"octobus/internal/store"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
 )
+
+func TestMain(m *testing.M) {
+	if os.Getenv("OCTOBUS_CMD_HELPER") == "1" {
+		runCmdHelper()
+		return
+	}
+	os.Exit(m.Run())
+}
 
 func TestRootAddrFlagOverridesAdminCommands(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -52,6 +67,44 @@ func TestServeReturnsPublicBindError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "address already in use") {
 		t.Fatalf("expected public bind error, got %v", err)
 	}
+}
+
+func TestServeShutsDownRecoveredInstancesWhenPublicBindFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("helper process fixture")
+	}
+	dataDir, instanceID := setupServeRecoverFixture(t)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	err = serve(serveOptions{dataDir: dataDir, addr: ln.Addr().String()})
+	if err == nil || !strings.Contains(err.Error(), "address already in use") {
+		t.Fatalf("expected public bind error, got %v", err)
+	}
+	assertRecoveredInstanceStopped(t, dataDir, instanceID)
+}
+
+func TestServeShutsDownRecoveredInstancesWhenStartupInventoryFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("helper process fixture")
+	}
+	dataDir, instanceID := setupServeRecoverFixture(t)
+	inventoryErr := errors.New("startup inventory failed")
+
+	err := serve(serveOptions{
+		dataDir: dataDir,
+		addr:    "127.0.0.1:0",
+		startupInventory: func(context.Context, *slog.Logger, *store.Store) error {
+			return inventoryErr
+		},
+	})
+	if !errors.Is(err, inventoryErr) {
+		t.Fatalf("expected startup inventory error, got %v", err)
+	}
+	assertRecoveredInstanceStopped(t, dataDir, instanceID)
 }
 
 func TestRunReturnsCommandError(t *testing.T) {
@@ -265,4 +318,114 @@ func waitForHTTP(t *testing.T, url string) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatalf("server did not become ready at %s", url)
+}
+
+func setupServeRecoverFixture(t *testing.T) (string, string) {
+	t.Helper()
+	dataDir := filepath.Join(t.TempDir(), "data")
+	st, err := store.Open(filepath.Join(dataDir, "octobus.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ctx := context.Background()
+	serviceRuntime := filepath.Join(dataDir, "artifacts/services/echo/runtime")
+	if err := os.MkdirAll(serviceRuntime, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entry := "fixture-entry"
+	if err := writeCmdHelperEntry(filepath.Join(serviceRuntime, entry)); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertService(ctx, domain.Service{
+		ID:                "echo",
+		Name:              "Echo",
+		PackageSource:     "fixture",
+		PackageSHA256:     "pkgsha",
+		DescriptorPath:    "desc",
+		DescriptorSHA256:  "descsha",
+		DescriptorVersion: "descsha",
+		NodeEntry:         entry,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	instanceID := "echo-test"
+	if err := st.UpsertInstance(ctx, domain.Instance{
+		ID:         instanceID,
+		ServiceID:  "echo",
+		Name:       "Echo Test",
+		Enabled:    true,
+		Status:     domain.StatusStopped,
+		NodeEntry:  entry,
+		ConfigJSON: json.RawMessage(`{}`),
+		SecretJSON: json.RawMessage(`{}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return dataDir, instanceID
+}
+
+func writeCmdHelperEntry(path string) error {
+	body := fmt.Sprintf("#!/bin/sh\nexec env OCTOBUS_CMD_HELPER=1 %q -test.run=TestMain -- \"$@\"\n", os.Args[0])
+	return os.WriteFile(path, []byte(body), 0o755)
+}
+
+func assertRecoveredInstanceStopped(t *testing.T, dataDir, instanceID string) {
+	t.Helper()
+	st, err := store.Open(filepath.Join(dataDir, "octobus.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	inst, err := st.GetInstance(context.Background(), instanceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inst.Enabled || inst.Status != domain.StatusStopped || inst.PID != nil || inst.ListenAddr != "" {
+		t.Fatalf("recovered instance was not stopped cleanly: %+v", inst)
+	}
+}
+
+func runCmdHelper() {
+	args := os.Args
+	sep := 0
+	for i, arg := range args {
+		if arg == "--" {
+			sep = i
+			break
+		}
+	}
+	if sep == 0 {
+		os.Exit(2)
+	}
+	port := ""
+	if sep+2 >= len(args) || args[sep+1] != "--runtime" || args[sep+2] != "serve" {
+		os.Exit(2)
+	}
+	for i := sep + 1; i < len(args)-1; i++ {
+		if args[i] == "--port" {
+			port = args[i+1]
+			break
+		}
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		os.Exit(2)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		os.Exit(2)
+	}
+	srv := grpc.NewServer()
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(srv, healthServer)
+	go func() {
+		_ = srv.Serve(ln)
+	}()
+	waitForInterrupt()
+	srv.Stop()
+}
+
+func waitForInterrupt() {
+	select {}
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -25,6 +25,8 @@ import (
 
 var ErrUnsupportedRuntimeControl = errors.New("on-demand runtime mode does not support persistent runtime control")
 
+var errProcessStopTimeout = errors.New("process stop timed out")
+
 type Supervisor struct {
 	DataDir           string
 	Store             *store.Store
@@ -205,9 +207,11 @@ func (s *Supervisor) Start(ctx context.Context, instanceID string) error {
 }
 
 func (s *Supervisor) startWithAttempt(ctx context.Context, instanceID string, restartAttempt int, generation int64) error {
-	if err := s.lifecycleErr(); err != nil {
+	ctx, finishOperation, err := s.beginOperation(ctx)
+	if err != nil {
 		return err
 	}
+	defer finishOperation()
 	inst, err := s.Store.GetInstance(ctx, instanceID)
 	if err != nil {
 		return err
@@ -309,14 +313,19 @@ func (s *Supervisor) startWithAttempt(ctx context.Context, instanceID string, re
 	if err := s.lifecycleErrLocked(); err != nil {
 		s.mu.Unlock()
 		s.cleanupFailedStart(instanceID, state, stdout, stderr)
+		_ = s.persistStoppedInstance(ctx, inst, true)
 		startErr = err
 		return err
 	}
 	s.procs[instanceID] = state
 	s.mu.Unlock()
 	if err := waitHealth(ctx, addr, 5*time.Second); err != nil {
-		inst.Status = domain.StatusFailed
-		_ = s.Store.UpsertInstance(ctx, inst)
+		if ctx.Err() != nil && s.lifecycleErr() != nil {
+			_ = s.persistStoppedInstance(ctx, inst, true)
+		} else {
+			inst.Status = domain.StatusFailed
+			_ = s.Store.UpsertInstance(ctx, inst)
+		}
 		s.cleanupFailedStart(instanceID, state, stdout, stderr)
 		logger.Warn("instance_health_failed", "instance_id", instanceID, "listen_addr", addr, "error", err)
 		startErr = err
@@ -327,12 +336,14 @@ func (s *Supervisor) startWithAttempt(ctx context.Context, instanceID string, re
 	if s.procs[instanceID] != state {
 		s.mu.Unlock()
 		s.cleanupFailedStart(instanceID, state, stdout, stderr)
+		_ = s.persistStoppedInstance(ctx, inst, true)
 		startErr = context.Canceled
 		return startErr
 	}
 	if err := s.lifecycleErrLocked(); err != nil {
 		s.mu.Unlock()
 		s.cleanupFailedStart(instanceID, state, stdout, stderr)
+		_ = s.persistStoppedInstance(ctx, inst, true)
 		startErr = err
 		return err
 	}
@@ -409,24 +420,23 @@ func (s *Supervisor) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	for _, id := range sortedKeys(ids) {
+	errs = append(errs, RunBounded(sortedKeys(ids), 4, func(id string) error {
 		inst, getErr := s.Store.GetInstance(ctx, id)
 		if getErr != nil {
-			errs = append(errs, fmt.Errorf("%s: get instance for supervisor shutdown: %w", id, getErr))
-			continue
+			return fmt.Errorf("%s: get instance for supervisor shutdown: %w", id, getErr)
 		}
 		svc, getErr := s.Store.GetService(ctx, inst.ServiceID)
 		if getErr != nil {
-			errs = append(errs, fmt.Errorf("%s: get service for supervisor shutdown: %w", id, getErr))
-			continue
+			return fmt.Errorf("%s: get service for supervisor shutdown: %w", id, getErr)
 		}
 		if svc.RuntimeMode != domain.RuntimeModeLongRunning {
-			continue
+			return nil
 		}
 		if err := s.stopProcess(ctx, inst, inst.Enabled); err != nil {
-			errs = append(errs, fmt.Errorf("%s: stop process for supervisor shutdown: %w", id, err))
+			return fmt.Errorf("%s: stop process for supervisor shutdown: %w", id, err)
 		}
-	}
+		return nil
+	})...)
 
 	done := make(chan struct{})
 	go func() {
@@ -511,6 +521,9 @@ func (s *Supervisor) rejectOnDemandRuntimeControl(ctx context.Context, serviceID
 }
 
 func (s *Supervisor) stopProcess(ctx context.Context, inst domain.Instance, enabled bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	logger := s.logger()
 	logger.Info("instance_stopping", "instance_id", inst.ID)
 	inst.Enabled = enabled
@@ -522,25 +535,25 @@ func (s *Supervisor) stopProcess(ctx context.Context, inst domain.Instance, enab
 	state := s.procs[inst.ID]
 	delete(s.procs, inst.ID)
 	s.mu.Unlock()
+	var stopErr error
 	if state != nil && state.cmd.Process != nil {
 		_ = state.cmd.Process.Signal(os.Interrupt)
-		select {
-		case <-state.done:
-		case <-time.After(2 * time.Second):
+		if err := waitProcessDone(ctx, state.done, 2*time.Second); err != nil {
 			_ = state.cmd.Process.Kill()
-			select {
-			case <-state.done:
-			case <-time.After(2 * time.Second):
+			if killErr := waitProcessDone(ctx, state.done, 2*time.Second); killErr != nil {
+				stopErr = killErr
+			} else if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				stopErr = err
 			}
 		}
 	}
-	if err := s.Store.UpsertInstance(ctx, inst); err != nil {
+	if err := s.persistStoppedInstance(ctx, inst, enabled); err != nil {
 		logger.Error("instance_stop_failed", "instance_id", inst.ID, "error", err)
-		return err
+		return errors.Join(stopErr, err)
 	}
 	s.notifyInstanceChanged(inst.ID)
 	logger.Info("instance_stopped", "instance_id", inst.ID)
-	return nil
+	return stopErr
 }
 
 func (s *Supervisor) RecoverEnabled(ctx context.Context) (int, error) {
@@ -738,6 +751,40 @@ func (s *Supervisor) generationMatches(instanceID string, generation int64) bool
 	return s.generations[instanceID] == generation
 }
 
+func (s *Supervisor) beginOperation(ctx context.Context) (context.Context, func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.mu.Lock()
+	if err := s.lifecycleErrLocked(); err != nil {
+		s.mu.Unlock()
+		return nil, nil, err
+	}
+	lifecycleCtx := s.lifecycleCtx
+	if lifecycleCtx == nil {
+		lifecycleCtx = context.Background()
+	}
+	opCtx, cancel := context.WithCancel(ctx)
+	s.wg.Add(1)
+	s.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		select {
+		case <-lifecycleCtx.Done():
+			cancel()
+		case <-opCtx.Done():
+		}
+	}()
+	finish := func() {
+		cancel()
+		<-done
+		s.wg.Done()
+	}
+	return opCtx, finish, nil
+}
+
 func (s *Supervisor) lifecycleContext() context.Context {
 	if s.lifecycleCtx == nil {
 		return context.Background()
@@ -763,6 +810,39 @@ func (s *Supervisor) backoff(attempt int) time.Duration {
 		return backoff(attempt)
 	}
 	return s.restartDelay(attempt)
+}
+
+func (s *Supervisor) persistStoppedInstance(ctx context.Context, inst domain.Instance, enabled bool) error {
+	inst.Enabled = enabled
+	inst.Status = domain.StatusStopped
+	inst.PID = nil
+	inst.ListenAddr = ""
+	storeCtx := ctx
+	if storeCtx == nil {
+		storeCtx = context.Background()
+	}
+	if storeCtx.Err() != nil {
+		var cancel context.CancelFunc
+		storeCtx, cancel = context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+	}
+	return s.Store.UpsertInstance(storeCtx, inst)
+}
+
+func waitProcessDone(ctx context.Context, done <-chan struct{}, timeout time.Duration) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return errProcessStopTimeout
+	}
 }
 
 func shouldStopOnShutdown(inst domain.Instance, svc domain.Service) bool {
@@ -832,6 +912,9 @@ func waitHealth(ctx context.Context, addr string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("instance health check failed at %s: %w", addr, err)
+		}
 		attemptCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err == nil {
@@ -847,6 +930,9 @@ func waitHealth(ctx context.Context, addr string, timeout time.Duration) error {
 			lastErr = err
 		}
 		cancel()
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("instance health check failed at %s: %w", addr, err)
+		}
 		time.Sleep(100 * time.Millisecond)
 	}
 	if lastErr == nil {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -33,6 +34,11 @@ type Supervisor struct {
 	mu          sync.Mutex
 	procs       map[string]*processState
 	generations map[string]int64
+
+	lifecycleCtx    context.Context
+	lifecycleCancel context.CancelFunc
+	wg              sync.WaitGroup
+	restartDelay    func(int) time.Duration
 }
 
 type processState struct {
@@ -55,7 +61,17 @@ func New(dataDir string, st *store.Store) *Supervisor {
 	if abs, err := filepath.Abs(dataDir); err == nil {
 		dataDir = abs
 	}
-	return &Supervisor{DataDir: dataDir, Store: st, Logger: daemonlog.Nop(), procs: map[string]*processState{}, generations: map[string]int64{}}
+	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
+	return &Supervisor{
+		DataDir:         dataDir,
+		Store:           st,
+		Logger:          daemonlog.Nop(),
+		procs:           map[string]*processState{},
+		generations:     map[string]int64{},
+		lifecycleCtx:    lifecycleCtx,
+		lifecycleCancel: lifecycleCancel,
+		restartDelay:    backoff,
+	}
 }
 
 func (s *Supervisor) CreateInstance(ctx context.Context, req CreateInstanceRequest) (domain.Instance, error) {
@@ -189,6 +205,9 @@ func (s *Supervisor) Start(ctx context.Context, instanceID string) error {
 }
 
 func (s *Supervisor) startWithAttempt(ctx context.Context, instanceID string, restartAttempt int, generation int64) error {
+	if err := s.lifecycleErr(); err != nil {
+		return err
+	}
 	inst, err := s.Store.GetInstance(ctx, instanceID)
 	if err != nil {
 		return err
@@ -285,8 +304,14 @@ func (s *Supervisor) startWithAttempt(ctx context.Context, instanceID string, re
 		return err
 	}
 	logger.Info("instance_started", "instance_id", instanceID, "pid", pid, "listen_addr", addr)
-	s.mu.Lock()
 	state := &processState{cmd: cmd, done: make(chan struct{}), attempt: restartAttempt, generation: generation}
+	s.mu.Lock()
+	if err := s.lifecycleErrLocked(); err != nil {
+		s.mu.Unlock()
+		s.cleanupFailedStart(instanceID, state, stdout, stderr)
+		startErr = err
+		return err
+	}
 	s.procs[instanceID] = state
 	s.mu.Unlock()
 	if err := waitHealth(ctx, addr, 5*time.Second); err != nil {
@@ -298,8 +323,26 @@ func (s *Supervisor) startWithAttempt(ctx context.Context, instanceID string, re
 		return err
 	}
 	logger.Info("instance_health_ready", "instance_id", instanceID, "listen_addr", addr)
+	s.mu.Lock()
+	if s.procs[instanceID] != state {
+		s.mu.Unlock()
+		s.cleanupFailedStart(instanceID, state, stdout, stderr)
+		startErr = context.Canceled
+		return startErr
+	}
+	if err := s.lifecycleErrLocked(); err != nil {
+		s.mu.Unlock()
+		s.cleanupFailedStart(instanceID, state, stdout, stderr)
+		startErr = err
+		return err
+	}
+	s.wg.Add(1)
+	s.mu.Unlock()
 	s.notifyInstanceChanged(instanceID)
-	go s.wait(instanceID, state, stdout, stderr)
+	go func() {
+		defer s.wg.Done()
+		s.wait(instanceID, state, stdout, stderr)
+	}()
 	return nil
 }
 
@@ -327,6 +370,81 @@ func (s *Supervisor) Stop(ctx context.Context, instanceID string) error {
 		return err
 	}
 	return s.stopProcess(ctx, inst, false)
+}
+
+func (s *Supervisor) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	logger := s.logger()
+	logger.Info("supervisor_shutdown_started")
+	ids := map[string]struct{}{}
+	s.mu.Lock()
+	if s.lifecycleCancel != nil {
+		s.lifecycleCancel()
+	}
+	for id := range s.procs {
+		ids[id] = struct{}{}
+	}
+	for id := range s.generations {
+		ids[id] = struct{}{}
+		s.nextGenerationLocked(id)
+	}
+	s.mu.Unlock()
+
+	instances, err := s.Store.ListInstances(ctx)
+	var errs []error
+	if err != nil {
+		errs = append(errs, fmt.Errorf("list instances for supervisor shutdown: %w", err))
+	} else {
+		for _, inst := range instances {
+			svc, getErr := s.Store.GetService(ctx, inst.ServiceID)
+			if getErr != nil {
+				errs = append(errs, fmt.Errorf("%s: get service for supervisor shutdown: %w", inst.ID, getErr))
+				continue
+			}
+			if shouldStopOnShutdown(inst, svc) {
+				ids[inst.ID] = struct{}{}
+			}
+		}
+	}
+
+	for _, id := range sortedKeys(ids) {
+		inst, getErr := s.Store.GetInstance(ctx, id)
+		if getErr != nil {
+			errs = append(errs, fmt.Errorf("%s: get instance for supervisor shutdown: %w", id, getErr))
+			continue
+		}
+		svc, getErr := s.Store.GetService(ctx, inst.ServiceID)
+		if getErr != nil {
+			errs = append(errs, fmt.Errorf("%s: get service for supervisor shutdown: %w", id, getErr))
+			continue
+		}
+		if svc.RuntimeMode != domain.RuntimeModeLongRunning {
+			continue
+		}
+		if err := s.stopProcess(ctx, inst, inst.Enabled); err != nil {
+			errs = append(errs, fmt.Errorf("%s: stop process for supervisor shutdown: %w", id, err))
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		errs = append(errs, ctx.Err())
+	}
+	err = errors.Join(errs...)
+	if err != nil {
+		logger.Warn("supervisor_shutdown_failed", "error", err)
+		return err
+	}
+	logger.Info("supervisor_shutdown_done")
+	return nil
 }
 
 func (s *Supervisor) Restart(ctx context.Context, instanceID string) error {
@@ -398,6 +516,7 @@ func (s *Supervisor) stopProcess(ctx context.Context, inst domain.Instance, enab
 	inst.Enabled = enabled
 	inst.Status = domain.StatusStopped
 	inst.PID = nil
+	inst.ListenAddr = ""
 	s.mu.Lock()
 	s.nextGenerationLocked(inst.ID)
 	state := s.procs[inst.ID]
@@ -534,9 +653,12 @@ func (s *Supervisor) wait(instanceID string, state *processState, stdout, stderr
 		delete(s.procs, instanceID)
 	}
 	s.mu.Unlock()
-	ctx := context.Background()
+	ctx := s.lifecycleContext()
+	if ctx.Err() != nil {
+		return
+	}
 	inst, getErr := s.Store.GetInstance(ctx, instanceID)
-	if getErr != nil || !inst.Enabled || current != state {
+	if getErr != nil || !inst.Enabled || current != state || ctx.Err() != nil {
 		return
 	}
 	s.logger().Warn("instance_exited", "instance_id", instanceID, "pid", processPID(state.cmd), "attempt", state.attempt+1, "error", err)
@@ -546,7 +668,7 @@ func (s *Supervisor) wait(instanceID string, state *processState, stdout, stderr
 		_ = s.Store.UpsertInstance(ctx, inst)
 		s.notifyInstanceChanged(instanceID)
 		s.logger().Warn("instance_degraded", "instance_id", instanceID, "attempt", state.attempt+1)
-		go s.restartAfterBackoff(instanceID, state.attempt+1, state.generation)
+		s.scheduleRestartAfterBackoff(instanceID, state.attempt+1, state.generation)
 		return
 	}
 	inst.Status = domain.StatusDegraded
@@ -554,23 +676,43 @@ func (s *Supervisor) wait(instanceID string, state *processState, stdout, stderr
 	_ = s.Store.UpsertInstance(ctx, inst)
 	s.notifyInstanceChanged(instanceID)
 	s.logger().Warn("instance_degraded", "instance_id", instanceID, "attempt", state.attempt+1)
-	go s.restartAfterBackoff(instanceID, state.attempt+1, state.generation)
+	s.scheduleRestartAfterBackoff(instanceID, state.attempt+1, state.generation)
+}
+
+func (s *Supervisor) scheduleRestartAfterBackoff(instanceID string, attempt int, generation int64) {
+	s.mu.Lock()
+	if err := s.lifecycleErrLocked(); err != nil {
+		s.mu.Unlock()
+		return
+	}
+	s.wg.Add(1)
+	s.mu.Unlock()
+	go func() {
+		defer s.wg.Done()
+		s.restartAfterBackoff(instanceID, attempt, generation)
+	}()
 }
 
 func (s *Supervisor) restartAfterBackoff(instanceID string, attempt int, generation int64) {
-	delay := backoff(attempt)
+	ctx := s.lifecycleContext()
+	delay := s.backoff(attempt)
 	s.logger().Warn("instance_restart_scheduled", "instance_id", instanceID, "attempt", attempt+1, "delay", delay.String())
-	time.Sleep(delay)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return
+	case <-timer.C:
+	}
 	if !s.generationMatches(instanceID, generation) {
 		return
 	}
-	ctx := context.Background()
 	inst, err := s.Store.GetInstance(ctx, instanceID)
 	if err != nil || !inst.Enabled {
 		return
 	}
 	if err := s.startWithAttempt(ctx, instanceID, attempt, generation); err != nil {
-		if !s.generationMatches(instanceID, generation) {
+		if ctx.Err() != nil || !s.generationMatches(instanceID, generation) {
 			return
 		}
 		s.logger().Warn("instance_degraded", "instance_id", instanceID, "attempt", attempt+1)
@@ -578,7 +720,7 @@ func (s *Supervisor) restartAfterBackoff(instanceID string, attempt int, generat
 		inst.PID = nil
 		_ = s.Store.UpsertInstance(ctx, inst)
 		s.notifyInstanceChanged(instanceID)
-		go s.restartAfterBackoff(instanceID, attempt+1, generation)
+		s.scheduleRestartAfterBackoff(instanceID, attempt+1, generation)
 	}
 }
 
@@ -594,6 +736,55 @@ func (s *Supervisor) generationMatches(instanceID string, generation int64) bool
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.generations[instanceID] == generation
+}
+
+func (s *Supervisor) lifecycleContext() context.Context {
+	if s.lifecycleCtx == nil {
+		return context.Background()
+	}
+	return s.lifecycleCtx
+}
+
+func (s *Supervisor) lifecycleErr() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lifecycleErrLocked()
+}
+
+func (s *Supervisor) lifecycleErrLocked() error {
+	if s.lifecycleCtx == nil {
+		return nil
+	}
+	return s.lifecycleCtx.Err()
+}
+
+func (s *Supervisor) backoff(attempt int) time.Duration {
+	if s.restartDelay == nil {
+		return backoff(attempt)
+	}
+	return s.restartDelay(attempt)
+}
+
+func shouldStopOnShutdown(inst domain.Instance, svc domain.Service) bool {
+	if svc.RuntimeMode != domain.RuntimeModeLongRunning {
+		return false
+	}
+	if inst.PID != nil {
+		return true
+	}
+	if !inst.Enabled {
+		return false
+	}
+	return inst.Status == domain.StatusStarting || inst.Status == domain.StatusRunning || inst.Status == domain.StatusDegraded || inst.Status == domain.StatusFailed
+}
+
+func sortedKeys(keys map[string]struct{}) []string {
+	out := make([]string, 0, len(keys))
+	for key := range keys {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func (s *Supervisor) notifyInstanceChanged(instanceID string) {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -385,6 +386,100 @@ func TestShutdownCancelsPendingAutoRestart(t *testing.T) {
 	}
 	if stopped.Status != domain.StatusStopped || stopped.PID != nil || stopped.ListenAddr != "" {
 		t.Fatalf("shutdown should cancel pending restart and leave no running process: %+v", stopped)
+	}
+}
+
+func TestShutdownWaitsForStartInProgress(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("helper process fixture is unix-oriented")
+	}
+	dataDir, st, entry := setupSupervisorHelperRuntimeWithEnv(t, "OCTOBUS_SUPERVISOR_HELPER_START_DELAY=1500ms")
+	ctx := context.Background()
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "echo-test", ServiceID: "echo", Name: "Echo Test", Enabled: false, Status: domain.StatusStopped, NodeEntry: entry, ConfigJSON: []byte(`{}`), SecretJSON: []byte(`{}`)}); err != nil {
+		t.Fatal(err)
+	}
+	sup := New(dataDir, st)
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- sup.Start(ctx, "echo-test")
+	}()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = sup.Shutdown(shutdownCtx)
+	})
+	eventually(t, 800*time.Millisecond, func() bool {
+		inst, err := st.GetInstance(ctx, "echo-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return inst.Status == domain.StatusRunning && inst.PID != nil
+	})
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := sup.Shutdown(shutdownCtx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-startErr:
+		if err == nil {
+			t.Fatal("in-progress start unexpectedly succeeded after shutdown")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("shutdown returned before in-progress start completed")
+	}
+	stopped, err := st.GetInstance(ctx, "echo-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stopped.Enabled || stopped.Status != domain.StatusStopped || stopped.PID != nil || stopped.ListenAddr != "" {
+		t.Fatalf("shutdown should clean up in-progress start: %+v", stopped)
+	}
+}
+
+func TestShutdownBoundsUnresponsiveProcessStopByContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("helper process fixture is unix-oriented")
+	}
+	dataDir, st, entry := setupSupervisorHelperRuntimeWithEnv(t, "OCTOBUS_SUPERVISOR_HELPER_IGNORE_INTERRUPT=1")
+	ctx := context.Background()
+	for _, id := range []string{"echo-a", "echo-b"} {
+		if err := st.UpsertInstance(ctx, domain.Instance{ID: id, ServiceID: "echo", Name: id, Enabled: false, Status: domain.StatusStopped, NodeEntry: entry, ConfigJSON: []byte(`{}`), SecretJSON: []byte(`{}`)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sup := New(dataDir, st)
+	for _, id := range []string{"echo-a", "echo-b"} {
+		if err := sup.Start(ctx, id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = sup.Shutdown(shutdownCtx)
+	})
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 700*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err := sup.Shutdown(shutdownCtx)
+	elapsed := time.Since(start)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("shutdown error=%v, want context deadline exceeded", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("shutdown ignored context budget, elapsed=%s", elapsed)
+	}
+	for _, id := range []string{"echo-a", "echo-b"} {
+		inst, err := st.GetInstance(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !inst.Enabled || inst.Status != domain.StatusStopped || inst.PID != nil || inst.ListenAddr != "" {
+			t.Fatalf("shutdown should persist stopped state for %s: %+v", id, inst)
+		}
 	}
 }
 
@@ -1314,12 +1409,17 @@ func TestBackoff(t *testing.T) {
 	}
 }
 
-func writeSupervisorHelperEntry(path string) error {
-	body := fmt.Sprintf("#!/bin/sh\nexec env OCTOBUS_SUPERVISOR_HELPER=1 %q -test.run=TestMain -- \"$@\"\n", os.Args[0])
+func writeSupervisorHelperEntry(path string, extraEnv ...string) error {
+	env := append([]string{"OCTOBUS_SUPERVISOR_HELPER=1"}, extraEnv...)
+	body := fmt.Sprintf("#!/bin/sh\nexec env %s %q -test.run=TestMain -- \"$@\"\n", strings.Join(env, " "), os.Args[0])
 	return os.WriteFile(path, []byte(body), 0o755)
 }
 
 func setupSupervisorHelperRuntime(t *testing.T) (string, *store.Store, string) {
+	return setupSupervisorHelperRuntimeWithEnv(t)
+}
+
+func setupSupervisorHelperRuntimeWithEnv(t *testing.T, extraEnv ...string) (string, *store.Store, string) {
 	t.Helper()
 	root := t.TempDir()
 	dataDir := filepath.Join(root, "data")
@@ -1334,7 +1434,7 @@ func setupSupervisorHelperRuntime(t *testing.T) (string, *store.Store, string) {
 		t.Fatal(err)
 	}
 	entry := "fixture-entry"
-	if err := writeSupervisorHelperEntry(filepath.Join(serviceRuntime, entry)); err != nil {
+	if err := writeSupervisorHelperEntry(filepath.Join(serviceRuntime, entry), extraEnv...); err != nil {
 		t.Fatal(err)
 	}
 	if err := st.UpsertService(ctx, domain.Service{ID: "echo", Name: "Echo", PackageSource: "fixture", PackageArtifactPath: "pkg", PackageSHA256: "pkgsha", DescriptorPath: "desc", DescriptorSHA256: "descsha", DescriptorVersion: "descsha", NodeEntry: entry}); err != nil {
@@ -1344,6 +1444,9 @@ func setupSupervisorHelperRuntime(t *testing.T) (string, *store.Store, string) {
 }
 
 func runSupervisorHelper() {
+	if os.Getenv("OCTOBUS_SUPERVISOR_HELPER_IGNORE_INTERRUPT") == "1" {
+		signal.Ignore(os.Interrupt)
+	}
 	args := os.Args
 	sep := 0
 	for i, arg := range args {
@@ -1367,6 +1470,13 @@ func runSupervisorHelper() {
 	}
 	if _, err := strconv.Atoi(port); err != nil {
 		os.Exit(2)
+	}
+	if raw := os.Getenv("OCTOBUS_SUPERVISOR_HELPER_START_DELAY"); raw != "" {
+		delay, err := time.ParseDuration(raw)
+		if err != nil {
+			os.Exit(2)
+		}
+		time.Sleep(delay)
 	}
 	ln, err := net.Listen("tcp", "127.0.0.1:"+port)
 	if err != nil {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -282,6 +283,109 @@ func TestKilledEnabledProcessAutoRecovers(t *testing.T) {
 	}
 	inst, _ := st.GetInstance(ctx, "echo-test")
 	t.Fatalf("killed process did not recover: before=%+v after=%+v", started, inst)
+}
+
+func TestShutdownStopsRunningProcessAndPreservesEnabledState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("helper process fixture is unix-oriented")
+	}
+	dataDir, st, entry := setupSupervisorHelperRuntime(t)
+	ctx := context.Background()
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "echo-test", ServiceID: "echo", Name: "Echo Test", Enabled: false, Status: domain.StatusStopped, NodeEntry: entry, ConfigJSON: []byte(`{}`), SecretJSON: []byte(`{}`)}); err != nil {
+		t.Fatal(err)
+	}
+	sup := New(dataDir, st)
+	if err := sup.Start(ctx, "echo-test"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = sup.Shutdown(shutdownCtx)
+	})
+	started, err := st.GetInstance(ctx, "echo-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if started.PID == nil {
+		t.Fatalf("started instance missing pid: %+v", started)
+	}
+	pid := *started.PID
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := sup.Shutdown(shutdownCtx); err != nil {
+		t.Fatal(err)
+	}
+	stopped, err := st.GetInstance(ctx, "echo-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stopped.Enabled || stopped.Status != domain.StatusStopped || stopped.PID != nil {
+		t.Fatalf("shutdown should stop process without disabling instance: %+v", stopped)
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := proc.Signal(syscall.Signal(0)); err == nil {
+		t.Fatalf("shutdown returned while child process %d was still alive", pid)
+	}
+}
+
+func TestShutdownCancelsPendingAutoRestart(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("helper process fixture is unix-oriented")
+	}
+	dataDir, st, entry := setupSupervisorHelperRuntime(t)
+	ctx := context.Background()
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "echo-test", ServiceID: "echo", Name: "Echo Test", Enabled: false, Status: domain.StatusStopped, NodeEntry: entry, ConfigJSON: []byte(`{}`), SecretJSON: []byte(`{}`)}); err != nil {
+		t.Fatal(err)
+	}
+	sup := New(dataDir, st)
+	if err := sup.Start(ctx, "echo-test"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = sup.Shutdown(shutdownCtx)
+	})
+	started, err := st.GetInstance(ctx, "echo-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if started.PID == nil {
+		t.Fatalf("started instance missing pid: %+v", started)
+	}
+	proc, err := os.FindProcess(*started.PID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := proc.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	eventually(t, 800*time.Millisecond, func() bool {
+		inst, err := st.GetInstance(ctx, "echo-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return inst.Status == domain.StatusDegraded && inst.PID == nil
+	})
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := sup.Shutdown(shutdownCtx); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(1200 * time.Millisecond)
+	stopped, err := st.GetInstance(ctx, "echo-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.Status != domain.StatusStopped || stopped.PID != nil || stopped.ListenAddr != "" {
+		t.Fatalf("shutdown should cancel pending restart and leave no running process: %+v", stopped)
+	}
 }
 
 func TestStartWithRelativeDataDirRequiresMatchingWorkingDirectory(t *testing.T) {
@@ -1281,6 +1385,20 @@ func runSupervisorHelper() {
 
 func waitForInterrupt() {
 	select {}
+}
+
+func eventually(t *testing.T, timeout time.Duration, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !fn() {
+		t.Fatalf("condition was not satisfied within %s", timeout)
+	}
 }
 
 func ptr[T any](v T) *T {


### PR DESCRIPTION
## 问题

OctoBus daemon 关闭时只收束 HTTP/gRPC/gateway 层，没有把 Supervisor 纳入 daemon 生命周期。Supervisor 管理的 long-running 实例子进程以及自动重启 goroutine 仍可能继续存在，导致 daemon 退出后出现子进程泄漏、pending restart 继续启动实例、store 中残留旧 PID/listen_addr 等状态不一致问题。

此外，在评审中发现 daemon 启动阶段也存在提前返回路径：`RecoverEnabled` 已经恢复并启动实例后，如果启动库存读取失败，或 public/admin 端口绑定失败，`serve` 会直接返回，导致刚恢复的子进程和 Running/PID/listen_addr 状态没有被清理。

## 分析

原实现中 `wait()` 和 `restartAfterBackoff()` 使用 `context.Background()` / `time.Sleep()` 驱动自动重启，缺少统一的生命周期取消信号。daemon shutdown 分支也没有调用 Supervisor 停止当前进程。因此即使 daemon 收到 SIGTERM 并关闭服务入口，Supervisor 仍没有机会：

- 停止已启动的 runtime 子进程；
- 取消等待中的 restart goroutine；
- 清理实例的 PID/listen_addr；
- 等待后台 goroutine 完整退出。

后续 review 进一步指出：daemon 启动时的顺序是 `sup.RecoverEnabled(ctx)` -> `logStartupInventory(...)` -> `net.Listen(...)`。一旦后两步失败，代码会跳过正常 shutdown select，因此同样需要纳入统一 cleanup。

## 优化方案

本 PR 将 Supervisor 纳入 daemon lifecycle：

- 为 Supervisor 增加 lifecycle context、cancel 和 WaitGroup。
- 新增 `Supervisor.Shutdown(ctx)`：
  - cancel lifecycle context，阻止后续自动重启；
  - 递增 generation，使旧 restart 任务失效；
  - 停止当前 long-running 子进程；
  - 保留实例 `Enabled` 状态，保证下次 daemon 启动仍可通过 `RecoverEnabled` 恢复；
  - 清理 `PID` 和 `ListenAddr`；
  - 等待已注册后台 goroutine 退出。
- 将 `restartAfterBackoff` 从不可取消的 `time.Sleep` 改为可被 lifecycle context 取消的 timer。
- daemon 的正常退出和 server error 退出路径都调用 `sup.Shutdown`，并设置 10s 超时。
- 在 `serve` 中增加一次性 Supervisor cleanup：只要执行过 `RecoverEnabled`，后续启动库存失败、端口绑定失败、server error、SIGTERM 都保证最多调用一次 `sup.Shutdown`，避免 early return 泄漏与重复关闭。

## 回归测试

新增测试覆盖：

- shutdown 会停止运行中的子进程且不禁用实例；
- shutdown 会取消崩溃后等待中的自动重启；
- shutdown 会等待 start in-progress，避免 start/Shutdown 竞态产生孤儿进程；
- shutdown 停止不响应 SIGINT 的进程时受 ctx deadline 约束；
- daemon 启动阶段 public/admin 端口绑定失败时，会停止 `RecoverEnabled` 启动的实例并保留 `Enabled`；
- daemon 启动库存读取失败时，同样会清理 recovered instance 状态。

## 验证

- `go test ./cmd/octobus -run 'TestServeShutsDownRecoveredInstancesWhen(PublicBindFails|StartupInventoryFails)'`
- `go test ./cmd/octobus`
- `go test ./internal/supervisor`

此前验证过：

- `go test ./internal/supervisor -run 'TestShutdown'`
- `go test ./internal/supervisor`
- `go test ./cmd/octobus`

`go test ./...` 在本地环境未全量通过，失败集中在缺少 `protoc` 和未构建的 `sdk/dist/cli.js`，与本次改动无关。
