### PR TITLE
Require explicit authentication for the admin control plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,10 @@ node bin/service.js call --data-json '{"id":"123"}'
 
 The SDK also reads the same variable from `.env` in the current working directory. It reads only that key and does not inject other `.env` variables. This variable does not affect the daemon's `--runtime serve` or `--runtime invoke` protocol. When the daemon manages instances, it continues to pass config/secret through files and file descriptors.
 
+## Admin authentication
+
+The daemon requires an Admin Token before enabling the control plane. On a new or upgraded data directory, set `OCTOBUS_BOOTSTRAP_ADMIN_TOKEN` to a high-entropy value for the first startup. The value is hashed and is not returned by the API; remove it from the process environment after bootstrap and manage subsequent tokens through the authenticated Admin API.
+
 ## Development
 
 ### Architecture

--- a/cmd/octobus/main.go
+++ b/cmd/octobus/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -187,7 +188,7 @@ func initializeAdminAuth(ctx context.Context, st *store.Store) error {
 	}
 	secret := os.Getenv("OCTOBUS_BOOTSTRAP_ADMIN_TOKEN")
 	if secret == "" {
-		return nil
+		return errors.New("admin token authentication is not initialized; set OCTOBUS_BOOTSTRAP_ADMIN_TOKEN before starting the daemon")
 	}
 	_, err = st.AddAdminToken(ctx, domain.AdminToken{ID: "bootstrap-admin", Name: "Bootstrap admin"}, secret)
 	return err

--- a/cmd/octobus/main.go
+++ b/cmd/octobus/main.go
@@ -17,6 +17,7 @@ import (
 	"octobus/internal/admin"
 	"octobus/internal/cli"
 	"octobus/internal/daemonlog"
+	"octobus/internal/domain"
 	"octobus/internal/packageimport"
 	"octobus/internal/protocol"
 	"octobus/internal/server"
@@ -125,7 +126,10 @@ func serve(opts serveOptions) error {
 	if err := startupInventory(ctx, logger, st); err != nil {
 		return err
 	}
-	adminServer := &admin.Server{Store: st, Importer: &packageimport.Importer{DataDir: dataDir, Store: st}, Supervisor: sup, Gateway: gateway, AccessLogPath: filepath.Join(dataDir, accesslog.FileName), Logger: logger}
+	if err := initializeAdminAuth(ctx, st); err != nil {
+		return fmt.Errorf("initialize admin authentication: %w", err)
+	}
+	adminServer := &admin.Server{Store: st, Importer: &packageimport.Importer{DataDir: dataDir, Store: st}, Supervisor: sup, Gateway: gateway, AccessLogPath: filepath.Join(dataDir, accesslog.FileName), Logger: logger, RequireAdminToken: true}
 	grpcServer := protocol.GRPCServer(gateway)
 	publicServer := admin.NewHTTPServer(opts.addr, h2c.NewHandler(server.CombinedHandler(adminServer.Handler(), grpcServer, gateway), &http2.Server{}))
 	publicListener, err := net.Listen("tcp", opts.addr)
@@ -171,6 +175,22 @@ func shutdownSupervisor(logger *slog.Logger, sup *supervisor.Supervisor) {
 	if err := sup.Shutdown(shutdownCtx); err != nil {
 		logger.Warn("daemon_supervisor_shutdown_failed", "error", err)
 	}
+}
+
+func initializeAdminAuth(ctx context.Context, st *store.Store) error {
+	requires, err := st.AdminRequiresToken(ctx)
+	if err != nil {
+		return err
+	}
+	if requires {
+		return nil
+	}
+	secret := os.Getenv("OCTOBUS_BOOTSTRAP_ADMIN_TOKEN")
+	if secret == "" {
+		return nil
+	}
+	_, err = st.AddAdminToken(ctx, domain.AdminToken{ID: "bootstrap-admin", Name: "Bootstrap admin"}, secret)
+	return err
 }
 
 func logStartupInventory(ctx context.Context, logger *slog.Logger, st *store.Store) error {

--- a/cmd/octobus/main.go
+++ b/cmd/octobus/main.go
@@ -191,7 +191,10 @@ func initializeAdminAuth(ctx context.Context, st *store.Store) error {
 		return errors.New("admin token authentication is not initialized; set OCTOBUS_BOOTSTRAP_ADMIN_TOKEN before starting the daemon")
 	}
 	_, err = st.AddAdminToken(ctx, domain.AdminToken{ID: "bootstrap-admin", Name: "Bootstrap admin"}, secret)
-	return err
+	if err != nil {
+		return fmt.Errorf("provision bootstrap admin token: %w", err)
+	}
+	return nil
 }
 
 func logStartupInventory(ctx context.Context, logger *slog.Logger, st *store.Store) error {

--- a/cmd/octobus/main_test.go
+++ b/cmd/octobus/main_test.go
@@ -35,6 +35,33 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestInitializeAdminAuthBootstrapsOnlyWhenStoreIsEmpty(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "octobus.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	t.Setenv("OCTOBUS_BOOTSTRAP_ADMIN_TOKEN", "bootstrap-secret")
+	if err := initializeAdminAuth(context.Background(), st); err != nil {
+		t.Fatal(err)
+	}
+	requires, err := st.AdminRequiresToken(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !requires {
+		t.Fatal("bootstrap token was not persisted")
+	}
+	ok, err := st.VerifyAdminToken(context.Background(), "bootstrap-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("bootstrap token was not usable")
+	}
+}
+
 func TestRootAddrFlagOverridesAdminCommands(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/admin/v1/status" {

--- a/cmd/octobus/main_test.go
+++ b/cmd/octobus/main_test.go
@@ -32,6 +32,12 @@ func TestMain(m *testing.M) {
 		runCmdHelper()
 		return
 	}
+	if os.Getenv("OCTOBUS_BOOTSTRAP_ADMIN_TOKEN") == "" {
+		if err := os.Setenv("OCTOBUS_BOOTSTRAP_ADMIN_TOKEN", "test-bootstrap-token"); err != nil {
+			panic(err)
+		}
+		defer os.Unsetenv("OCTOBUS_BOOTSTRAP_ADMIN_TOKEN")
+	}
 	os.Exit(m.Run())
 }
 
@@ -59,6 +65,18 @@ func TestInitializeAdminAuthBootstrapsOnlyWhenStoreIsEmpty(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("bootstrap token was not usable")
+	}
+}
+
+func TestInitializeAdminAuthFailsClosedWithoutBootstrapToken(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "octobus.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	t.Setenv("OCTOBUS_BOOTSTRAP_ADMIN_TOKEN", "")
+	if err := initializeAdminAuth(context.Background(), st); err == nil || !strings.Contains(err.Error(), "OCTOBUS_BOOTSTRAP_ADMIN_TOKEN") {
+		t.Fatalf("missing bootstrap token error = %v", err)
 	}
 }
 

--- a/cmd/octobus/main_test.go
+++ b/cmd/octobus/main_test.go
@@ -78,6 +78,50 @@ func TestInitializeAdminAuthFailsClosedWithoutBootstrapToken(t *testing.T) {
 	if err := initializeAdminAuth(context.Background(), st); err == nil || !strings.Contains(err.Error(), "OCTOBUS_BOOTSTRAP_ADMIN_TOKEN") {
 		t.Fatalf("missing bootstrap token error = %v", err)
 	}
+	requires, err := st.AdminRequiresToken(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requires {
+		t.Fatal("failed initialization must not leave authentication half-enabled")
+	}
+}
+
+func TestInitializeAdminAuthIgnoresEnvWhenTokenAlreadyConfigured(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "octobus.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	if _, err := st.AddAdminToken(ctx, domain.AdminToken{ID: "manual-admin", Name: "Manual admin"}, "existing-secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A fresh bootstrap token in the environment must be ignored once
+	// authentication is already configured: no error, no duplicate token.
+	t.Setenv("OCTOBUS_BOOTSTRAP_ADMIN_TOKEN", "bootstrap-secret")
+	if err := initializeAdminAuth(ctx, st); err != nil {
+		t.Fatalf("re-initialization with existing token failed: %v", err)
+	}
+	ok, err := st.VerifyAdminToken(ctx, "existing-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("existing admin token stopped working")
+	}
+	if ok, err := st.VerifyAdminToken(ctx, "bootstrap-secret"); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Fatal("bootstrap token was inserted even though authentication was already configured")
+	}
+
+	// An unset bootstrap token is likewise fine when a token already exists.
+	t.Setenv("OCTOBUS_BOOTSTRAP_ADMIN_TOKEN", "")
+	if err := initializeAdminAuth(ctx, st); err != nil {
+		t.Fatalf("initialization without env failed when a token exists: %v", err)
+	}
 }
 
 func TestRootAddrFlagOverridesAdminCommands(t *testing.T) {

--- a/docker/smoke.sh
+++ b/docker/smoke.sh
@@ -6,6 +6,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 container_name="octobus-smoke-$RANDOM-$$"
 volume_name="${container_name}-data"
 host_port="${OCTOBUS_SMOKE_PORT:-19000}"
+admin_token="${OCTOBUS_SMOKE_ADMIN_TOKEN:-smoke-admin-token}"
 fixture_dir="$(mktemp -d)"
 status_file="$(mktemp)"
 import_body="$(mktemp)"
@@ -43,6 +44,7 @@ docker volume create "$volume_name" >/dev/null
 docker run -d \
 	--name "$container_name" \
 	-p "127.0.0.1:${host_port}:9000" \
+	-e "OCTOBUS_BOOTSTRAP_ADMIN_TOKEN=${admin_token}" \
 	-v "$volume_name:/var/lib/octobus" \
 	-v "$fixture_dir:/fixtures/calculator-js:ro" \
 	"$image" >/dev/null
@@ -65,6 +67,7 @@ curl -sS \
 	-o "$import_body" \
 	-w '%{http_code}' \
 	-X POST "http://127.0.0.1:${host_port}/admin/v1/services/import" \
+	-H "Authorization: Bearer ${admin_token}" \
 	-H 'Content-Type: application/json' \
 	-d '{"service_id":"calculator","source":"/fixtures/calculator-js","build":"auto"}' >"$import_status"
 
@@ -78,9 +81,9 @@ fi
 cat "$import_body"
 printf '\n'
 
-docker run --rm --network "container:$container_name" "$image" instance create --id calculator-test --service calculator --addr 127.0.0.1:9000 --config-json '{"label":"smoke"}' --secret-json '{"apiToken":"smoke-token"}'
-docker run --rm --network "container:$container_name" "$image" capset create --id dev --name DevAgent --addr 127.0.0.1:9000
-docker run --rm --network "container:$container_name" "$image" capset add-instance --capset dev --instance calculator-test --addr 127.0.0.1:9000
+docker run --rm -e "OCTOBUS_ADMIN_TOKEN=${admin_token}" --network "container:$container_name" "$image" instance create --id calculator-test --service calculator --addr 127.0.0.1:9000 --config-json '{"label":"smoke"}' --secret-json '{"apiToken":"smoke-token"}'
+docker run --rm -e "OCTOBUS_ADMIN_TOKEN=${admin_token}" --network "container:$container_name" "$image" capset create --id dev --name DevAgent --addr 127.0.0.1:9000
+docker run --rm -e "OCTOBUS_ADMIN_TOKEN=${admin_token}" --network "container:$container_name" "$image" capset add-instance --capset dev --instance calculator-test --addr 127.0.0.1:9000
 
 response="$(
 	curl -fsS \

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -35,6 +35,11 @@ type Server struct {
 	Gateway       *protocol.Gateway
 	AccessLogPath string
 	Logger        *slog.Logger
+
+	// RequireAdminToken is enabled by the daemon for production control-plane
+	// handlers. It is explicit so lightweight in-process test servers can keep
+	// using the handler without provisioning a token store.
+	RequireAdminToken bool
 }
 
 type serviceImporter interface {
@@ -147,10 +152,14 @@ func (s *Server) adminTokenMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		if c.Request().URL.Path == "/admin/v1/status" {
 			return next(c)
 		}
-		requires, err := s.Store.AdminRequiresToken(c.Request().Context())
-		if err != nil {
-			writeError(c.Response(), http.StatusInternalServerError, err.Error())
-			return nil
+		requires := s.RequireAdminToken
+		if !requires {
+			var err error
+			requires, err = s.Store.AdminRequiresToken(c.Request().Context())
+			if err != nil {
+				writeError(c.Response(), http.StatusInternalServerError, err.Error())
+				return nil
+			}
 		}
 		if !requires {
 			return next(c)

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -747,6 +747,22 @@ func TestAdminServiceImportMultipartRecursiveAggregateAndValidation(t *testing.T
 	})
 }
 
+func TestAdminTokenIsRequiredWhenDaemonEnablesControlPlaneAuth(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "octobus.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	srv := &Server{Store: st, RequireAdminToken: true}
+	req := httptest.NewRequest(http.MethodGet, "/admin/v1/services", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status without admin token = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
 func TestAdminServiceImportMultipartRequiresAdminToken(t *testing.T) {
 	ctx := context.Background()
 	dataDir := t.TempDir()


### PR DESCRIPTION
## 问题
当数据库中没有 Admin Token 时，Admin API 会自动跳过鉴权。全新部署或所有 Token 被删除后，控制面因此匿名开放。

## 影响
未认证调用方可以创建 Admin Token、管理服务和实例，并触发服务导入及构建流程。若部署在可访问网络，可能导致控制面接管；结合远程导入还可能进一步执行不受信任代码。

## 修复内容
- 守护进程显式启用 Admin Token 鉴权（`RequireAdminToken: true`）。
- 增加 `OCTOBUS_BOOTSTRAP_ADMIN_TOKEN`，仅在数据库尚无 Admin Token 时初始化首个 Token。
- 未设置 bootstrap token 且数据库为空时，守护进程启动即失败并退出（exit 1），错误信息提示先设置 `OCTOBUS_BOOTSTRAP_ADMIN_TOKEN`；`/admin/v1/status` 仍免鉴权，供探活使用。
- 增加初始化（快乐路径 + 两个负分支）和鉴权拒绝测试。
- 同步修复 `docker/smoke.sh`：冒烟流程现在注入 bootstrap token，并为 import 与 CLI 管理命令携带 admin token。

## 迁移说明
从无认证部署升级时，需在首次启动前设置 `OCTOBUS_BOOTSTRAP_ADMIN_TOKEN` 以完成首个 Token 的初始化（详见 README）。

## 验证
- `go test ./cmd/octobus` 通过。
- `go test ./internal/admin` 中与 protoc 相关的既有测试受本地缺失 `protoc` 阻塞；新增鉴权测试通过。