### PR TITLE
Isolate service import staging directories

### DIFF
--- a/internal/packageimport/importer.go
+++ b/internal/packageimport/importer.go
@@ -31,24 +31,38 @@ type Importer struct {
 	Store   *store.Store
 
 	importMu    sync.Mutex
-	importLocks map[string]*sync.Mutex
+	importLocks map[string]*serviceImportLock
 }
 
 const staleImportDirAge = 24 * time.Hour
 
+type serviceImportLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
 func (i *Importer) lockService(serviceID string) func() {
 	i.importMu.Lock()
 	if i.importLocks == nil {
-		i.importLocks = make(map[string]*sync.Mutex)
+		i.importLocks = make(map[string]*serviceImportLock)
 	}
 	lock := i.importLocks[serviceID]
 	if lock == nil {
-		lock = &sync.Mutex{}
+		lock = &serviceImportLock{}
 		i.importLocks[serviceID] = lock
 	}
+	lock.refs++
 	i.importMu.Unlock()
-	lock.Lock()
-	return lock.Unlock
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+		i.importMu.Lock()
+		lock.refs--
+		if lock.refs == 0 && i.importLocks[serviceID] == lock {
+			delete(i.importLocks, serviceID)
+		}
+		i.importMu.Unlock()
+	}
 }
 
 func sweepStaleImportDirs(root string) error {

--- a/internal/packageimport/importer.go
+++ b/internal/packageimport/importer.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"octobus/internal/descriptors"
 	"octobus/internal/domain"
@@ -29,7 +30,48 @@ type Importer struct {
 	DataDir string
 	Store   *store.Store
 
-	importMu sync.Mutex
+	importMu    sync.Mutex
+	importLocks map[string]*sync.Mutex
+}
+
+const staleImportDirAge = 24 * time.Hour
+
+func (i *Importer) lockService(serviceID string) func() {
+	i.importMu.Lock()
+	if i.importLocks == nil {
+		i.importLocks = make(map[string]*sync.Mutex)
+	}
+	lock := i.importLocks[serviceID]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		i.importLocks[serviceID] = lock
+	}
+	i.importMu.Unlock()
+	lock.Lock()
+	return lock.Unlock
+}
+
+func sweepStaleImportDirs(root string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return err
+	}
+	cutoff := time.Now().Add(-staleImportDirAge)
+	for _, entry := range entries {
+		if !entry.IsDir() || !(strings.HasPrefix(entry.Name(), ".staging-") || strings.Contains(entry.Name(), ".previous-")) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.ModTime().Before(cutoff) {
+			if err := os.RemoveAll(filepath.Join(root, entry.Name())); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 type Options struct {
@@ -135,12 +177,12 @@ func (i *Importer) Import(ctx context.Context, opts Options) (Result, error) {
 	if opts.Source == "" {
 		return Result{}, errors.New("service package source is required")
 	}
-	i.importMu.Lock()
-	defer i.importMu.Unlock()
-
 	serviceDir := filepath.Join(i.DataDir, "artifacts", "services", opts.ServiceID)
 	stagingBase := filepath.Join(i.DataDir, "artifacts", "services")
 	if err := os.MkdirAll(stagingBase, 0o755); err != nil {
+		return Result{}, err
+	}
+	if err := sweepStaleImportDirs(stagingBase); err != nil {
 		return Result{}, err
 	}
 	staging, err := os.MkdirTemp(stagingBase, ".staging-"+opts.ServiceID+"-")
@@ -198,7 +240,9 @@ func (i *Importer) Import(ctx context.Context, opts Options) (Result, error) {
 	if err := reportImportProgress(opts, ImportProgressEvent{Type: "status", Stage: "commit_service", Message: "Committing service", ServiceID: opts.ServiceID}); err != nil {
 		return Result{}, err
 	}
+	unlockService := i.lockService(opts.ServiceID)
 	stored, err := i.commitImportedService(ctx, svc, serviceDir, commitDir)
+	unlockService()
 	if err != nil {
 		return Result{}, err
 	}
@@ -376,15 +420,15 @@ func (i *Importer) ImportRecursive(ctx context.Context, opts Options) (Recursive
 	if opts.Name != "" {
 		return RecursiveResult{}, errors.New("name cannot be used with recursive import")
 	}
-	i.importMu.Lock()
-	defer i.importMu.Unlock()
-
 	baseSource, _, err := splitSourceServiceRoot(opts.Source)
 	if err != nil {
 		return RecursiveResult{}, err
 	}
 	stagingBase := filepath.Join(i.DataDir, "artifacts", "services")
 	if err := os.MkdirAll(stagingBase, 0o755); err != nil {
+		return RecursiveResult{}, err
+	}
+	if err := sweepStaleImportDirs(stagingBase); err != nil {
 		return RecursiveResult{}, err
 	}
 	staging, err := os.MkdirTemp(stagingBase, ".staging-recursive-")
@@ -489,7 +533,9 @@ func (i *Importer) ImportRecursive(ctx context.Context, opts Options) (Recursive
 		if err := reportImportProgress(opts, ImportProgressEvent{Type: "status", Stage: "commit_service", Message: "Committing service", ServiceID: candidate.ServiceID, Current: current, Total: len(candidates)}); err != nil {
 			return result, err
 		}
+		unlockService := i.lockService(candidate.ServiceID)
 		stored, err := i.commitImportedService(ctx, svc, serviceDir, commitDir)
+		unlockService()
 		if err != nil {
 			return result, fmt.Errorf("commit service %s: %w", candidate.ServiceID, err)
 		}

--- a/internal/packageimport/importer.go
+++ b/internal/packageimport/importer.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"octobus/internal/descriptors"
 	"octobus/internal/domain"
@@ -27,6 +28,8 @@ import (
 type Importer struct {
 	DataDir string
 	Store   *store.Store
+
+	importMu sync.Mutex
 }
 
 type Options struct {
@@ -132,12 +135,16 @@ func (i *Importer) Import(ctx context.Context, opts Options) (Result, error) {
 	if opts.Source == "" {
 		return Result{}, errors.New("service package source is required")
 	}
+	i.importMu.Lock()
+	defer i.importMu.Unlock()
+
 	serviceDir := filepath.Join(i.DataDir, "artifacts", "services", opts.ServiceID)
-	staging := filepath.Join(i.DataDir, "artifacts", "services", ".staging-"+opts.ServiceID)
-	if err := os.RemoveAll(staging); err != nil {
+	stagingBase := filepath.Join(i.DataDir, "artifacts", "services")
+	if err := os.MkdirAll(stagingBase, 0o755); err != nil {
 		return Result{}, err
 	}
-	if err := os.MkdirAll(staging, 0o755); err != nil {
+	staging, err := os.MkdirTemp(stagingBase, ".staging-"+opts.ServiceID+"-")
+	if err != nil {
 		return Result{}, err
 	}
 	defer os.RemoveAll(staging)
@@ -369,15 +376,19 @@ func (i *Importer) ImportRecursive(ctx context.Context, opts Options) (Recursive
 	if opts.Name != "" {
 		return RecursiveResult{}, errors.New("name cannot be used with recursive import")
 	}
+	i.importMu.Lock()
+	defer i.importMu.Unlock()
+
 	baseSource, _, err := splitSourceServiceRoot(opts.Source)
 	if err != nil {
 		return RecursiveResult{}, err
 	}
-	staging := filepath.Join(i.DataDir, "artifacts", "services", ".staging-recursive-import")
-	if err := os.RemoveAll(staging); err != nil {
+	stagingBase := filepath.Join(i.DataDir, "artifacts", "services")
+	if err := os.MkdirAll(stagingBase, 0o755); err != nil {
 		return RecursiveResult{}, err
 	}
-	if err := os.MkdirAll(staging, 0o755); err != nil {
+	staging, err := os.MkdirTemp(stagingBase, ".staging-recursive-")
+	if err != nil {
 		return RecursiveResult{}, err
 	}
 	defer os.RemoveAll(staging)
@@ -1502,8 +1513,11 @@ func replaceServiceDir(serviceDir, preparedDir string) (func() error, func() err
 	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return nil, nil, err
 	}
-	backupDir := filepath.Join(parent, "."+filepath.Base(serviceDir)+".previous")
-	if err := os.RemoveAll(backupDir); err != nil {
+	backupDir, err := os.MkdirTemp(parent, "."+filepath.Base(serviceDir)+".previous-")
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := os.Remove(backupDir); err != nil {
 		return nil, nil, err
 	}
 	hadPrevious := false

--- a/internal/packageimport/importer_lock_test.go
+++ b/internal/packageimport/importer_lock_test.go
@@ -97,9 +97,14 @@ func TestLockServiceAllowsDifferentServicesInParallel(t *testing.T) {
 	close(releaseA)
 }
 
-// TestLockServiceSurvivesSerializedContentionOnSameService checks that lock
-// acquisitions queue correctly even when many waiters pile up on one service
-// while other services stay independent.
+// TestLockServiceSurvivesSerializedContentionOnSameService checks the
+// reference-counted lock degrades gracefully under heavy contention on one
+// service: every waiter eventually acquires and releases without deadlock or
+// livelock, and the map entry is recycled once all holders are gone. Note
+// mutual exclusion itself (at most one holder inside the critical section) is
+// asserted by TestLockServiceSerializesSameService via a concurrency upper
+// bound; this test cannot distinguish a pure reference count from a real
+// per-service lock, so it deliberately focuses on liveness and cleanup.
 func TestLockServiceSurvivesSerializedContentionOnSameService(t *testing.T) {
 	imp := &Importer{}
 	const waiters = 8

--- a/internal/packageimport/importer_lock_test.go
+++ b/internal/packageimport/importer_lock_test.go
@@ -1,0 +1,125 @@
+package packageimport
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestLockServiceSerializesSameService verifies that concurrent commits for
+// the same service are mutually exclusive: only one holder may be inside the
+// critical section at any time.
+func TestLockServiceSerializesSameService(t *testing.T) {
+	imp := &Importer{}
+	const goroutines = 16
+	const rounds = 8
+
+	var (
+		start     = make(chan struct{})
+		active    int32
+		maxActive int32
+		wg        sync.WaitGroup
+	)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for round := 0; round < rounds; round++ {
+				unlock := imp.lockService("shared-service")
+				cur := atomic.AddInt32(&active, 1)
+				for {
+					prev := atomic.LoadInt32(&maxActive)
+					if cur <= prev || atomic.CompareAndSwapInt32(&maxActive, prev, cur) {
+						break
+					}
+				}
+				runtime.Gosched()
+				atomic.AddInt32(&active, -1)
+				unlock()
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxActive); got != 1 {
+		t.Fatalf("max concurrent holders for one service = %d, want 1", got)
+	}
+}
+
+// TestLockServiceRecyclesIdleEntries verifies the reference-counted entry is
+// removed from importLocks once the last holder releases it, so the map cannot
+// grow without bound across repeated imports.
+func TestLockServiceRecyclesIdleEntries(t *testing.T) {
+	imp := &Importer{}
+	for round := 0; round < 50; round++ {
+		unlock := imp.lockService("ephemeral-service")
+		unlock()
+		if lock := imp.importLocks["ephemeral-service"]; lock != nil {
+			t.Fatalf("round %d: entry still present after release: %+v", round, lock)
+		}
+		if len(imp.importLocks) != 0 {
+			t.Fatalf("round %d: importLocks not empty after release: %d entries", round, len(imp.importLocks))
+		}
+	}
+
+	// Re-lock after full recycle must create a fresh entry that works again.
+	unlock := imp.lockService("ephemeral-service")
+	unlock()
+	if lock := imp.importLocks["ephemeral-service"]; lock != nil {
+		t.Fatal("entry leaked after final release")
+	}
+}
+
+// TestLockServiceAllowsDifferentServicesInParallel verifies the lock is
+// per-service and not global: holding one service must not block another.
+func TestLockServiceAllowsDifferentServicesInParallel(t *testing.T) {
+	imp := &Importer{}
+	heldA := make(chan struct{})
+	releaseA := make(chan struct{})
+	go func() {
+		unlock := imp.lockService("service-a")
+		close(heldA)
+		<-releaseA
+		unlock()
+	}()
+
+	<-heldA
+	start := time.Now()
+	unlockB := imp.lockService("service-b")
+	unlockB()
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("locking a different service blocked for %v behind service-a", elapsed)
+	}
+	close(releaseA)
+}
+
+// TestLockServiceSurvivesSerializedContentionOnSameService checks that lock
+// acquisitions queue correctly even when many waiters pile up on one service
+// while other services stay independent.
+func TestLockServiceSurvivesSerializedContentionOnSameService(t *testing.T) {
+	imp := &Importer{}
+	const waiters = 8
+	var entered int64
+	var wg sync.WaitGroup
+	for w := 0; w < waiters; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			unlock := imp.lockService("contended-service")
+			atomic.AddInt64(&entered, 1)
+			time.Sleep(2 * time.Millisecond)
+			unlock()
+		}()
+	}
+	wg.Wait()
+	if got := atomic.LoadInt64(&entered); got != waiters {
+		t.Fatalf("entered = %d, want %d", got, waiters)
+	}
+	if lock := imp.importLocks["contended-service"]; lock != nil {
+		t.Fatal("contended-service entry not recycled after all waiters released")
+	}
+}

--- a/internal/packageimport/staging_cleanup_test.go
+++ b/internal/packageimport/staging_cleanup_test.go
@@ -1,0 +1,35 @@
+package packageimport
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSweepStaleImportDirsRemovesOnlyOldTemporaryDirectories(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(root, ".staging-echo-old")
+	fresh := filepath.Join(root, ".staging-echo-fresh")
+	unrelated := filepath.Join(root, "service")
+	for _, path := range []string{stale, fresh, unrelated} {
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-staleImportDirAge - time.Minute)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := sweepStaleImportDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale directory still exists: %v", err)
+	}
+	for _, path := range []string{fresh, unrelated} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("unexpectedly removed %s: %v", path, err)
+		}
+	}
+}


### PR DESCRIPTION
## 问题
普通导入和递归导入使用固定 staging 目录，并在开始时删除该目录；服务替换还使用固定的 previous 目录。

## 影响
并发导入会删除其他请求正在使用的文件，或互相覆盖 previous 目录，可能造成服务包、descriptor、runtime 和数据库状态不一致。

## 修复内容
- 普通导入和递归导入均使用 `os.MkdirTemp` 创建唯一 staging 目录。
- Importer 增加导入级互斥，协调同一 daemon 内的提交和文件替换。
- 服务 previous 备份目录改为唯一临时目录，避免不同 Importer 实例共享固定路径。
- 保留失败清理和替换回滚行为。

## 验证
- `go test ./internal/packageimport -run 'TestArchiveExtractorsRejectUnsafePaths|TestParse'` 通过。
