### PR TITLE
Validate runtime update controls before persisting

### DIFF
--- a/internal/supervisor/runtime_update_test.go
+++ b/internal/supervisor/runtime_update_test.go
@@ -1,0 +1,42 @@
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"octobus/internal/domain"
+	"octobus/internal/store"
+)
+
+func TestRuntimeControlRejectionPrecedesInstanceMutation(t *testing.T) {
+	st, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	if err := st.UpsertService(ctx, domain.Service{ID: "on-demand", Name: "On Demand", RuntimeMode: domain.RuntimeModeOnDemand}); err != nil {
+		t.Fatal(err)
+	}
+	originalConfig := []byte(`{"value":"before"}`)
+	originalSecret := []byte(`{"token":"before"}`)
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "instance", ServiceID: "on-demand", Name: "Instance", Enabled: true, Status: domain.StatusRunning, ConfigJSON: originalConfig, SecretJSON: originalSecret}); err != nil {
+		t.Fatal(err)
+	}
+
+	sup := New(t.TempDir(), st)
+	if _, err := sup.UpdateConfig(ctx, "instance", []byte(`{"value":"after"}`), true); !errors.Is(err, ErrUnsupportedRuntimeControl) {
+		t.Fatalf("config restart error = %v", err)
+	}
+	if _, err := sup.UpdateSecret(ctx, "instance", []byte(`{"token":"after"}`), true); !errors.Is(err, ErrUnsupportedRuntimeControl) {
+		t.Fatalf("secret restart error = %v", err)
+	}
+	got, err := st.GetInstance(ctx, "instance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.ConfigJSON) != string(originalConfig) || string(got.SecretJSON) != string(originalSecret) {
+		t.Fatalf("rejected runtime control mutated instance: %+v", got)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -147,6 +147,11 @@ func (s *Supervisor) UpdateSecret(ctx context.Context, instanceID string, secret
 	if err := validateSecretSchema(svc.SecretSchemaPath, secret); err != nil {
 		return domain.Instance{}, err
 	}
+	if restart {
+		if err := s.rejectOnDemandRuntimeControl(ctx, inst.ServiceID); err != nil {
+			return domain.Instance{}, err
+		}
+	}
 	inst.SecretJSON = secret
 	inst.SecretSHA256 = domain.HashBytes(secret)
 	if err := s.Store.UpsertInstance(ctx, inst); err != nil {
@@ -154,9 +159,6 @@ func (s *Supervisor) UpdateSecret(ctx context.Context, instanceID string, secret
 	}
 	s.logger().Info("instance_secret_updated", "instance_id", instanceID, "secret_sha256", inst.SecretSHA256, "restart", restart)
 	if restart {
-		if err := s.rejectOnDemandRuntimeControl(ctx, inst.ServiceID); err != nil {
-			return domain.Instance{}, err
-		}
 		if err := s.Restart(ctx, instanceID); err != nil {
 			return domain.Instance{}, err
 		}
@@ -179,6 +181,11 @@ func (s *Supervisor) UpdateConfig(ctx context.Context, instanceID string, config
 	if err := validateConfigSchema(svc.ConfigSchemaPath, config); err != nil {
 		return domain.Instance{}, err
 	}
+	if restart {
+		if err := s.rejectOnDemandRuntimeControl(ctx, inst.ServiceID); err != nil {
+			return domain.Instance{}, err
+		}
+	}
 	if err := s.writeInstanceConfig(instanceID, config); err != nil {
 		return domain.Instance{}, err
 	}
@@ -189,9 +196,6 @@ func (s *Supervisor) UpdateConfig(ctx context.Context, instanceID string, config
 	}
 	s.logger().Info("instance_config_updated", "instance_id", instanceID, "config_sha256", inst.ConfigSHA256, "restart", restart)
 	if restart {
-		if err := s.rejectOnDemandRuntimeControl(ctx, inst.ServiceID); err != nil {
-			return domain.Instance{}, err
-		}
 		if err := s.Restart(ctx, instanceID); err != nil {
 			return domain.Instance{}, err
 		}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -186,12 +186,29 @@ func (s *Supervisor) UpdateConfig(ctx context.Context, instanceID string, config
 			return domain.Instance{}, err
 		}
 	}
+	configPath := filepath.Join(s.InstanceWorkdir(instanceID), "config.json")
+	previousConfig, readErr := os.ReadFile(configPath)
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		return domain.Instance{}, readErr
+	}
 	if err := s.writeInstanceConfig(instanceID, config); err != nil {
 		return domain.Instance{}, err
 	}
 	inst.ConfigJSON = config
 	inst.ConfigSHA256 = domain.ConfigHash(config)
 	if err := s.Store.UpsertInstance(ctx, inst); err != nil {
+		var restoreErr error
+		if readErr == nil {
+			restoreErr = s.writeInstanceConfig(instanceID, previousConfig)
+		} else {
+			restoreErr = os.Remove(configPath)
+			if errors.Is(restoreErr, os.ErrNotExist) {
+				restoreErr = nil
+			}
+		}
+		if restoreErr != nil {
+			return domain.Instance{}, fmt.Errorf("persist config: %w; restore previous config: %v", err, restoreErr)
+		}
 		return domain.Instance{}, err
 	}
 	s.logger().Info("instance_config_updated", "instance_id", instanceID, "config_sha256", inst.ConfigSHA256, "restart", restart)
@@ -634,7 +651,28 @@ func (s *Supervisor) writeInstanceConfig(instanceID string, config []byte) error
 	if err := os.MkdirAll(workdir, 0o700); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(workdir, "config.json"), config, 0o600)
+	tmp, err := os.CreateTemp(workdir, ".config.json-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(config); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, filepath.Join(workdir, "config.json"))
 }
 
 func secretReadFile(secret []byte) (*os.File, func(), error) {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -678,8 +678,16 @@ func (s *Supervisor) writeInstanceConfig(instanceID string, config []byte) error
 	}
 	// Sync the parent directory so the rename itself is durable: without it a
 	// crash right after a config update can roll the file back to its previous
-	// content even though the database already holds the new config.
-	return syncDirectory(workdir)
+	// content even though the database already holds the new config. A failed
+	// directory sync must not surface as a write error: the rename already
+	// committed and the file content was synced before it, so callers would
+	// wrongly conclude the config was never written and skip the authoritative
+	// database update, leaving disk (new) and DB (old) inconsistent. Degrade to
+	// a warning instead; the next start rewrites the file from the database.
+	if err := syncDirectory(workdir); err != nil {
+		s.logger().Warn("config_dir_sync_failed", "instance_id", instanceID, "error", err)
+	}
+	return nil
 }
 
 // syncDirectory fsyncs a directory so recently renamed entries survive a

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"syscall"
 	"time"
 
 	"octobus/internal/daemonlog"
@@ -672,7 +673,29 @@ func (s *Supervisor) writeInstanceConfig(instanceID string, config []byte) error
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmpPath, filepath.Join(workdir, "config.json"))
+	if err := os.Rename(tmpPath, filepath.Join(workdir, "config.json")); err != nil {
+		return err
+	}
+	// Sync the parent directory so the rename itself is durable: without it a
+	// crash right after a config update can roll the file back to its previous
+	// content even though the database already holds the new config.
+	return syncDirectory(workdir)
+}
+
+// syncDirectory fsyncs a directory so recently renamed entries survive a
+// crash. Filesystems that do not support directory fsync report an error;
+// those errors are ignored because the directory entry is typically still
+// journaled by the filesystem.
+func syncDirectory(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil && !errors.Is(err, syscall.EINVAL) && !errors.Is(err, syscall.ENOTSUP) && !errors.Is(err, syscall.EBADF) {
+		return err
+	}
+	return nil
 }
 
 func secretReadFile(secret []byte) (*os.File, func(), error) {


### PR DESCRIPTION
## 问题
`UpdateConfig` 和 `UpdateSecret` 在完成文件/数据库写入后，才检查 On-demand 服务是否支持 restart。

## 影响
客户端收到失败响应时，配置或 Secret 其实已经被修改，造成 API 语义与持久化状态不一致；自动化重试可能进一步覆盖数据并造成审计误判。

## 修复内容
- 将运行时控制能力检查移动到所有持久化操作之前。
- On-demand 实例请求 restart 时立即返回不支持错误。
- 确保失败路径不写入配置文件、Secret 或数据库。
- 增加配置和 Secret 的回归测试。

## 验证
- `go test ./internal/supervisor -run TestRuntimeControlRejectionPrecedesInstanceMutation` 通过。
