### PR TITLE
Restrict server-side remote import targets

### DIFF
--- a/cmd/octobus/main.go
+++ b/cmd/octobus/main.go
@@ -125,7 +125,7 @@ func serve(opts serveOptions) error {
 	if err := startupInventory(ctx, logger, st); err != nil {
 		return err
 	}
-	adminServer := &admin.Server{Store: st, Importer: &packageimport.Importer{DataDir: dataDir, Store: st}, Supervisor: sup, Gateway: gateway, AccessLogPath: filepath.Join(dataDir, accesslog.FileName), Logger: logger}
+	adminServer := &admin.Server{Store: st, Importer: &packageimport.Importer{DataDir: dataDir, Store: st, RemoteTargetValidator: packageimport.DefaultRemoteTargetValidator}, Supervisor: sup, Gateway: gateway, AccessLogPath: filepath.Join(dataDir, accesslog.FileName), Logger: logger}
 	grpcServer := protocol.GRPCServer(gateway)
 	publicServer := admin.NewHTTPServer(opts.addr, h2c.NewHandler(server.CombinedHandler(adminServer.Handler(), grpcServer, gateway), &http2.Server{}))
 	publicListener, err := net.Listen("tcp", opts.addr)

--- a/internal/packageimport/git_source.go
+++ b/internal/packageimport/git_source.go
@@ -222,7 +222,7 @@ func (i *Importer) prepareGitSource(ctx context.Context, rawSource, staging stri
 	var gitProxy *validatedGitProxy
 	var proxyURL string
 	if i.RemoteTargetValidator != nil {
-		gitProxy, err = startValidatedGitProxy(ctx)
+		gitProxy, err = startValidatedGitProxy(ctx, i.RemoteTargetValidator)
 		if err != nil {
 			return preparedSource{}, fmt.Errorf("start Git validation proxy: %w", err)
 		}

--- a/internal/packageimport/git_source.go
+++ b/internal/packageimport/git_source.go
@@ -227,6 +227,11 @@ func (i *Importer) prepareGitSource(ctx context.Context, rawSource, staging stri
 	if err := os.MkdirAll(repoDir, 0o755); err != nil {
 		return preparedSource{}, err
 	}
+	if i.RemoteTargetValidator != nil {
+		if err := i.RemoteTargetValidator(ctx, src.CredentialURL); err != nil {
+			return preparedSource{}, fmt.Errorf("validate Git remote: %w", err)
+		}
+	}
 	if err := runner.run(ctx, repoDir, "init", "--bare", "."); err != nil {
 		return preparedSource{}, err
 	}
@@ -318,7 +323,8 @@ func (r *gitRunner) run(ctx context.Context, dir string, args ...string) error {
 }
 
 func (r *gitRunner) output(ctx context.Context, dir string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	gitArgs := append([]string{"-c", "http.followRedirects=false"}, args...)
+	cmd := exec.CommandContext(ctx, "git", gitArgs...)
 	cmd.Dir = dir
 	cmd.Env = r.env
 	var out strings.Builder

--- a/internal/packageimport/git_source.go
+++ b/internal/packageimport/git_source.go
@@ -219,7 +219,17 @@ func (i *Importer) prepareGitSource(ctx context.Context, rawSource, staging stri
 	if err != nil {
 		return preparedSource{}, err
 	}
-	runner, err := newGitRunner(src, staging)
+	var gitProxy *validatedGitProxy
+	var proxyURL string
+	if i.RemoteTargetValidator != nil {
+		gitProxy, err = startValidatedGitProxy(ctx)
+		if err != nil {
+			return preparedSource{}, fmt.Errorf("start Git validation proxy: %w", err)
+		}
+		defer gitProxy.Close()
+		proxyURL = gitProxy.URL()
+	}
+	runner, err := newGitRunner(src, staging, proxyURL)
 	if err != nil {
 		return preparedSource{}, err
 	}
@@ -276,11 +286,12 @@ func serviceRootOrDefault(serviceRoot string) string {
 }
 
 type gitRunner struct {
-	source gitSource
-	env    []string
+	source   gitSource
+	env      []string
+	proxyURL string
 }
 
-func newGitRunner(src gitSource, staging string) (*gitRunner, error) {
+func newGitRunner(src gitSource, staging string, proxyURL ...string) (*gitRunner, error) {
 	if _, err := exec.LookPath("git"); err != nil {
 		return nil, errors.New("git is required to import HTTPS Git sources; install git and ensure it is on PATH")
 	}
@@ -299,7 +310,11 @@ func newGitRunner(src gitSource, staging string) (*gitRunner, error) {
 	} else {
 		env = append(env, "GIT_TERMINAL_PROMPT=0")
 	}
-	return &gitRunner{source: src, env: env}, nil
+	runner := &gitRunner{source: src, env: env}
+	if len(proxyURL) > 0 {
+		runner.proxyURL = proxyURL[0]
+	}
+	return runner, nil
 }
 
 func writeGitAskpass(staging string, src gitSource) (string, error) {
@@ -323,7 +338,11 @@ func (r *gitRunner) run(ctx context.Context, dir string, args ...string) error {
 }
 
 func (r *gitRunner) output(ctx context.Context, dir string, args ...string) (string, error) {
-	gitArgs := append([]string{"-c", "http.followRedirects=false"}, args...)
+	gitArgs := []string{"-c", "http.followRedirects=false"}
+	if r.proxyURL != "" {
+		gitArgs = append(gitArgs, "-c", "http.proxy="+r.proxyURL)
+	}
+	gitArgs = append(gitArgs, args...)
 	cmd := exec.CommandContext(ctx, "git", gitArgs...)
 	cmd.Dir = dir
 	cmd.Env = r.env

--- a/internal/packageimport/importer.go
+++ b/internal/packageimport/importer.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -27,6 +26,11 @@ import (
 type Importer struct {
 	DataDir string
 	Store   *store.Store
+
+	// RemoteTargetValidator is configured by the daemon to enforce the
+	// network policy for server-side remote imports. Tests and local-only
+	// importers may leave it unset.
+	RemoteTargetValidator func(context.Context, string) error
 }
 
 type Options struct {
@@ -608,7 +612,7 @@ func (i *Importer) prepareSource(ctx context.Context, opts Options, staging stri
 		prepared.ServiceRoot = serviceRoot
 		return prepared, nil
 	case sourceRemoteArchive:
-		return prepareRemoteArchiveSource(ctx, source, serviceRoot, staging)
+		return i.prepareRemoteArchiveSource(ctx, source, serviceRoot, staging)
 	case sourceHTTPSGit:
 		return i.prepareGitSource(ctx, opts.Source, staging)
 	case sourceUnsupportedGit:
@@ -771,13 +775,13 @@ func hashFile(path string) (string, error) {
 	return domain.HashBytes(b), nil
 }
 
-func prepareRemoteArchiveSource(ctx context.Context, source, serviceRoot, staging string) (preparedSource, error) {
+func (i *Importer) prepareRemoteArchiveSource(ctx context.Context, source, serviceRoot, staging string) (preparedSource, error) {
 	artifactName, err := remoteArchiveArtifactName(source)
 	if err != nil {
 		return preparedSource{}, err
 	}
 	artifactPath := filepath.Join(staging, artifactName)
-	if err := downloadRemoteArchive(ctx, source, artifactPath); err != nil {
+	if err := downloadRemoteArchive(ctx, source, artifactPath, i.RemoteTargetValidator); err != nil {
 		return preparedSource{}, err
 	}
 	packageDir := filepath.Join(staging, "package")
@@ -817,34 +821,6 @@ func remoteArchiveArtifactName(source string) (string, error) {
 		return "package.tgz", nil
 	}
 	return "", fmt.Errorf("unsupported remote package source %q: must end with .tgz, .tar.gz, or .zip", redactedRemoteArchiveSource(source))
-}
-
-func downloadRemoteArchive(ctx context.Context, source, artifactPath string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, source, nil)
-	if err != nil {
-		return fmt.Errorf("download remote package %q: %w", redactedRemoteArchiveSource(source), err)
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("download remote package %q: %w", redactedRemoteArchiveSource(source), err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("download remote package %q: HTTP %d", redactedRemoteArchiveSource(source), resp.StatusCode)
-	}
-	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
-		return err
-	}
-	out, err := os.OpenFile(artifactPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	_, copyErr := io.Copy(out, resp.Body)
-	closeErr := out.Close()
-	if copyErr != nil {
-		return copyErr
-	}
-	return closeErr
 }
 
 func redactedRemoteArchiveSource(source string) string {

--- a/internal/packageimport/importer.go
+++ b/internal/packageimport/importer.go
@@ -30,6 +30,15 @@ type Importer struct {
 	// RemoteTargetValidator is configured by the daemon to enforce the
 	// network policy for server-side remote imports. Tests and local-only
 	// importers may leave it unset.
+	//
+	// The validator is a host-level network policy: it is called with the
+	// complete source URL (including path and credentials) for archive
+	// downloads, HTTP redirects, and the initial Git source check, and it is
+	// also called with a synthetic "https://host:port" URL for every Git
+	// CONNECT request (a CONNECT tunnel only exposes host:port and cannot
+	// carry the original path). Implementations must not require a specific
+	// path or credentials; allow/deny decisions must be based on scheme,
+	// host, and port only.
 	RemoteTargetValidator func(context.Context, string) error
 }
 

--- a/internal/packageimport/remote_security.go
+++ b/internal/packageimport/remote_security.go
@@ -1,0 +1,179 @@
+package packageimport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const remoteImportTimeout = 10 * time.Minute
+
+var forbiddenRemoteNetworks = mustParseRemoteNetworks(
+	"0.0.0.0/8",
+	"10.0.0.0/8",
+	"100.64.0.0/10",
+	"127.0.0.0/8",
+	"169.254.0.0/16",
+	"172.16.0.0/12",
+	"192.0.0.0/24",
+	"192.0.2.0/24",
+	"192.168.0.0/16",
+	"198.18.0.0/15",
+	"198.51.100.0/24",
+	"203.0.113.0/24",
+	"224.0.0.0/4",
+	"240.0.0.0/4",
+	"::/128",
+	"::1/128",
+	"fc00::/7",
+	"fe80::/10",
+	"ff00::/8",
+	"2001:db8::/32",
+)
+
+func mustParseRemoteNetworks(cidrs ...string) []*net.IPNet {
+	networks := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(err)
+		}
+		networks = append(networks, network)
+	}
+	return networks
+}
+
+func DefaultRemoteTargetValidator(ctx context.Context, raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid remote URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.New("only HTTP(S) remote targets are allowed")
+	}
+	if u.Hostname() == "" {
+		return errors.New("remote URL host is required")
+	}
+	return validateRemoteHost(ctx, u.Hostname())
+}
+
+func validateRemoteHost(ctx context.Context, hostname string) error {
+	if ip := net.ParseIP(hostname); ip != nil {
+		if isForbiddenRemoteIP(ip) {
+			return fmt.Errorf("remote target %q resolves to a private or special address", hostname)
+		}
+		return nil
+	}
+
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, hostname)
+	if err != nil {
+		return fmt.Errorf("resolve remote target %q: %w", hostname, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("remote target %q has no address", hostname)
+	}
+	for _, item := range ips {
+		if isForbiddenRemoteIP(item.IP) {
+			return fmt.Errorf("remote target %q resolves to a private or special address", hostname)
+		}
+	}
+	return nil
+}
+
+func isForbiddenRemoteIP(ip net.IP) bool {
+	if ip == nil || !ip.IsGlobalUnicast() {
+		return true
+	}
+	for _, network := range forbiddenRemoteNetworks {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func newRemoteHTTPClient(validate func(context.Context, string) error) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   remoteImportTimeout,
+	}
+	if validate == nil {
+		return client
+	}
+	transport.DialContext = safeRemoteDialContext(validate)
+	client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+		return validate(req.Context(), req.URL.String())
+	}
+	return client
+}
+
+func safeRemoteDialContext(validate func(context.Context, string) error) func(context.Context, string, string) (net.Conn, error) {
+	dialer := &net.Dialer{}
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if err := validate(ctx, "https://"+net.JoinHostPort(host, port)); err != nil {
+			return nil, err
+		}
+
+		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range ips {
+			if isForbiddenRemoteIP(item.IP) {
+				continue
+			}
+			conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(item.IP.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+		}
+		return nil, fmt.Errorf("unable to connect to allowed address for %s", host)
+	}
+}
+
+func downloadRemoteArchive(ctx context.Context, source, artifactPath string, validate func(context.Context, string) error) error {
+	if validate != nil {
+		if err := validate(ctx, source); err != nil {
+			return fmt.Errorf("validate remote package target: %w", err)
+		}
+	}
+	ctx, cancel := context.WithTimeout(ctx, remoteImportTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, source, nil)
+	if err != nil {
+		return fmt.Errorf("download remote package %q: %w", redactedRemoteArchiveSource(source), err)
+	}
+	resp, err := newRemoteHTTPClient(validate).Do(req)
+	if err != nil {
+		return fmt.Errorf("download remote package %q: %w", redactedRemoteArchiveSource(source), err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("download remote package %q: HTTP %d", redactedRemoteArchiveSource(source), resp.StatusCode)
+	}
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(artifactPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(out, resp.Body)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}

--- a/internal/packageimport/remote_security.go
+++ b/internal/packageimport/remote_security.go
@@ -153,16 +153,17 @@ func safeRemoteDialContext(validate func(context.Context, string) error) func(co
 type validatedGitProxy struct {
 	listener  net.Listener
 	ctx       context.Context
+	validate  func(context.Context, string) error
 	done      chan struct{}
 	closeOnce sync.Once
 }
 
-func startValidatedGitProxy(ctx context.Context) (*validatedGitProxy, error) {
+func startValidatedGitProxy(ctx context.Context, validate func(context.Context, string) error) (*validatedGitProxy, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}
-	proxy := &validatedGitProxy{listener: listener, ctx: ctx, done: make(chan struct{})}
+	proxy := &validatedGitProxy{listener: listener, ctx: ctx, validate: validate, done: make(chan struct{})}
 	go proxy.serve()
 	return proxy, nil
 }
@@ -196,7 +197,7 @@ func (p *validatedGitProxy) handle(client net.Conn) {
 		_, _ = io.WriteString(client, "HTTP/1.1 405 Method Not Allowed\\r\\nConnection: close\\r\\n\\r\\n")
 		return
 	}
-	remote, err := dialValidatedRemote(p.ctx, request.Host)
+	remote, err := dialValidatedRemote(p.ctx, request.Host, p.validate)
 	if err != nil {
 		_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\\r\\nConnection: close\\r\\n\\r\\n")
 		return
@@ -219,12 +220,15 @@ func (p *validatedGitProxy) Close() error {
 	return err
 }
 
-func dialValidatedRemote(ctx context.Context, address string) (net.Conn, error) {
+func dialValidatedRemote(ctx context.Context, address string, validate func(context.Context, string) error) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err
 	}
-	if err := DefaultRemoteTargetValidator(ctx, "https://"+net.JoinHostPort(host, port)); err != nil {
+	if validate == nil {
+		validate = DefaultRemoteTargetValidator
+	}
+	if err := validate(ctx, "https://"+net.JoinHostPort(host, port)); err != nil {
 		return nil, err
 	}
 	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)

--- a/internal/packageimport/remote_security.go
+++ b/internal/packageimport/remote_security.go
@@ -192,7 +192,8 @@ func (p *validatedGitProxy) serve() {
 
 func (p *validatedGitProxy) handle(client net.Conn) {
 	defer client.Close()
-	request, err := http.ReadRequest(bufio.NewReader(client))
+	reader := bufio.NewReader(client)
+	request, err := http.ReadRequest(reader)
 	if err != nil || request.Method != http.MethodConnect {
 		_, _ = io.WriteString(client, "HTTP/1.1 405 Method Not Allowed\\r\\nConnection: close\\r\\n\\r\\n")
 		return
@@ -207,7 +208,7 @@ func (p *validatedGitProxy) handle(client net.Conn) {
 		return
 	}
 	go func() {
-		_, _ = io.Copy(remote, client)
+		_, _ = io.Copy(remote, io.MultiReader(reader, client))
 		_ = remote.Close()
 	}()
 	_, _ = io.Copy(client, remote)

--- a/internal/packageimport/remote_security.go
+++ b/internal/packageimport/remote_security.go
@@ -1,6 +1,7 @@
 package packageimport
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
@@ -108,6 +110,9 @@ func newRemoteHTTPClient(validate func(context.Context, string) error) *http.Cli
 	if validate == nil {
 		return client
 	}
+	// Do not let HTTP(S)_PROXY redirect a validated request to an
+	// unvalidated destination through an external proxy.
+	transport.Proxy = nil
 	transport.DialContext = safeRemoteDialContext(validate)
 	client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
 		return validate(req.Context(), req.URL.String())
@@ -141,6 +146,102 @@ func safeRemoteDialContext(validate func(context.Context, string) error) func(co
 		}
 		return nil, fmt.Errorf("unable to connect to allowed address for %s", host)
 	}
+}
+
+// validatedGitProxy forces the git subprocess to use the target policy while
+// retaining the original hostname for HTTPS certificate verification.
+type validatedGitProxy struct {
+	listener  net.Listener
+	ctx       context.Context
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func startValidatedGitProxy(ctx context.Context) (*validatedGitProxy, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	proxy := &validatedGitProxy{listener: listener, ctx: ctx, done: make(chan struct{})}
+	go proxy.serve()
+	return proxy, nil
+}
+
+func (p *validatedGitProxy) URL() string {
+	return "http://" + p.listener.Addr().String()
+}
+
+func (p *validatedGitProxy) serve() {
+	defer close(p.done)
+	go func() {
+		select {
+		case <-p.ctx.Done():
+			_ = p.listener.Close()
+		case <-p.done:
+		}
+	}()
+	for {
+		conn, err := p.listener.Accept()
+		if err != nil {
+			return
+		}
+		go p.handle(conn)
+	}
+}
+
+func (p *validatedGitProxy) handle(client net.Conn) {
+	defer client.Close()
+	request, err := http.ReadRequest(bufio.NewReader(client))
+	if err != nil || request.Method != http.MethodConnect {
+		_, _ = io.WriteString(client, "HTTP/1.1 405 Method Not Allowed\\r\\nConnection: close\\r\\n\\r\\n")
+		return
+	}
+	remote, err := dialValidatedRemote(p.ctx, request.Host)
+	if err != nil {
+		_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\\r\\nConnection: close\\r\\n\\r\\n")
+		return
+	}
+	defer remote.Close()
+	if _, err := io.WriteString(client, "HTTP/1.1 200 Connection Established\\r\\n\\r\\n"); err != nil {
+		return
+	}
+	go func() {
+		_, _ = io.Copy(remote, client)
+		_ = remote.Close()
+	}()
+	_, _ = io.Copy(client, remote)
+}
+
+func (p *validatedGitProxy) Close() error {
+	var err error
+	p.closeOnce.Do(func() { err = p.listener.Close() })
+	<-p.done
+	return err
+}
+
+func dialValidatedRemote(ctx context.Context, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	if err := DefaultRemoteTargetValidator(ctx, "https://"+net.JoinHostPort(host, port)); err != nil {
+		return nil, err
+	}
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	dialer := &net.Dialer{}
+	for _, item := range ips {
+		if isForbiddenRemoteIP(item.IP) {
+			continue
+		}
+		conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(item.IP.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+	}
+	return nil, fmt.Errorf("unable to connect to allowed address for %s", host)
 }
 
 func downloadRemoteArchive(ctx context.Context, source, artifactPath string, validate func(context.Context, string) error) error {

--- a/internal/packageimport/remote_security.go
+++ b/internal/packageimport/remote_security.go
@@ -237,7 +237,21 @@ func (p *validatedGitProxy) dialToValidatedRemote(address string) (net.Conn, err
 	return dialValidatedRemote(p.ctx, address, p.validate)
 }
 
+// ipResolver resolves a hostname to addresses; *net.Resolver implements it.
+type ipResolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
 func dialValidatedRemote(ctx context.Context, address string, validate func(context.Context, string) error) (net.Conn, error) {
+	return dialValidatedRemoteWith(ctx, address, validate, nil, nil)
+}
+
+// dialValidatedRemoteWith is dialValidatedRemote with swappable resolver and
+// dial functions so tests can exercise the allowed-address selection loop —
+// skipping forbidden addresses from the resolution list and dialing the first
+// allowed one — without real DNS or network access. Nil resolver and dial
+// fall back to the process defaults.
+func dialValidatedRemoteWith(ctx context.Context, address string, validate func(context.Context, string) error, resolver ipResolver, dial func(ctx context.Context, network, address string) (net.Conn, error)) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err
@@ -248,16 +262,21 @@ func dialValidatedRemote(ctx context.Context, address string, validate func(cont
 	if err := validate(ctx, "https://"+net.JoinHostPort(host, port)); err != nil {
 		return nil, err
 	}
-	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	if dial == nil {
+		dial = (&net.Dialer{}).DialContext
+	}
+	ips, err := resolver.LookupIPAddr(ctx, host)
 	if err != nil {
 		return nil, err
 	}
-	dialer := &net.Dialer{}
 	for _, item := range ips {
 		if isForbiddenRemoteIP(item.IP) {
 			continue
 		}
-		conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(item.IP.String(), port))
+		conn, err := dial(ctx, "tcp", net.JoinHostPort(item.IP.String(), port))
 		if err == nil {
 			return conn, nil
 		}

--- a/internal/packageimport/remote_security.go
+++ b/internal/packageimport/remote_security.go
@@ -151,19 +151,26 @@ func safeRemoteDialContext(validate func(context.Context, string) error) func(co
 // validatedGitProxy forces the git subprocess to use the target policy while
 // retaining the original hostname for HTTPS certificate verification.
 type validatedGitProxy struct {
-	listener  net.Listener
-	ctx       context.Context
-	validate  func(context.Context, string) error
+	listener net.Listener
+	ctx      context.Context
+	validate func(context.Context, string) error
+	// dial is the connection factory used for the CONNECT target. When nil,
+	// dialValidatedRemote is used; tests may inject a stub to exercise the
+	// success path without contacting an external host.
+	dial      func(ctx context.Context, address string, validate func(context.Context, string) error) (net.Conn, error)
 	done      chan struct{}
 	closeOnce sync.Once
 }
 
-func startValidatedGitProxy(ctx context.Context, validate func(context.Context, string) error) (*validatedGitProxy, error) {
+func startValidatedGitProxy(ctx context.Context, validate func(context.Context, string) error, dial ...func(ctx context.Context, address string, validate func(context.Context, string) error) (net.Conn, error)) (*validatedGitProxy, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}
 	proxy := &validatedGitProxy{listener: listener, ctx: ctx, validate: validate, done: make(chan struct{})}
+	if len(dial) > 0 {
+		proxy.dial = dial[0]
+	}
 	go proxy.serve()
 	return proxy, nil
 }
@@ -200,7 +207,7 @@ func (p *validatedGitProxy) handle(client net.Conn) {
 		_, _ = io.WriteString(client, "HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\n\r\n")
 		return
 	}
-	remote, err := dialValidatedRemote(p.ctx, request.Host, p.validate)
+	remote, err := p.dialToValidatedRemote(request.Host)
 	if err != nil {
 		_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n")
 		return
@@ -221,6 +228,13 @@ func (p *validatedGitProxy) Close() error {
 	p.closeOnce.Do(func() { err = p.listener.Close() })
 	<-p.done
 	return err
+}
+
+func (p *validatedGitProxy) dialToValidatedRemote(address string) (net.Conn, error) {
+	if p.dial != nil {
+		return p.dial(p.ctx, address, p.validate)
+	}
+	return dialValidatedRemote(p.ctx, address, p.validate)
 }
 
 func dialValidatedRemote(ctx context.Context, address string, validate func(context.Context, string) error) (net.Conn, error) {

--- a/internal/packageimport/remote_security.go
+++ b/internal/packageimport/remote_security.go
@@ -195,16 +195,18 @@ func (p *validatedGitProxy) handle(client net.Conn) {
 	reader := bufio.NewReader(client)
 	request, err := http.ReadRequest(reader)
 	if err != nil || request.Method != http.MethodConnect {
-		_, _ = io.WriteString(client, "HTTP/1.1 405 Method Not Allowed\\r\\nConnection: close\\r\\n\\r\\n")
+		// Status lines below must use real CRLF; a literal "\r\n" text is not
+		// parseable by git and would fail every proxied fetch.
+		_, _ = io.WriteString(client, "HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\n\r\n")
 		return
 	}
 	remote, err := dialValidatedRemote(p.ctx, request.Host, p.validate)
 	if err != nil {
-		_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\\r\\nConnection: close\\r\\n\\r\\n")
+		_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n")
 		return
 	}
 	defer remote.Close()
-	if _, err := io.WriteString(client, "HTTP/1.1 200 Connection Established\\r\\n\\r\\n"); err != nil {
+	if _, err := io.WriteString(client, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
 		return
 	}
 	go func() {

--- a/internal/packageimport/remote_security_test.go
+++ b/internal/packageimport/remote_security_test.go
@@ -32,6 +32,17 @@ func TestDefaultRemoteTargetValidatorRejectsUnsupportedURLs(t *testing.T) {
 	}
 }
 
+func TestRemoteHTTPClientDisablesAmbientProxy(t *testing.T) {
+	client := newRemoteHTTPClient(DefaultRemoteTargetValidator)
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T", client.Transport)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("validated remote client inherited an ambient proxy")
+	}
+}
+
 func TestRemoteHTTPClientRevalidatesRedirects(t *testing.T) {
 	validator := func(_ context.Context, raw string) error {
 		if strings.HasSuffix(raw, "/internal") {

--- a/internal/packageimport/remote_security_test.go
+++ b/internal/packageimport/remote_security_test.go
@@ -1,0 +1,59 @@
+package packageimport
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestDefaultRemoteTargetValidatorRejectsPrivateAndSpecialAddresses(t *testing.T) {
+	for _, raw := range []string{
+		"http://127.0.0.1/package.tgz",
+		"https://localhost/package.tgz",
+		"http://169.254.169.254/package.tgz",
+		"http://192.0.2.8/package.tgz",
+		"http://[::1]/package.tgz",
+	} {
+		err := DefaultRemoteTargetValidator(context.Background(), raw)
+		if err == nil {
+			t.Fatalf("validator accepted %s", raw)
+		}
+		if !strings.Contains(err.Error(), "private or special") {
+			t.Fatalf("unexpected error for %s: %v", raw, err)
+		}
+	}
+}
+
+func TestDefaultRemoteTargetValidatorRejectsUnsupportedURLs(t *testing.T) {
+	if err := DefaultRemoteTargetValidator(context.Background(), "file:///tmp/package.tgz"); err == nil {
+		t.Fatal("validator accepted a non-HTTP URL")
+	}
+}
+
+func TestRemoteHTTPClientRevalidatesRedirects(t *testing.T) {
+	validator := func(_ context.Context, raw string) error {
+		if strings.HasSuffix(raw, "/internal") {
+			return context.Canceled
+		}
+		return nil
+	}
+	client := newRemoteHTTPClient(validator)
+	redirect, err := url.Parse("https://public.example/internal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.CheckRedirect(&http.Request{URL: redirect, Method: http.MethodGet}, nil)
+	if err == nil || !strings.Contains(err.Error(), context.Canceled.Error()) {
+		t.Fatalf("redirect validation error = %v", err)
+	}
+}
+
+func TestPrepareGitSourceRejectsPrivateRemoteBeforeGitFetch(t *testing.T) {
+	imp := &Importer{RemoteTargetValidator: DefaultRemoteTargetValidator}
+	_, err := imp.prepareGitSource(context.Background(), "https://127.0.0.1/repo.git", t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "private or special") {
+		t.Fatalf("private Git remote error = %v", err)
+	}
+}

--- a/internal/packageimport/remote_security_test.go
+++ b/internal/packageimport/remote_security_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -74,17 +75,34 @@ func TestPrepareGitSourceRejectsPrivateRemoteBeforeGitFetch(t *testing.T) {
 	}
 }
 
+// recordedCalls collects the URLs passed to a RemoteTargetValidator. The
+// validator is invoked from the proxy's serving goroutine, so reads from the
+// test goroutine must go through snapshot to stay race-free.
+type recordedCalls struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (r *recordedCalls) add(raw string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, raw)
+}
+
+func (r *recordedCalls) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.calls...)
+}
+
 // hostAllowlistValidator implements the documented host-level contract for
 // RemoteTargetValidator: it decides on scheme, host, and port and must not
 // depend on a path, because Git CONNECT validation receives a synthetic
 // "https://host:port" URL.
-func hostAllowlistValidator(allowedHost string) (func(context.Context, string) error, *[]string) {
-	var seen sync.Mutex
-	var calls []string
+func hostAllowlistValidator(allowedHost string) (func(context.Context, string) error, *recordedCalls) {
+	seen := &recordedCalls{}
 	return func(_ context.Context, raw string) error {
-		seen.Lock()
-		calls = append(calls, raw)
-		seen.Unlock()
+		seen.add(raw)
 		u, err := url.Parse(raw)
 		if err != nil {
 			return err
@@ -93,7 +111,47 @@ func hostAllowlistValidator(allowedHost string) (func(context.Context, string) e
 			return fmt.Errorf("remote host %q is not allowed", u.Hostname())
 		}
 		return nil
-	}, &calls
+	}, seen
+}
+
+// readStatusLine reads one HTTP response status line and fails the test if
+// the proxy never terminates it with a real CRLF (a literal backslash-r
+// backslash-n cannot be parsed by git and stalls until EOF).
+func readStatusLine(t *testing.T, conn net.Conn) string {
+	t.Helper()
+	status, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read status line: %v", err)
+	}
+	if !strings.HasSuffix(status, "\r\n") {
+		t.Fatalf("status line %q is not terminated by CRLF", status)
+	}
+	return strings.TrimSuffix(status, "\r\n")
+}
+
+// TestGitProxyRejectsNonCONNECTWith405 covers the 405 status line (and its
+// CRLF termination) written when a connection is not a CONNECT request.
+func TestGitProxyRejectsNonCONNECTWith405(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	validate, _ := hostAllowlistValidator("allowed.example.com")
+	proxy, err := startValidatedGitProxy(ctx, validate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proxy.Close()
+
+	conn, err := net.DialTimeout("tcp", proxy.listener.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, err := fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: allowed.example.com\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	if got := readStatusLine(t, conn); got != "HTTP/1.1 405 Method Not Allowed" {
+		t.Fatalf("CONNECT status = %q, want 405", got)
+	}
 }
 
 // TestGitProxyCONNECTRejectsNonAllowlistedHost exercises the CONNECT
@@ -117,12 +175,8 @@ func TestGitProxyCONNECTRejectsNonAllowlistedHost(t *testing.T) {
 	if _, err := fmt.Fprintf(conn, "CONNECT denied.example.com:443 HTTP/1.1\r\nHost: denied.example.com:443\r\n\r\n"); err != nil {
 		t.Fatal(err)
 	}
-	status, err := bufio.NewReader(conn).ReadString('\n')
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(status, "403") {
-		t.Fatalf("CONNECT status = %q, want 403", strings.TrimSpace(status))
+	if got := readStatusLine(t, conn); !strings.Contains(got, "403") {
+		t.Fatalf("CONNECT status = %q, want 403", got)
 	}
 }
 
@@ -148,14 +202,70 @@ func TestGitProxyCONNECTNeverRelaxesIPPinAndUsesSyntheticURL(t *testing.T) {
 	if _, err := fmt.Fprintf(conn, "CONNECT localhost:443 HTTP/1.1\r\nHost: localhost:443\r\n\r\n"); err != nil {
 		t.Fatal(err)
 	}
-	status, err := bufio.NewReader(conn).ReadString('\n')
+	if got := readStatusLine(t, conn); !strings.Contains(got, "403") {
+		t.Fatalf("CONNECT status = %q, want 403 for loopback resolution", got)
+	}
+	seen := calls.snapshot()
+	if len(seen) == 0 || !strings.HasPrefix(seen[0], "https://localhost:443") {
+		t.Fatalf("validator calls = %v, want synthetic https://localhost:443 URL", seen)
+	}
+}
+
+// TestGitProxyCONNECTWritesRealCRLF200Status covers the most security-relevant
+// status line: the 200 Connection Established response that git must parse to
+// proceed with the TLS tunnel. A literal "\r\n" (backslash r backslash n)
+// regression fails this test with an io.EOF from ReadString('\n').
+func TestGitProxyCONNECTWritesRealCRLF200Status(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	validate, _ := hostAllowlistValidator("target.invalid")
+	// Do not dial an external target: hand the proxy a pipe whose peer is
+	// held by this test, standing in for the CONNECT destination.
+	tunneled, remotePeer := net.Pipe()
+	defer remotePeer.Close()
+	proxy, err := startValidatedGitProxy(ctx, validate, func(_ context.Context, address string, _ func(context.Context, string) error) (net.Conn, error) {
+		if address != "target.invalid:443" {
+			t.Errorf("dial address = %q, want target.invalid:443", address)
+		}
+		return tunneled, nil
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(status, "403") {
-		t.Fatalf("CONNECT status = %q, want 403 for loopback resolution", strings.TrimSpace(status))
+	defer proxy.Close()
+
+	conn, err := net.DialTimeout("tcp", proxy.listener.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if len(*calls) == 0 || !strings.HasPrefix((*calls)[0], "https://localhost:443") {
-		t.Fatalf("validator calls = %v, want synthetic https://localhost:443 URL", *calls)
+	defer conn.Close()
+	if _, err := fmt.Fprintf(conn, "CONNECT target.invalid:443 HTTP/1.1\r\nHost: target.invalid:443\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	if got := readStatusLine(t, conn); got != "HTTP/1.1 200 Connection Established" {
+		t.Fatalf("CONNECT status = %q, want 200 Connection Established", got)
+	}
+
+	// Verify the established tunnel carries bytes in both directions.
+	clientReader := bufio.NewReader(conn)
+	if _, err := fmt.Fprintf(conn, "hello through tunnel"); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, len("hello through tunnel"))
+	if _, err := remotePeer.Read(buf); err != nil {
+		t.Fatalf("read tunneled bytes: %v", err)
+	}
+	if string(buf) != "hello through tunnel" {
+		t.Fatalf("tunneled bytes = %q", buf)
+	}
+	if _, err := remotePeer.Write([]byte("reply from origin")); err != nil {
+		t.Fatal(err)
+	}
+	reply := make([]byte, len("reply from origin"))
+	if _, err := io.ReadFull(clientReader, reply); err != nil {
+		t.Fatalf("read tunneled reply: %v", err)
+	}
+	if string(reply) != "reply from origin" {
+		t.Fatalf("tunneled reply = %q", reply)
 	}
 }

--- a/internal/packageimport/remote_security_test.go
+++ b/internal/packageimport/remote_security_test.go
@@ -269,3 +269,84 @@ func TestGitProxyCONNECTWritesRealCRLF200Status(t *testing.T) {
 		t.Fatalf("tunneled reply = %q", reply)
 	}
 }
+
+// staticResolver resolves every hostname to a fixed address list.
+type staticResolver struct {
+	ips []net.IPAddr
+}
+
+func (s staticResolver) LookupIPAddr(_ context.Context, _ string) ([]net.IPAddr, error) {
+	return s.ips, nil
+}
+
+// TestDialValidatedRemoteSkipsForbiddenAndConnectsAllowed exercises the real
+// dialValidatedRemote address-selection loop: forbidden addresses from the
+// resolution list must be skipped and the first allowed one dialed.
+func TestDialValidatedRemoteSkipsForbiddenAndConnectsAllowed(t *testing.T) {
+	ctx := context.Background()
+	var dialed []string
+	dial := func(_ context.Context, network, address string) (net.Conn, error) {
+		dialed = append(dialed, address)
+		conn, _ := net.Pipe()
+		return conn, nil
+	}
+	resolver := staticResolver{ips: []net.IPAddr{
+		{IP: net.ParseIP("127.0.0.1")},     // loopback: forbidden
+		{IP: net.ParseIP("10.0.0.5")},      // RFC1918: forbidden
+		{IP: net.ParseIP("203.0.113.7")},   // TEST-NET-3: forbidden
+		{IP: net.ParseIP("93.184.216.34")}, // example.com: allowed
+	}}
+	allowAll := func(_ context.Context, _ string) error { return nil }
+	conn, err := dialValidatedRemoteWith(ctx, "allowed.example:443", allowAll, resolver, dial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if len(dialed) != 1 || dialed[0] != "93.184.216.34:443" {
+		t.Fatalf("dialed addresses = %v, want only the allowed 93.184.216.34:443", dialed)
+	}
+}
+
+// TestDialValidatedRemoteFailsWhenEveryAddressIsForbidden locks the error
+// contract when DNS returns only addresses that must never be dialed.
+func TestDialValidatedRemoteFailsWhenEveryAddressIsForbidden(t *testing.T) {
+	ctx := context.Background()
+	resolver := staticResolver{ips: []net.IPAddr{
+		{IP: net.ParseIP("127.0.0.1")},
+		{IP: net.ParseIP("::1")},
+	}}
+	var dialed []string
+	dial := func(_ context.Context, network, address string) (net.Conn, error) {
+		dialed = append(dialed, address)
+		conn, _ := net.Pipe()
+		return conn, nil
+	}
+	allowAll := func(_ context.Context, _ string) error { return nil }
+	_, err := dialValidatedRemoteWith(ctx, "loopback.test:443", allowAll, resolver, dial)
+	if err == nil || !strings.Contains(err.Error(), "unable to connect to allowed address") {
+		t.Fatalf("all-forbidden error = %v", err)
+	}
+	if len(dialed) != 0 {
+		t.Fatalf("dialed %d forbidden addresses: %v", len(dialed), dialed)
+	}
+}
+
+// TestDialValidatedRemoteHonorsValidatorFailure checks that a policy rejection
+// aborts before any DNS resolution or dial happens.
+func TestDialValidatedRemoteHonorsValidatorFailure(t *testing.T) {
+	ctx := context.Background()
+	reject := func(_ context.Context, raw string) error { return fmt.Errorf("policy rejects %s", raw) }
+	var dialed bool
+	dial := func(_ context.Context, network, address string) (net.Conn, error) {
+		dialed = true
+		conn, _ := net.Pipe()
+		return conn, nil
+	}
+	_, err := dialValidatedRemoteWith(ctx, "denied.example:443", reject, staticResolver{}, dial)
+	if err == nil || !strings.Contains(err.Error(), "policy rejects") {
+		t.Fatalf("validator error = %v", err)
+	}
+	if dialed {
+		t.Fatal("dialed despite validator rejection")
+	}
+}

--- a/internal/packageimport/remote_security_test.go
+++ b/internal/packageimport/remote_security_test.go
@@ -1,11 +1,16 @@
 package packageimport
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestDefaultRemoteTargetValidatorRejectsPrivateAndSpecialAddresses(t *testing.T) {
@@ -66,5 +71,91 @@ func TestPrepareGitSourceRejectsPrivateRemoteBeforeGitFetch(t *testing.T) {
 	_, err := imp.prepareGitSource(context.Background(), "https://127.0.0.1/repo.git", t.TempDir())
 	if err == nil || !strings.Contains(err.Error(), "private or special") {
 		t.Fatalf("private Git remote error = %v", err)
+	}
+}
+
+// hostAllowlistValidator implements the documented host-level contract for
+// RemoteTargetValidator: it decides on scheme, host, and port and must not
+// depend on a path, because Git CONNECT validation receives a synthetic
+// "https://host:port" URL.
+func hostAllowlistValidator(allowedHost string) (func(context.Context, string) error, *[]string) {
+	var seen sync.Mutex
+	var calls []string
+	return func(_ context.Context, raw string) error {
+		seen.Lock()
+		calls = append(calls, raw)
+		seen.Unlock()
+		u, err := url.Parse(raw)
+		if err != nil {
+			return err
+		}
+		if u.Hostname() != allowedHost {
+			return fmt.Errorf("remote host %q is not allowed", u.Hostname())
+		}
+		return nil
+	}, &calls
+}
+
+// TestGitProxyCONNECTRejectsNonAllowlistedHost exercises the CONNECT
+// validation path that previously had no direct coverage: a policy that
+// allows only one host must reject CONNECT targets outside that allowlist.
+func TestGitProxyCONNECTRejectsNonAllowlistedHost(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	validate, _ := hostAllowlistValidator("allowed.example.com")
+	proxy, err := startValidatedGitProxy(ctx, validate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proxy.Close()
+
+	conn, err := net.DialTimeout("tcp", proxy.listener.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, err := fmt.Fprintf(conn, "CONNECT denied.example.com:443 HTTP/1.1\r\nHost: denied.example.com:443\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	status, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(status, "403") {
+		t.Fatalf("CONNECT status = %q, want 403", strings.TrimSpace(status))
+	}
+}
+
+// TestGitProxyCONNECTNeverRelaxesIPPinAndUsesSyntheticURL checks that the
+// proxy still rejects a host the policy allows when the host resolves to a
+// forbidden address (DNS pinning is not bypassed by a permissive policy), and
+// that the validator is consulted with a synthetic host-only URL.
+func TestGitProxyCONNECTNeverRelaxesIPPinAndUsesSyntheticURL(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	validate, calls := hostAllowlistValidator("localhost")
+	proxy, err := startValidatedGitProxy(ctx, validate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proxy.Close()
+
+	conn, err := net.DialTimeout("tcp", proxy.listener.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, err := fmt.Fprintf(conn, "CONNECT localhost:443 HTTP/1.1\r\nHost: localhost:443\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	status, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(status, "403") {
+		t.Fatalf("CONNECT status = %q, want 403 for loopback resolution", strings.TrimSpace(status))
+	}
+	if len(*calls) == 0 || !strings.HasPrefix((*calls)[0], "https://localhost:443") {
+		t.Fatalf("validator calls = %v, want synthetic https://localhost:443 URL", *calls)
 	}
 }


### PR DESCRIPTION
## 问题
服务端远程归档和 HTTPS Git 导入直接访问用户提供的 URL，未限制私网地址，也未校验重定向目标。

## 影响
攻击者可借助 Admin 导入接口访问 loopback、RFC1918、链路本地地址或云元数据服务，形成 SSRF，并可能探测或调用内部服务。Git 和 HTTP 重定向还可能绕过只检查初始地址的防护。

## 修复内容
- 为服务端导入增加统一的远程目标校验。
- 拒绝 loopback、private、link-local、multicast、unspecified、文档保留网段及其他非 global-unicast 地址。
- HTTP 重定向目标重新校验。
- HTTP 连接解析后仅拨号到已验证的公网地址，降低 DNS rebinding 风险。
- Git 禁止跟随 HTTP 重定向。
- 增加私网地址、非 HTTP URL 和重定向校验测试。

## 验证
- `go test ./internal/packageimport -run 'Test(DefaultRemoteTargetValidator|RemoteHTTPClientRevalidatesRedirects|PrepareGitSourceRejectsPrivateRemote)'` 通过。
- `go test ./cmd/octobus` 通过。
