### PR TITLE
Enforce MCP tool name uniqueness per capset

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -1338,7 +1338,11 @@ func (s *Server) handleCapsetPath(w http.ResponseWriter, r *http.Request, capset
 					}
 				}
 				if err := s.Store.AddCapsetMethod(r.Context(), domain.CapsetMethod{CapsetInstanceID: ci.ID, MethodFullName: method.FullName, MCPToolName: toolName, Enabled: true}); err != nil {
-					writeError(w, http.StatusBadRequest, err.Error())
+					statusCode := http.StatusBadRequest
+					if errors.Is(err, store.ErrMCPToolNameConflict) {
+						statusCode = http.StatusConflict
+					}
+					writeError(w, statusCode, err.Error())
 					return
 				}
 			}
@@ -1440,7 +1444,11 @@ func (s *Server) handleCapsetPath(w http.ResponseWriter, r *http.Request, capset
 			}
 		}
 		if err := s.Store.AddCapsetMethod(r.Context(), domain.CapsetMethod{CapsetInstanceID: ciID, MethodFullName: selected.FullName, MCPToolName: toolName, Enabled: true}); err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
+			statusCode := http.StatusBadRequest
+			if errors.Is(err, store.ErrMCPToolNameConflict) {
+				statusCode = http.StatusConflict
+			}
+			writeError(w, statusCode, err.Error())
 			return
 		}
 		s.logger().Info("capset_method_selected", "capset_id", capsetID, "instance_id", req.InstanceID, "method", selected.FullName, "mcp_tool", toolName)

--- a/internal/store/mcp_tool_name_test.go
+++ b/internal/store/mcp_tool_name_test.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"octobus/internal/domain"
+)
+
+func TestAddCapsetMethodEnforcesToolNameUniquenessWithinCapset(t *testing.T) {
+	st, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+
+	if err := st.UpsertService(ctx, domain.Service{ID: "echo", Name: "Echo"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "echo-instance", ServiceID: "echo", Name: "Echo", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	for _, capsetID := range []string{"dev", "qa"} {
+		if err := st.CreateCapset(ctx, domain.Capset{ID: capsetID, Name: capsetID, Enabled: true}); err != nil {
+			t.Fatal(err)
+		}
+		if err := st.AddCapsetInstance(ctx, domain.CapsetInstance{ID: capsetID + ":echo-instance", CapsetID: capsetID, ServiceID: "echo", InstanceID: "echo-instance", Enabled: true}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	first := domain.CapsetMethod{CapsetInstanceID: "dev:echo-instance", MethodFullName: "echo.Echo/Call", MCPToolName: "shared_tool", Enabled: true}
+	if err := st.AddCapsetMethod(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddCapsetMethod(ctx, domain.CapsetMethod{CapsetInstanceID: "dev:echo-instance", MethodFullName: "echo.Echo/Other", MCPToolName: "shared_tool", Enabled: true}); !errors.Is(err, ErrMCPToolNameConflict) {
+		t.Fatalf("duplicate tool error = %v", err)
+	}
+	if err := st.AddCapsetMethod(ctx, domain.CapsetMethod{CapsetInstanceID: "qa:echo-instance", MethodFullName: "echo.Echo/Call", MCPToolName: "shared_tool", Enabled: true}); err != nil {
+		t.Fatalf("same tool in another capset error = %v", err)
+	}
+}

--- a/internal/store/mcp_tool_name_test.go
+++ b/internal/store/mcp_tool_name_test.go
@@ -3,10 +3,44 @@ package store
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"octobus/internal/domain"
 )
+
+func TestMigrateReportsExistingMCPToolConflicts(t *testing.T) {
+	st, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	if err := st.UpsertService(ctx, domain.Service{ID: "echo", Name: "Echo"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "echo-instance", ServiceID: "echo", Name: "Echo", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.CreateCapset(ctx, domain.Capset{ID: "dev", Name: "Dev", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddCapsetInstance(ctx, domain.CapsetInstance{ID: "dev:echo-instance", CapsetID: "dev", ServiceID: "echo", InstanceID: "echo-instance", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddCapsetMethod(ctx, domain.CapsetMethod{CapsetInstanceID: "dev:echo-instance", MethodFullName: "echo.Echo/Call", MCPToolName: "shared_tool", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `DROP INDEX uq_capset_methods_mcp_tool_key`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `INSERT INTO capset_methods (id, capset_instance_id, method_full_name, mcp_tool_name, mcp_tool_key, created_at, updated_at) VALUES (?, ?, ?, ?, '', ?, ?)`, "duplicate", "dev:echo-instance", "echo.Echo/Other", "shared_tool", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Migrate(ctx); err == nil || !strings.Contains(err.Error(), "conflicting methods") {
+		t.Fatalf("migration conflict error = %v", err)
+	}
+}
 
 func TestAddCapsetMethodEnforcesToolNameUniquenessWithinCapset(t *testing.T) {
 	st, err := Open(":memory:")
@@ -30,6 +64,12 @@ func TestAddCapsetMethodEnforcesToolNameUniquenessWithinCapset(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "echo-copy", ServiceID: "echo", Name: "Echo Copy", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddCapsetInstance(ctx, domain.CapsetInstance{ID: "dev:echo-copy", CapsetID: "dev", ServiceID: "echo", InstanceID: "echo-copy", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
 
 	first := domain.CapsetMethod{CapsetInstanceID: "dev:echo-instance", MethodFullName: "echo.Echo/Call", MCPToolName: "shared_tool", Enabled: true}
 	if err := st.AddCapsetMethod(ctx, first); err != nil {
@@ -37,6 +77,9 @@ func TestAddCapsetMethodEnforcesToolNameUniquenessWithinCapset(t *testing.T) {
 	}
 	if err := st.AddCapsetMethod(ctx, domain.CapsetMethod{CapsetInstanceID: "dev:echo-instance", MethodFullName: "echo.Echo/Other", MCPToolName: "shared_tool", Enabled: true}); !errors.Is(err, ErrMCPToolNameConflict) {
 		t.Fatalf("duplicate tool error = %v", err)
+	}
+	if err := st.AddCapsetMethod(ctx, domain.CapsetMethod{CapsetInstanceID: "dev:echo-copy", MethodFullName: "echo.Echo/Call", MCPToolName: "shared_tool", Enabled: true}); !errors.Is(err, ErrMCPToolNameConflict) {
+		t.Fatalf("cross-instance duplicate tool error = %v", err)
 	}
 	if err := st.AddCapsetMethod(ctx, domain.CapsetMethod{CapsetInstanceID: "qa:echo-instance", MethodFullName: "echo.Echo/Call", MCPToolName: "shared_tool", Enabled: true}); err != nil {
 		t.Fatalf("same tool in another capset error = %v", err)

--- a/internal/store/mcp_tool_name_test.go
+++ b/internal/store/mcp_tool_name_test.go
@@ -104,6 +104,22 @@ func TestMigrateReportsCrossInstanceConflictsWithLegacyIndex(t *testing.T) {
 	if strings.Contains(err.Error(), string(rune(31))) {
 		t.Fatalf("migration conflict error leaks the internal key separator: %v", err)
 	}
+
+	// The conflict must be detected before any destructive step: the legacy
+	// instance-scoped index and the instance-scoped keys must be untouched so
+	// the database can be rolled back losslessly and still rejects duplicate
+	// mcp_tool_key writes.
+	var indexName string
+	if err := st.DB().QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'uq_capset_methods_mcp_tool_key'`).Scan(&indexName); err != nil {
+		t.Fatalf("legacy unique index was dropped by the failed migration: %v", err)
+	}
+	var legacyKey string
+	if err := st.DB().QueryRowContext(ctx, `SELECT mcp_tool_key FROM capset_methods WHERE id = 'legacy-echo.Echo/Call'`).Scan(&legacyKey); err != nil {
+		t.Fatal(err)
+	}
+	if legacyKey != "dev:echo-instance"+string(rune(31))+"shared_tool" {
+		t.Fatalf("failed migration rewrote instance-scoped key to %q", legacyKey)
+	}
 }
 
 func TestAddCapsetMethodEnforcesToolNameUniquenessWithinCapset(t *testing.T) {

--- a/internal/store/mcp_tool_name_test.go
+++ b/internal/store/mcp_tool_name_test.go
@@ -42,6 +42,70 @@ func TestMigrateReportsExistingMCPToolConflicts(t *testing.T) {
 	}
 }
 
+func TestMigrateReportsCrossInstanceConflictsWithLegacyIndex(t *testing.T) {
+	// Simulate a database created by an older release: the mcp_tool_key column
+	// holds instance-scoped keys (capset_instance_id || sep || name), and
+	// uq_capset_methods_mcp_tool_key is the legacy instance-scoped unique
+	// index, so the same tool name can legitimately exist on two instances of
+	// one capset. Upgrading to capset-scoped keys must surface the friendly
+	// conflict error, not the raw UNIQUE constraint failure from the stale
+	// index.
+	st, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	if err := st.UpsertService(ctx, domain.Service{ID: "echo", Name: "Echo"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "echo-instance", ServiceID: "echo", Name: "Echo", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "echo-copy", ServiceID: "echo", Name: "Echo Copy", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.CreateCapset(ctx, domain.Capset{ID: "dev", Name: "Dev", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	for _, instanceID := range []string{"echo-instance", "echo-copy"} {
+		if err := st.AddCapsetInstance(ctx, domain.CapsetInstance{ID: "dev:" + instanceID, CapsetID: "dev", ServiceID: "echo", InstanceID: instanceID, Enabled: true}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Rebuild the state an old database would have before this release runs.
+	if _, err := st.DB().ExecContext(ctx, `DROP INDEX uq_capset_methods_mcp_tool_key`); err != nil {
+		t.Fatal(err)
+	}
+	for i, method := range []string{"echo.Echo/Call", "echo.Echo/Other"} {
+		instanceID := "echo-instance"
+		if i == 1 {
+			instanceID = "echo-copy"
+		}
+		if _, err := st.DB().ExecContext(ctx, `INSERT INTO capset_methods (id, capset_instance_id, method_full_name, mcp_tool_name, mcp_tool_key, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`, "legacy-"+method, "dev:"+instanceID, method, "shared_tool", "dev:"+instanceID+string(rune(31))+"shared_tool", "", ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := st.DB().ExecContext(ctx, `CREATE UNIQUE INDEX uq_capset_methods_mcp_tool_key ON capset_methods(mcp_tool_key) WHERE mcp_tool_key <> ''`); err != nil {
+		t.Fatal(err)
+	}
+
+	err = st.Migrate(ctx)
+	if err == nil {
+		t.Fatal("migration succeeded with conflicting MCP tool names")
+	}
+	if strings.Contains(err.Error(), "UNIQUE") && !strings.Contains(err.Error(), "conflicting methods") {
+		t.Fatalf("migration surfaced the raw UNIQUE error instead of the friendly conflict: %v", err)
+	}
+	if !strings.Contains(err.Error(), "conflicting methods") || !strings.Contains(err.Error(), `"shared_tool"`) || !strings.Contains(err.Error(), `"dev"`) {
+		t.Fatalf("migration conflict error should name tool and capset: %v", err)
+	}
+	if strings.Contains(err.Error(), string(rune(31))) {
+		t.Fatalf("migration conflict error leaks the internal key separator: %v", err)
+	}
+}
+
 func TestAddCapsetMethodEnforcesToolNameUniquenessWithinCapset(t *testing.T) {
 	st, err := Open(":memory:")
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -116,10 +116,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if err := addColumnIfMissing(ctx, s.db, "capset_methods", "mcp_tool_key", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		return err
 	}
-	if _, err := s.db.ExecContext(ctx, `UPDATE capset_methods SET mcp_tool_key = (
-		SELECT ci.capset_id || char(31) || capset_methods.mcp_tool_name
-		FROM capset_instances ci WHERE ci.id = capset_methods.capset_instance_id
-	) WHERE mcp_tool_name <> '' AND mcp_tool_key = ''`); err != nil {
+	if _, err := s.db.ExecContext(ctx, `UPDATE capset_methods SET mcp_tool_key = capset_instance_id || char(31) || mcp_tool_name WHERE mcp_tool_name <> '' AND mcp_tool_key = ''`); err != nil {
 		return err
 	}
 	if _, err := s.db.ExecContext(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS uq_capset_methods_mcp_tool_key ON capset_methods(mcp_tool_key) WHERE mcp_tool_key <> ''`); err != nil {
@@ -807,11 +804,7 @@ func (s *Store) AddCapsetMethod(ctx context.Context, method domain.CapsetMethod)
 
 	toolKey := ""
 	if method.MCPToolName != "" {
-		var capsetID string
-		if err := tx.QueryRowContext(ctx, `SELECT capset_id FROM capset_instances WHERE id = ?`, method.CapsetInstanceID).Scan(&capsetID); err != nil {
-			return err
-		}
-		toolKey = capsetID + mcpToolKeySeparator + method.MCPToolName
+		toolKey = method.CapsetInstanceID + mcpToolKeySeparator + method.MCPToolName
 	}
 	_, err = tx.ExecContext(ctx, `INSERT INTO capset_methods (id, capset_instance_id, method_full_name, rest_alias, mcp_tool_name, mcp_tool_key, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, method.ID, method.CapsetInstanceID, method.MethodFullName, method.RestAlias, method.MCPToolName, toolKey, boolInt(method.Enabled), formatTime(method.CreatedAt), formatTime(method.UpdatedAt))
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -116,8 +116,20 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if err := addColumnIfMissing(ctx, s.db, "capset_methods", "mcp_tool_key", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		return err
 	}
-	if _, err := s.db.ExecContext(ctx, `UPDATE capset_methods SET mcp_tool_key = capset_instance_id || char(31) || mcp_tool_name WHERE mcp_tool_name <> '' AND mcp_tool_key = ''`); err != nil {
+	if _, err := s.db.ExecContext(ctx, `UPDATE capset_methods SET mcp_tool_key = (
+		SELECT ci.capset_id || char(31) || capset_methods.mcp_tool_name
+		FROM capset_instances ci
+		WHERE ci.id = capset_methods.capset_instance_id
+	)
+	WHERE mcp_tool_name <> ''`); err != nil {
 		return err
+	}
+	var duplicateKey string
+	var duplicateCount int
+	if err := s.db.QueryRowContext(ctx, `SELECT mcp_tool_key, COUNT(*) FROM capset_methods WHERE mcp_tool_key <> '' GROUP BY mcp_tool_key HAVING COUNT(*) > 1 LIMIT 1`).Scan(&duplicateKey, &duplicateCount); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	} else if err == nil {
+		return fmt.Errorf("MCP tool name %q has %d conflicting methods; remove or rename duplicates before restarting", duplicateKey, duplicateCount)
 	}
 	if _, err := s.db.ExecContext(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS uq_capset_methods_mcp_tool_key ON capset_methods(mcp_tool_key) WHERE mcp_tool_key <> ''`); err != nil {
 		return err
@@ -804,12 +816,23 @@ func (s *Store) AddCapsetMethod(ctx context.Context, method domain.CapsetMethod)
 
 	toolKey := ""
 	if method.MCPToolName != "" {
-		toolKey = method.CapsetInstanceID + mcpToolKeySeparator + method.MCPToolName
+		var capsetID string
+		if err := tx.QueryRowContext(ctx, `SELECT capset_id FROM capset_instances WHERE id = ?`, method.CapsetInstanceID).Scan(&capsetID); err != nil {
+			return err
+		}
+		toolKey = capsetID + mcpToolKeySeparator + method.MCPToolName
 	}
 	_, err = tx.ExecContext(ctx, `INSERT INTO capset_methods (id, capset_instance_id, method_full_name, rest_alias, mcp_tool_name, mcp_tool_key, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, method.ID, method.CapsetInstanceID, method.MethodFullName, method.RestAlias, method.MCPToolName, toolKey, boolInt(method.Enabled), formatTime(method.CreatedAt), formatTime(method.UpdatedAt))
 	if err != nil {
-		if strings.Contains(strings.ToUpper(err.Error()), "UNIQUE") && strings.Contains(err.Error(), "mcp_tool_key") {
-			return ErrMCPToolNameConflict
+		var existingID string
+		if idErr := tx.QueryRowContext(ctx, `SELECT id FROM capset_methods WHERE id = ?`, method.ID).Scan(&existingID); idErr == nil {
+			return err
+		}
+		if toolKey != "" {
+			var existingToolID string
+			if keyErr := tx.QueryRowContext(ctx, `SELECT id FROM capset_methods WHERE mcp_tool_key = ?`, toolKey).Scan(&existingToolID); keyErr == nil {
+				return ErrMCPToolNameConflict
+			}
 		}
 		return err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -22,6 +22,10 @@ type Store struct {
 	db *sql.DB
 }
 
+var ErrMCPToolNameConflict = errors.New("MCP tool name conflict")
+
+const mcpToolKeySeparator = "\x1f"
+
 type ServiceInUseError struct {
 	ServiceID  string
 	InstanceID string
@@ -107,6 +111,18 @@ func (s *Store) Migrate(ctx context.Context) error {
 		return err
 	}
 	if err := addColumnIfMissing(ctx, s.db, "services", "service_root", "TEXT NOT NULL DEFAULT '.'"); err != nil {
+		return err
+	}
+	if err := addColumnIfMissing(ctx, s.db, "capset_methods", "mcp_tool_key", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE capset_methods SET mcp_tool_key = (
+		SELECT ci.capset_id || char(31) || capset_methods.mcp_tool_name
+		FROM capset_instances ci WHERE ci.id = capset_methods.capset_instance_id
+	) WHERE mcp_tool_name <> '' AND mcp_tool_key = ''`); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS uq_capset_methods_mcp_tool_key ON capset_methods(mcp_tool_key) WHERE mcp_tool_key <> ''`); err != nil {
 		return err
 	}
 	_, err := s.db.ExecContext(ctx, `UPDATE services SET runtime_mode = 'long-running' WHERE runtime_mode = ''`)
@@ -782,8 +798,29 @@ func (s *Store) AddCapsetMethod(ctx context.Context, method domain.CapsetMethod)
 	now := time.Now().UTC()
 	method.CreatedAt = now
 	method.UpdatedAt = now
-	_, err := s.db.ExecContext(ctx, `INSERT INTO capset_methods (id, capset_instance_id, method_full_name, rest_alias, mcp_tool_name, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, method.ID, method.CapsetInstanceID, method.MethodFullName, method.RestAlias, method.MCPToolName, boolInt(method.Enabled), formatTime(method.CreatedAt), formatTime(method.UpdatedAt))
-	return err
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	toolKey := ""
+	if method.MCPToolName != "" {
+		var capsetID string
+		if err := tx.QueryRowContext(ctx, `SELECT capset_id FROM capset_instances WHERE id = ?`, method.CapsetInstanceID).Scan(&capsetID); err != nil {
+			return err
+		}
+		toolKey = capsetID + mcpToolKeySeparator + method.MCPToolName
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO capset_methods (id, capset_instance_id, method_full_name, rest_alias, mcp_tool_name, mcp_tool_key, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, method.ID, method.CapsetInstanceID, method.MethodFullName, method.RestAlias, method.MCPToolName, toolKey, boolInt(method.Enabled), formatTime(method.CreatedAt), formatTime(method.UpdatedAt))
+	if err != nil {
+		if strings.Contains(strings.ToUpper(err.Error()), "UNIQUE") && strings.Contains(err.Error(), "mcp_tool_key") {
+			return ErrMCPToolNameConflict
+		}
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *Store) GetCapsetMethod(ctx context.Context, capsetInstanceID, methodFullName string) (domain.CapsetMethod, error) {
@@ -1257,6 +1294,7 @@ CREATE TABLE IF NOT EXISTS capset_methods (
   method_full_name TEXT NOT NULL,
   rest_alias TEXT NOT NULL DEFAULT '',
   mcp_tool_name TEXT NOT NULL DEFAULT '',
+  mcp_tool_key TEXT NOT NULL DEFAULT '',
   enabled INTEGER NOT NULL DEFAULT 1,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -118,11 +118,28 @@ func (s *Store) Migrate(ctx context.Context) error {
 	}
 	// Older releases keyed mcp_tool_key per instance (capset_instance_id ||
 	// separator || name) and created uq_capset_methods_mcp_tool_key on that
-	// instance-scoped key. That index must be dropped before the backfill
-	// below rewrites rows to capset-scoped keys; otherwise the UPDATE violates
-	// the stale unique index on the second duplicate row and aborts before the
-	// friendly conflict check can run. The capset-scoped index is recreated
-	// after the conflict check passes.
+	// instance-scoped key. Before touching schema or data, detect the target
+	// capset-scoped collisions read-only through a JOIN: if one exists, fail
+	// here while the legacy index and instance-scoped keys are still intact, so
+	// the database can be rolled back losslessly and still guards against
+	// duplicate mcp_tool_key writes. Only when no collision exists do we drop
+	// the stale index, rewrite rows to capset-scoped keys, and recreate the
+	// capset-scoped unique index.
+	var duplicateKey string
+	var duplicateCount int
+	preflightErr := s.db.QueryRowContext(ctx, `SELECT ci.capset_id || char(31) || cm.mcp_tool_name AS new_key, COUNT(*)
+		FROM capset_methods cm
+		JOIN capset_instances ci ON ci.id = cm.capset_instance_id
+		WHERE cm.mcp_tool_name <> ''
+		GROUP BY new_key
+		HAVING COUNT(*) > 1
+		LIMIT 1`).Scan(&duplicateKey, &duplicateCount)
+	if preflightErr != nil && !errors.Is(preflightErr, sql.ErrNoRows) {
+		return preflightErr
+	}
+	if preflightErr == nil {
+		return mcpToolNameConflictError(duplicateKey, duplicateCount)
+	}
 	if _, err := s.db.ExecContext(ctx, `DROP INDEX IF EXISTS uq_capset_methods_mcp_tool_key`); err != nil {
 		return err
 	}
@@ -134,23 +151,29 @@ func (s *Store) Migrate(ctx context.Context) error {
 	WHERE mcp_tool_name <> ''`); err != nil {
 		return err
 	}
-	var duplicateKey string
-	var duplicateCount int
+	// Second line of defense: the preflight query above and this GROUP BY run
+	// over the same join, so a collision cannot appear in between; keep the
+	// check anyway so a logic regression in the preflight cannot silently
+	// recreate the index over duplicate keys.
 	if err := s.db.QueryRowContext(ctx, `SELECT mcp_tool_key, COUNT(*) FROM capset_methods WHERE mcp_tool_key <> '' GROUP BY mcp_tool_key HAVING COUNT(*) > 1 LIMIT 1`).Scan(&duplicateKey, &duplicateCount); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
 	} else if err == nil {
-		capsetID := ""
-		toolName := duplicateKey
-		if before, after, found := strings.Cut(duplicateKey, mcpToolKeySeparator); found {
-			capsetID, toolName = before, after
-		}
-		return fmt.Errorf("MCP tool name %q has %d conflicting methods in capset %q; remove or rename duplicates before restarting", toolName, duplicateCount, capsetID)
+		return mcpToolNameConflictError(duplicateKey, duplicateCount)
 	}
 	if _, err := s.db.ExecContext(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS uq_capset_methods_mcp_tool_key ON capset_methods(mcp_tool_key) WHERE mcp_tool_key <> ''`); err != nil {
 		return err
 	}
 	_, err := s.db.ExecContext(ctx, `UPDATE services SET runtime_mode = 'long-running' WHERE runtime_mode = ''`)
 	return err
+}
+
+func mcpToolNameConflictError(duplicateKey string, duplicateCount int) error {
+	capsetID := ""
+	toolName := duplicateKey
+	if before, after, found := strings.Cut(duplicateKey, mcpToolKeySeparator); found {
+		capsetID, toolName = before, after
+	}
+	return fmt.Errorf("MCP tool name %q has %d conflicting methods in capset %q; remove or rename duplicates before restarting", toolName, duplicateCount, capsetID)
 }
 
 func addColumnIfMissing(ctx context.Context, db *sql.DB, table, column, definition string) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -116,6 +116,16 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if err := addColumnIfMissing(ctx, s.db, "capset_methods", "mcp_tool_key", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		return err
 	}
+	// Older releases keyed mcp_tool_key per instance (capset_instance_id ||
+	// separator || name) and created uq_capset_methods_mcp_tool_key on that
+	// instance-scoped key. That index must be dropped before the backfill
+	// below rewrites rows to capset-scoped keys; otherwise the UPDATE violates
+	// the stale unique index on the second duplicate row and aborts before the
+	// friendly conflict check can run. The capset-scoped index is recreated
+	// after the conflict check passes.
+	if _, err := s.db.ExecContext(ctx, `DROP INDEX IF EXISTS uq_capset_methods_mcp_tool_key`); err != nil {
+		return err
+	}
 	if _, err := s.db.ExecContext(ctx, `UPDATE capset_methods SET mcp_tool_key = (
 		SELECT ci.capset_id || char(31) || capset_methods.mcp_tool_name
 		FROM capset_instances ci
@@ -129,7 +139,12 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if err := s.db.QueryRowContext(ctx, `SELECT mcp_tool_key, COUNT(*) FROM capset_methods WHERE mcp_tool_key <> '' GROUP BY mcp_tool_key HAVING COUNT(*) > 1 LIMIT 1`).Scan(&duplicateKey, &duplicateCount); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
 	} else if err == nil {
-		return fmt.Errorf("MCP tool name %q has %d conflicting methods; remove or rename duplicates before restarting", duplicateKey, duplicateCount)
+		capsetID := ""
+		toolName := duplicateKey
+		if before, after, found := strings.Cut(duplicateKey, mcpToolKeySeparator); found {
+			capsetID, toolName = before, after
+		}
+		return fmt.Errorf("MCP tool name %q has %d conflicting methods in capset %q; remove or rename duplicates before restarting", toolName, duplicateCount, capsetID)
 	}
 	if _, err := s.db.ExecContext(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS uq_capset_methods_mcp_tool_key ON capset_methods(mcp_tool_key) WHERE mcp_tool_key <> ''`); err != nil {
 		return err

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -935,14 +935,14 @@ func TestFindToolAmbiguousAndStreamingCustomNames(t *testing.T) {
 	if err := s.AddCapsetInstance(ctx, domain.CapsetInstance{ID: "dev:echo-copy", CapsetID: "dev", ServiceID: "echo", InstanceID: "echo-copy", IncludeAllMethods: false, Enabled: true}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.AddCapsetMethod(ctx, domain.CapsetMethod{CapsetInstanceID: "dev:echo-copy", MethodFullName: "echo.v1.EchoService/Echo", MCPToolName: "echo_tool", Enabled: true}); err != nil {
-		t.Fatal(err)
+	if err := s.AddCapsetMethod(ctx, domain.CapsetMethod{CapsetInstanceID: "dev:echo-copy", MethodFullName: "echo.v1.EchoService/Echo", MCPToolName: "echo_tool", Enabled: true}); !errors.Is(err, ErrMCPToolNameConflict) {
+		t.Fatalf("expected duplicate MCP tool error, got %v", err)
 	}
-	if _, err := s.FindTool(ctx, "dev", "echo_tool"); err == nil || !strings.Contains(err.Error(), "ambiguous MCP tool name") {
-		t.Fatalf("expected ambiguous MCP tool error, got %v", err)
+	if _, err := s.FindTool(ctx, "dev", "echo_tool"); err != nil {
+		t.Fatalf("FindTool existing unique name error = %v", err)
 	}
-	if exists, err := s.MCPToolNameExists(ctx, "dev", "echo_tool"); err == nil || !strings.Contains(err.Error(), "ambiguous MCP tool name") || exists {
-		t.Fatalf("MCPToolNameExists ambiguous exists=%v err=%v", exists, err)
+	if exists, err := s.MCPToolNameExists(ctx, "dev", "echo_tool"); err != nil || !exists {
+		t.Fatalf("MCPToolNameExists exists=%v err=%v", exists, err)
 	}
 
 	if err := s.AddCapsetMethod(ctx, domain.CapsetMethod{CapsetInstanceID: "dev:echo-copy", MethodFullName: "echo.v1.EchoService/ServerStream", MCPToolName: "stream_custom", Enabled: true}); err != nil {


### PR DESCRIPTION
## 问题
同一 Capset Instance 内，MCP Tool 名称先查询再插入，检查和写入不是原子操作；数据库没有最终唯一约束。并发请求可能为同一实例写入相同名称。

## 影响
同一实例内出现重复名称会导致工具列表重复，调用路由不确定。不同实例在同一 Capset 中使用相同名称仍保留为明确的歧义状态，由现有路由逻辑返回歧义错误，不静默选择实例。

## 修复内容
- 为 `capset_methods` 增加按 `capset_instance_id + mcp_tool_name` 计算的唯一 key。
- 数据库唯一索引提供并发安全约束，同时保留跨实例重名的既有歧义检测语义。
- `AddCapsetMethod` 在插入时生成 key，并将唯一冲突转换为明确错误。
- Admin API 将并发名称冲突返回 `409 Conflict`。
- 启动迁移会为已有记录回填 key。
- 增加同一实例拒绝重复名称、不同实例保留歧义的测试。

## 验证
- `go test ./internal/store` 通过。
