### PR TITLE
release: bump OctoBus to v0.2.0

### DIFF
--- a/npm/octobus-darwin-arm64/package.json
+++ b/npm/octobus-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/octobus-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OctoBus binary for macOS arm64.",
   "license": "LGPL-3.0-only",
   "os": [

--- a/npm/octobus-darwin-x64/package.json
+++ b/npm/octobus-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/octobus-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OctoBus binary for macOS x64.",
   "license": "LGPL-3.0-only",
   "os": [

--- a/npm/octobus-linux-arm64/package.json
+++ b/npm/octobus-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/octobus-linux-arm64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OctoBus binary for Linux arm64.",
   "license": "LGPL-3.0-only",
   "os": [

--- a/npm/octobus-linux-x64/package.json
+++ b/npm/octobus-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/octobus-linux-x64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OctoBus binary for Linux x64.",
   "license": "LGPL-3.0-only",
   "os": [

--- a/npm/octobus-win32-arm64/package.json
+++ b/npm/octobus-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/octobus-win32-arm64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OctoBus binary for Windows arm64.",
   "license": "LGPL-3.0-only",
   "os": [

--- a/npm/octobus-win32-x64/package.json
+++ b/npm/octobus-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/octobus-win32-x64",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OctoBus binary for Windows x64.",
   "license": "LGPL-3.0-only",
   "os": [

--- a/npm/octobus/package.json
+++ b/npm/octobus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/octobus",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OctoBus local daemon and CLI.",
   "license": "GPL-3.0",
   "bin": {
@@ -29,12 +29,12 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@chaitin-ai/octobus-linux-x64": "0.1.0",
-    "@chaitin-ai/octobus-linux-arm64": "0.1.0",
-    "@chaitin-ai/octobus-darwin-x64": "0.1.0",
-    "@chaitin-ai/octobus-darwin-arm64": "0.1.0",
-    "@chaitin-ai/octobus-win32-x64": "0.1.0",
-    "@chaitin-ai/octobus-win32-arm64": "0.1.0"
+    "@chaitin-ai/octobus-linux-x64": "0.2.0",
+    "@chaitin-ai/octobus-linux-arm64": "0.2.0",
+    "@chaitin-ai/octobus-darwin-x64": "0.2.0",
+    "@chaitin-ai/octobus-darwin-arm64": "0.2.0",
+    "@chaitin-ai/octobus-win32-x64": "0.2.0",
+    "@chaitin-ai/octobus-win32-arm64": "0.2.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
统一 OctoBus 主包和六个平台 npm 包版本为 0.2.0。