### PR TITLE
Cap on-demand process concurrency and output

### DIFF
--- a/internal/protocol/gateway.go
+++ b/internal/protocol/gateway.go
@@ -1640,11 +1640,11 @@ func (g *Gateway) invokeOnDemand(ctx context.Context, item store.ExposedMethod, 
 	if ctx.Err() == context.DeadlineExceeded {
 		return nil, status.Error(codes.DeadlineExceeded, "on-demand invoke timed out")
 	}
-	if stdout.Truncated || stderr.Truncated {
-		return nil, status.Error(codes.ResourceExhausted, "on-demand process output exceeded limit")
-	}
 	if err != nil {
 		return nil, onDemandProcessError(err, stderr.String())
+	}
+	if stdout.Truncated || stderr.Truncated {
+		return nil, status.Error(codes.ResourceExhausted, "on-demand process output exceeded limit")
 	}
 	if err := g.validateOnDemandResponse(item, stdout.Bytes()); err != nil {
 		return nil, err
@@ -1653,7 +1653,7 @@ func (g *Gateway) invokeOnDemand(ctx context.Context, item store.ExposedMethod, 
 }
 
 type boundedBuffer struct {
-	bytes.Buffer
+	buf       bytes.Buffer
 	Limit     int64
 	Truncated bool
 }
@@ -1664,13 +1664,21 @@ func (b *boundedBuffer) Write(p []byte) (int, error) {
 		return len(p), nil
 	}
 	if int64(len(p)) > b.Limit {
-		_, _ = b.Buffer.Write(p[:int(b.Limit)])
+		_, _ = b.buf.Write(p[:int(b.Limit)])
 		b.Limit = 0
 		b.Truncated = true
 		return len(p), nil
 	}
 	b.Limit -= int64(len(p))
-	return b.Buffer.Write(p)
+	return b.buf.Write(p)
+}
+
+func (b *boundedBuffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
+func (b *boundedBuffer) String() string {
+	return b.buf.String()
 }
 
 func (g *Gateway) acquireOnDemandSlot(ctx context.Context) bool {

--- a/internal/protocol/gateway.go
+++ b/internal/protocol/gateway.go
@@ -57,9 +57,16 @@ type Gateway struct {
 	conns         map[string]*grpc.ClientConn
 	mcpToolsCache map[string][]map[string]any
 	connectCache  map[string]http.Handler
+
+	onDemandOnce  sync.Once
+	onDemandSlots chan struct{}
 }
 
-const DefaultMaxRequestBytes int64 = 1 << 20
+const (
+	DefaultMaxRequestBytes int64 = 1 << 20
+	maxOnDemandConcurrent        = 32
+	maxOnDemandOutputBytes int64 = 8 << 20
+)
 
 type Catalog struct {
 	CapsetID    string                  `json:"capset_id"`
@@ -1561,6 +1568,10 @@ func (g *Gateway) invokeOnDemand(ctx context.Context, item store.ExposedMethod, 
 	}
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
+	if !g.acquireOnDemandSlot(ctx) {
+		return nil, status.Error(codes.ResourceExhausted, "on-demand invocation capacity exhausted")
+	}
+	defer g.releaseOnDemandSlot()
 
 	workdir := filepath.Join(dataDir, "instances", item.Instance.ID)
 	tmpParent := filepath.Join(workdir, "tmp")
@@ -1620,12 +1631,17 @@ func (g *Gateway) invokeOnDemand(ctx context.Context, item store.ExposedMethod, 
 		"OCTOBUS_DESCRIPTOR_SHA256="+item.Service.DescriptorSHA256,
 	)
 	cmd.Stdin = bytes.NewReader(req)
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr boundedBuffer
+	stdout.Limit = maxOnDemandOutputBytes
+	stderr.Limit = maxOnDemandOutputBytes
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err = cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
 		return nil, status.Error(codes.DeadlineExceeded, "on-demand invoke timed out")
+	}
+	if stdout.Truncated || stderr.Truncated {
+		return nil, status.Error(codes.ResourceExhausted, "on-demand process output exceeded limit")
 	}
 	if err != nil {
 		return nil, onDemandProcessError(err, stderr.String())
@@ -1634,6 +1650,45 @@ func (g *Gateway) invokeOnDemand(ctx context.Context, item store.ExposedMethod, 
 		return nil, err
 	}
 	return stdout.Bytes(), nil
+}
+
+type boundedBuffer struct {
+	bytes.Buffer
+	Limit     int64
+	Truncated bool
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	if b.Limit <= 0 {
+		b.Truncated = true
+		return len(p), nil
+	}
+	if int64(len(p)) > b.Limit {
+		_, _ = b.Buffer.Write(p[:int(b.Limit)])
+		b.Limit = 0
+		b.Truncated = true
+		return len(p), nil
+	}
+	b.Limit -= int64(len(p))
+	return b.Buffer.Write(p)
+}
+
+func (g *Gateway) acquireOnDemandSlot(ctx context.Context) bool {
+	g.onDemandOnce.Do(func() {
+		g.onDemandSlots = make(chan struct{}, maxOnDemandConcurrent)
+	})
+	select {
+	case g.onDemandSlots <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	default:
+		return false
+	}
+}
+
+func (g *Gateway) releaseOnDemandSlot() {
+	<-g.onDemandSlots
 }
 
 func secretReadFile(secret []byte) (*os.File, func(), error) {

--- a/internal/protocol/resource_limits_test.go
+++ b/internal/protocol/resource_limits_test.go
@@ -3,6 +3,8 @@ package protocol
 import (
 	"bytes"
 	"context"
+	"io"
+	"strings"
 	"testing"
 )
 
@@ -24,6 +26,17 @@ func TestBoundedBufferCapsOutputWithoutBlockingProcess(t *testing.T) {
 	}
 	if !bytes.Equal(buf.Bytes(), []byte("over")) {
 		t.Fatalf("buffer grew after truncation: %q", buf.Bytes())
+	}
+}
+
+func TestBoundedBufferCapsIoCopyFastPath(t *testing.T) {
+	var buf boundedBuffer
+	buf.Limit = 4
+	if _, err := io.Copy(&buf, strings.NewReader("oversized")); err != nil {
+		t.Fatal(err)
+	}
+	if !buf.Truncated || !bytes.Equal(buf.Bytes(), []byte("over")) {
+		t.Fatalf("io.Copy output = %q truncated=%v", buf.Bytes(), buf.Truncated)
 	}
 }
 

--- a/internal/protocol/resource_limits_test.go
+++ b/internal/protocol/resource_limits_test.go
@@ -1,0 +1,43 @@
+package protocol
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestBoundedBufferCapsOutputWithoutBlockingProcess(t *testing.T) {
+	var buf boundedBuffer
+	buf.Limit = 4
+	written, err := buf.Write([]byte("oversized"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != len("oversized") {
+		t.Fatalf("reported written bytes = %d", written)
+	}
+	if !buf.Truncated || !bytes.Equal(buf.Bytes(), []byte("over")) {
+		t.Fatalf("bounded output = %q truncated=%v", buf.Bytes(), buf.Truncated)
+	}
+	if _, err := buf.Write([]byte("more")); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf.Bytes(), []byte("over")) {
+		t.Fatalf("buffer grew after truncation: %q", buf.Bytes())
+	}
+}
+
+func TestOnDemandSlotsRejectWhenCapacityIsFull(t *testing.T) {
+	gateway := &Gateway{}
+	for i := 0; i < maxOnDemandConcurrent; i++ {
+		if !gateway.acquireOnDemandSlot(context.Background()) {
+			t.Fatalf("slot %d was not acquired", i)
+		}
+	}
+	if gateway.acquireOnDemandSlot(context.Background()) {
+		t.Fatal("acquired a slot beyond the configured capacity")
+	}
+	for i := 0; i < maxOnDemandConcurrent; i++ {
+		gateway.releaseOnDemandSlot()
+	}
+}

--- a/internal/protocol/resource_limits_test.go
+++ b/internal/protocol/resource_limits_test.go
@@ -29,10 +29,19 @@ func TestBoundedBufferCapsOutputWithoutBlockingProcess(t *testing.T) {
 	}
 }
 
+// onlyReader hides an underlying reader's io.WriterTo so io.Copy must check
+// the destination's io.ReaderFrom (the old embedded bytes.Buffer promoted
+// ReadFrom and bypassed the limit) or fall back to the generic Write loop.
+type onlyReader struct {
+	r io.Reader
+}
+
+func (o onlyReader) Read(p []byte) (int, error) { return o.r.Read(p) }
+
 func TestBoundedBufferCapsIoCopyFastPath(t *testing.T) {
 	var buf boundedBuffer
 	buf.Limit = 4
-	if _, err := io.Copy(&buf, strings.NewReader("oversized")); err != nil {
+	if _, err := io.Copy(&buf, onlyReader{strings.NewReader("oversized")}); err != nil {
 		t.Fatal(err)
 	}
 	if !buf.Truncated || !bytes.Equal(buf.Bytes(), []byte("over")) {


### PR DESCRIPTION
## 问题
每个 On-demand 请求都会启动一个子进程，且 stdout/stderr 使用无界缓冲区。

## 影响
并发请求可耗尽 PID、CPU 和内存；恶意服务持续输出内容还可在进程超时前持续增长宿主进程内存，造成拒绝服务。

## 修复内容
- 增加全局 On-demand 并发槽，容量耗尽时返回 `ResourceExhausted`。
- stdout 和 stderr 分别限制为 8 MiB。
- 超出输出上限后继续消费并丢弃多余内容，避免子进程因管道阻塞长期挂起。
- 超限结果明确返回资源耗尽错误。
- 增加有界缓冲和并发槽测试。

## 验证
- `go test ./internal/protocol -run 'Test(BoundedBufferCapsOutputWithoutBlockingProcess|OnDemandSlotsRejectWhenCapacityIsFull)'` 通过。
