### PR TITLE
Bound access log query and response sizes

### DIFF
--- a/internal/accesslog/accesslog.go
+++ b/internal/accesslog/accesslog.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	FileName     = "access.log"
-	ContentType  = "application/x-ndjson"
-	DefaultLimit = 200
+	FileName               = "access.log"
+	ContentType            = "application/x-ndjson"
+	DefaultLimit           = 200
+	MaxFilterEntries       = 10_000
+	MaxResponseBytes int64 = 64 << 20
 )
 
 type Record struct {
@@ -95,8 +97,8 @@ type Filter struct {
 }
 
 func ReadFile(path string, filter Filter, w io.Writer) error {
-	if filter.Limit < 0 {
-		return fmt.Errorf("limit must be non-negative")
+	if err := validateFilterLimits(filter); err != nil {
+		return err
 	}
 	f, err := os.Open(path)
 	if err != nil {
@@ -110,6 +112,9 @@ func ReadFile(path string, filter Filter, w io.Writer) error {
 }
 
 func FilterLines(r io.Reader, filter Filter, w io.Writer) error {
+	if err := validateFilterLimits(filter); err != nil {
+		return err
+	}
 	if filter.Limit < 0 {
 		return fmt.Errorf("limit must be non-negative")
 	}
@@ -181,6 +186,16 @@ func FilterLines(r io.Reader, filter Filter, w io.Writer) error {
 		if _, err := w.Write([]byte("\n")); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func validateFilterLimits(filter Filter) error {
+	if filter.Limit > MaxFilterEntries {
+		return fmt.Errorf("limit must not exceed %d", MaxFilterEntries)
+	}
+	if filter.Tail > MaxFilterEntries {
+		return fmt.Errorf("tail must not exceed %d", MaxFilterEntries)
 	}
 	return nil
 }

--- a/internal/accesslog/accesslog.go
+++ b/internal/accesslog/accesslog.go
@@ -115,12 +115,6 @@ func FilterLines(r io.Reader, filter Filter, w io.Writer) error {
 	if err := validateFilterLimits(filter); err != nil {
 		return err
 	}
-	if filter.Limit < 0 {
-		return fmt.Errorf("limit must be non-negative")
-	}
-	if filter.Tail < 0 {
-		return fmt.Errorf("tail must be non-negative")
-	}
 	if filter.LimitSet && filter.TailSet {
 		return fmt.Errorf("limit and tail are mutually exclusive")
 	}
@@ -207,11 +201,8 @@ func validateFilterLimits(filter Filter) error {
 }
 
 func FollowFile(path string, filter Filter, w io.Writer, done <-chan struct{}) error {
-	if filter.Limit < 0 {
-		return fmt.Errorf("limit must be non-negative")
-	}
-	if filter.Tail < 0 {
-		return fmt.Errorf("tail must be non-negative")
+	if err := validateFilterLimits(filter); err != nil {
+		return err
 	}
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/accesslog/accesslog.go
+++ b/internal/accesslog/accesslog.go
@@ -191,6 +191,12 @@ func FilterLines(r io.Reader, filter Filter, w io.Writer) error {
 }
 
 func validateFilterLimits(filter Filter) error {
+	if filter.Limit < 0 {
+		return fmt.Errorf("limit must be non-negative")
+	}
+	if filter.Tail < 0 {
+		return fmt.Errorf("tail must be non-negative")
+	}
 	if filter.Limit > MaxFilterEntries {
 		return fmt.Errorf("limit must not exceed %d", MaxFilterEntries)
 	}

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -196,8 +196,13 @@ func (s *Server) handleAccessLogs(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	var out bytes.Buffer
+	var out boundedLogBuffer
+	out.Remaining = accesslog.MaxResponseBytes
 	if err := accesslog.ReadFile(path, filter, &out); err != nil {
+		if errors.Is(err, errAccessLogResponseTooLarge) {
+			writeError(w, http.StatusRequestEntityTooLarge, err.Error())
+			return
+		}
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -222,6 +227,9 @@ func parseAccessLogQuery(r *http.Request) (accesslog.Filter, error) {
 		if err != nil || limit < 0 {
 			return accesslog.Filter{}, fmt.Errorf("limit must be non-negative")
 		}
+		if limit > accesslog.MaxFilterEntries {
+			return accesslog.Filter{}, fmt.Errorf("limit must not exceed %d", accesslog.MaxFilterEntries)
+		}
 		filter.Limit = limit
 		filter.LimitSet = true
 	}
@@ -233,6 +241,9 @@ func parseAccessLogQuery(r *http.Request) (accesslog.Filter, error) {
 		tail, err := strconv.Atoi(raw)
 		if err != nil || tail < 0 {
 			return accesslog.Filter{}, fmt.Errorf("tail must be non-negative")
+		}
+		if tail > accesslog.MaxFilterEntries {
+			return accesslog.Filter{}, fmt.Errorf("tail must not exceed %d", accesslog.MaxFilterEntries)
 		}
 		filter.Tail = tail
 		filter.TailSet = true
@@ -260,6 +271,21 @@ func parseAccessLogQuery(r *http.Request) (accesslog.Filter, error) {
 func (s *Server) echoAccessLogs(c *echo.Context) error {
 	s.handleAccessLogs(c.Response(), c.Request())
 	return nil
+}
+
+var errAccessLogResponseTooLarge = errors.New("access log response exceeds configured size limit")
+
+type boundedLogBuffer struct {
+	bytes.Buffer
+	Remaining int64
+}
+
+func (b *boundedLogBuffer) Write(p []byte) (int, error) {
+	if int64(len(p)) > b.Remaining {
+		return 0, errAccessLogResponseTooLarge
+	}
+	b.Remaining -= int64(len(p))
+	return b.Buffer.Write(p)
 }
 
 type flushResponseWriter struct {

--- a/internal/admin/log_limits_test.go
+++ b/internal/admin/log_limits_test.go
@@ -1,0 +1,34 @@
+package admin
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"octobus/internal/accesslog"
+)
+
+func TestParseAccessLogQueryRejectsUnboundedEntryCounts(t *testing.T) {
+	for _, name := range []string{"limit", "tail"} {
+		req := httptest.NewRequest("GET", "/admin/v1/logs/access?"+name+"="+strconv.Itoa(accesslog.MaxFilterEntries+1), nil)
+		if _, err := parseAccessLogQuery(req); err == nil {
+			t.Fatalf("%s query was accepted", name)
+		}
+	}
+}
+
+func TestBoundedLogBufferRejectsOversizedResponse(t *testing.T) {
+	var out boundedLogBuffer
+	out.Remaining = 3
+	if _, err := out.Write([]byte("four")); err == nil {
+		t.Fatal("oversized access log response was accepted")
+	}
+	if out.Len() != 0 || !bytes.Equal(out.Bytes(), nil) {
+		t.Fatalf("partial oversized response was retained: %q", out.Bytes())
+	}
+	if !strings.Contains(errAccessLogResponseTooLarge.Error(), "size limit") {
+		t.Fatal("oversize error does not describe the configured limit")
+	}
+}


### PR DESCRIPTION
## 问题
访问日志接口只校验 `limit` 和 `tail` 非负，没有最大值；非 follow 查询还会先将结果完整缓存在内存中。

## 影响
恶意请求可以提交极大的 `limit`/`tail`，触发超大切片分配或让日志查询长期占用内存。超长日志行和大量结果还可能形成大响应，导致拒绝服务。

## 修复内容
- `limit` 和 `tail` 最大限制为 10000 条。
- `FilterLines`、`ReadFile`、`FollowFile` 共用边界校验，避免绕过 HTTP 层。
- Admin 非 follow 响应限制为 64 MiB，并使用有界缓冲区。
- 超过响应大小时返回 `413 Request Entity Too Large`。
- 增加参数上限和响应缓冲测试。

## 验证
- `go test ./internal/accesslog ./internal/admin -run 'Test(ParseAccessLogQueryRejectsUnboundedEntryCounts|BoundedLogBufferRejectsOversizedResponse|AccessLog|ParseAccessLogQueryBoundaries)'` 通过。
