### PR TITLE
Encrypt instance secrets at rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,10 @@ node bin/service.js call --data-json '{"id":"123"}'
 
 The SDK also reads the same variable from `.env` in the current working directory. It reads only that key and does not inject other `.env` variables. This variable does not affect the daemon's `--runtime serve` or `--runtime invoke` protocol. When the daemon manages instances, it continues to pass config/secret through files and file descriptors.
 
+## Secret storage
+
+Instance secrets are encrypted at rest with AES-256-GCM. Production deployments should provide `OCTOBUS_SECRET_ENCRYPTION_KEY` through a KMS/Vault-managed environment or provide `OCTOBUS_SECRET_ENCRYPTION_KEY_FILE` pointing to a separately protected 32-byte key file. If neither is configured, OctoBus creates `<database>.secret-key` with mode `0600`; this local fallback protects the database from casual inspection but does not protect against an attacker who can copy the entire data directory. Losing or changing the key is intentionally treated as a startup error when encrypted secrets exist.
+
 ## Development
 
 ### Architecture

--- a/internal/store/secret_crypto.go
+++ b/internal/store/secret_crypto.go
@@ -19,6 +19,7 @@ import (
 const (
 	encryptedSecretPrefix = "octobus-secret-v1:"
 	secretKeyEnv          = "OCTOBUS_SECRET_ENCRYPTION_KEY"
+	secretKeyFileEnv      = "OCTOBUS_SECRET_ENCRYPTION_KEY_FILE"
 	secretKeyBytes        = 32
 )
 
@@ -34,7 +35,10 @@ func loadSecretKey(dbPath string, hasEncryptedSecrets func() (bool, error)) ([]b
 		return randomSecretKey()
 	}
 
-	keyPath := dbPath + ".secret-key"
+	keyPath := os.Getenv(secretKeyFileEnv)
+	if keyPath == "" {
+		keyPath = dbPath + ".secret-key"
+	}
 	key, err := readSecretKeyFile(keyPath)
 	if err == nil {
 		return key, nil

--- a/internal/store/secret_crypto.go
+++ b/internal/store/secret_crypto.go
@@ -5,11 +5,15 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"database/sql"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
+	"time"
 )
 
 const (
@@ -18,7 +22,7 @@ const (
 	secretKeyBytes        = 32
 )
 
-func loadSecretKey(dbPath string) ([]byte, error) {
+func loadSecretKey(dbPath string, hasEncryptedSecrets func() (bool, error)) ([]byte, error) {
 	if encoded := os.Getenv(secretKeyEnv); encoded != "" {
 		key, err := base64.StdEncoding.DecodeString(encoded)
 		if err != nil || len(key) != secretKeyBytes {
@@ -31,43 +35,111 @@ func loadSecretKey(dbPath string) ([]byte, error) {
 	}
 
 	keyPath := dbPath + ".secret-key"
-	key, err := os.ReadFile(keyPath)
+	key, err := readSecretKeyFile(keyPath)
 	if err == nil {
-		if len(key) != secretKeyBytes {
-			return nil, fmt.Errorf("secret key file %q has invalid length", keyPath)
-		}
 		return key, nil
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
+	if hasEncryptedSecrets != nil {
+		encrypted, checkErr := hasEncryptedSecrets()
+		if checkErr != nil {
+			return nil, checkErr
+		}
+		if encrypted {
+			return nil, fmt.Errorf("secret key file %q is missing while encrypted instance secrets exist", keyPath)
+		}
+	}
 	key, err = randomSecretKey()
 	if err != nil {
 		return nil, err
 	}
-	file, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err == nil {
-		if _, writeErr := file.Write(key); writeErr != nil {
-			_ = file.Close()
-			_ = os.Remove(keyPath)
-			return nil, writeErr
-		}
-		if closeErr := file.Close(); closeErr != nil {
-			return nil, closeErr
-		}
+	if err := writeSecretKeyAtomically(keyPath, key); err == nil {
 		return key, nil
-	}
-	if !errors.Is(err, os.ErrExist) {
+	} else if !errors.Is(err, os.ErrExist) {
 		return nil, err
 	}
-	key, err = os.ReadFile(keyPath)
+	for attempt := 0; attempt < 5; attempt++ {
+		key, err = readSecretKeyFile(keyPath)
+		if err == nil {
+			return key, nil
+		}
+		if !errors.Is(err, errInvalidSecretKeyLength) {
+			return nil, err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("read secret key file %q: %w", keyPath, errInvalidSecretKeyLength)
+}
+
+var errInvalidSecretKeyLength = errors.New("secret key has invalid length")
+
+func readSecretKeyFile(path string) ([]byte, error) {
+	key, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 	if len(key) != secretKeyBytes {
-		return nil, fmt.Errorf("secret key file %q has invalid length", keyPath)
+		return nil, fmt.Errorf("%w: %q", errInvalidSecretKeyLength, path)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return nil, err
 	}
 	return key, nil
+}
+
+func writeSecretKeyAtomically(path string, key []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".secret-key-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(key); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Link(tmpPath, path); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Store) validateSecretKey(ctx context.Context) error {
+	var encoded string
+	err := s.db.QueryRowContext(ctx, `SELECT secret_json FROM instances WHERE substr(secret_json, 1, ?) = ? LIMIT 1`, len(encryptedSecretPrefix), encryptedSecretPrefix).Scan(&encoded)
+	if errors.Is(err, sql.ErrNoRows) || strings.Contains(errString(err), "no such table") {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if _, err := decryptSecret(s.secretKey, encoded); err != nil {
+		return fmt.Errorf("secret encryption key does not decrypt stored instance secrets: %w", err)
+	}
+	return nil
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 func randomSecretKey() ([]byte, error) {

--- a/internal/store/secret_crypto.go
+++ b/internal/store/secret_crypto.go
@@ -1,0 +1,164 @@
+package store
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	encryptedSecretPrefix = "octobus-secret-v1:"
+	secretKeyEnv          = "OCTOBUS_SECRET_ENCRYPTION_KEY"
+	secretKeyBytes        = 32
+)
+
+func loadSecretKey(dbPath string) ([]byte, error) {
+	if encoded := os.Getenv(secretKeyEnv); encoded != "" {
+		key, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil || len(key) != secretKeyBytes {
+			return nil, fmt.Errorf("%s must be base64-encoded %d-byte key", secretKeyEnv, secretKeyBytes)
+		}
+		return key, nil
+	}
+	if dbPath == ":memory:" {
+		return randomSecretKey()
+	}
+
+	keyPath := dbPath + ".secret-key"
+	key, err := os.ReadFile(keyPath)
+	if err == nil {
+		if len(key) != secretKeyBytes {
+			return nil, fmt.Errorf("secret key file %q has invalid length", keyPath)
+		}
+		return key, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	key, err = randomSecretKey()
+	if err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err == nil {
+		if _, writeErr := file.Write(key); writeErr != nil {
+			_ = file.Close()
+			_ = os.Remove(keyPath)
+			return nil, writeErr
+		}
+		if closeErr := file.Close(); closeErr != nil {
+			return nil, closeErr
+		}
+		return key, nil
+	}
+	if !errors.Is(err, os.ErrExist) {
+		return nil, err
+	}
+	key, err = os.ReadFile(keyPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(key) != secretKeyBytes {
+		return nil, fmt.Errorf("secret key file %q has invalid length", keyPath)
+	}
+	return key, nil
+}
+
+func randomSecretKey() ([]byte, error) {
+	key := make([]byte, secretKeyBytes)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func encryptSecret(key, plaintext []byte) (string, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+	return encryptedSecretPrefix + base64.RawStdEncoding.EncodeToString(ciphertext), nil
+}
+
+func decryptSecret(key []byte, encoded string) ([]byte, error) {
+	if len(encoded) < len(encryptedSecretPrefix) || encoded[:len(encryptedSecretPrefix)] != encryptedSecretPrefix {
+		return []byte(encoded), nil
+	}
+	payload, err := base64.RawStdEncoding.DecodeString(encoded[len(encryptedSecretPrefix):])
+	if err != nil {
+		return nil, fmt.Errorf("decode encrypted instance secret: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	if len(payload) < gcm.NonceSize() {
+		return nil, errors.New("encrypted instance secret is truncated")
+	}
+	return gcm.Open(nil, payload[:gcm.NonceSize()], payload[gcm.NonceSize():], nil)
+}
+
+func (s *Store) encryptLegacySecrets(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, secret_json FROM instances WHERE secret_json <> '' AND substr(secret_json, 1, ?) <> ?`, len(encryptedSecretPrefix), encryptedSecretPrefix)
+	if err != nil {
+		return err
+	}
+	type legacySecret struct {
+		id   string
+		data string
+	}
+	var legacy []legacySecret
+	for rows.Next() {
+		var item legacySecret
+		if err := rows.Scan(&item.id, &item.data); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		legacy = append(legacy, item)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if len(legacy) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, item := range legacy {
+		encrypted, err := encryptSecret(s.secretKey, []byte(item.data))
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE instances SET secret_json = ? WHERE id = ?`, encrypted, item.id); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}

--- a/internal/store/secret_crypto.go
+++ b/internal/store/secret_crypto.go
@@ -46,6 +46,10 @@ func loadSecretKey(dbPath string, hasEncryptedSecrets func() (bool, error)) ([]b
 	if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
+	explicitKeyFile := os.Getenv(secretKeyFileEnv) != ""
+	if explicitKeyFile {
+		return nil, fmt.Errorf("secret key file %q from %s does not exist", keyPath, secretKeyFileEnv)
+	}
 	if hasEncryptedSecrets != nil {
 		encrypted, checkErr := hasEncryptedSecrets()
 		if checkErr != nil {

--- a/internal/store/secret_crypto_test.go
+++ b/internal/store/secret_crypto_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -44,6 +45,31 @@ func TestInstanceSecretsAreEncryptedAtRestAndReadableAcrossReopen(t *testing.T) 
 	}
 	if string(got.SecretJSON) != string(plain) {
 		t.Fatalf("decrypted secret = %s", got.SecretJSON)
+	}
+}
+
+func TestOpenFailsWhenSecretKeyIsMissingForEncryptedData(t *testing.T) {
+	t.Setenv(secretKeyEnv, "")
+	dbPath := t.TempDir() + "/octobus.db"
+	ctx := context.Background()
+	st, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertService(ctx, domain.Service{ID: "secret-service", Name: "Secret Service"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "secret-instance", ServiceID: "secret-service", Name: "Instance", SecretJSON: []byte(`{"token":"value"}`)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(dbPath + ".secret-key"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Open(dbPath); err == nil || !strings.Contains(err.Error(), "encrypted instance secrets exist") {
+		t.Fatalf("missing secret key error = %v", err)
 	}
 }
 

--- a/internal/store/secret_crypto_test.go
+++ b/internal/store/secret_crypto_test.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"octobus/internal/domain"
+)
+
+func TestInstanceSecretsAreEncryptedAtRestAndReadableAcrossReopen(t *testing.T) {
+	dbPath := t.TempDir() + "/octobus.db"
+	ctx := context.Background()
+	st, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertService(ctx, domain.Service{ID: "secret-service", Name: "Secret Service"}); err != nil {
+		t.Fatal(err)
+	}
+	plain := []byte(`{"apiToken":"do-not-store-plaintext"}`)
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "secret-instance", ServiceID: "secret-service", Name: "Instance", SecretJSON: plain}); err != nil {
+		t.Fatal(err)
+	}
+	var stored string
+	if err := st.DB().QueryRowContext(ctx, `SELECT secret_json FROM instances WHERE id = ?`, "secret-instance").Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stored, "do-not-store-plaintext") || !strings.HasPrefix(stored, encryptedSecretPrefix) {
+		t.Fatalf("secret at rest is not encrypted: %q", stored)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err = Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	got, err := st.GetInstance(ctx, "secret-instance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.SecretJSON) != string(plain) {
+		t.Fatalf("decrypted secret = %s", got.SecretJSON)
+	}
+}
+
+func TestLegacyInstanceSecretsAreEncryptedDuringMigration(t *testing.T) {
+	dbPath := t.TempDir() + "/octobus.db"
+	ctx := context.Background()
+	st, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertService(ctx, domain.Service{ID: "legacy-service", Name: "Legacy Service"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertInstance(ctx, domain.Instance{ID: "legacy-instance", ServiceID: "legacy-service", Name: "Instance", SecretJSON: []byte(`{}`)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `UPDATE instances SET secret_json = ? WHERE id = ?`, `{"legacy":"secret"}`, "legacy-instance"); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err = Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	var stored string
+	if err := st.DB().QueryRowContext(ctx, `SELECT secret_json FROM instances WHERE id = ?`, "legacy-instance").Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stored, "legacy") || !strings.HasPrefix(stored, encryptedSecretPrefix) {
+		t.Fatalf("legacy secret was not migrated: %q", stored)
+	}
+	got, err := st.GetInstance(ctx, "legacy-instance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.SecretJSON) != `{"legacy":"secret"}` {
+		t.Fatalf("migrated secret = %s", got.SecretJSON)
+	}
+}

--- a/internal/store/secret_crypto_test.go
+++ b/internal/store/secret_crypto_test.go
@@ -73,6 +73,19 @@ func TestOpenFailsWhenSecretKeyIsMissingForEncryptedData(t *testing.T) {
 	}
 }
 
+func TestExplicitKeyFileMissingFailsInsteadOfGenerating(t *testing.T) {
+	t.Setenv(secretKeyEnv, "")
+	missing := t.TempDir() + "/keys/missing.key"
+	t.Setenv(secretKeyFileEnv, missing)
+	dbPath := t.TempDir() + "/octobus.db"
+	if _, err := Open(dbPath); err == nil || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("explicit missing key file error = %v", err)
+	}
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Fatalf("explicit key file must not be auto-created, stat error = %v", err)
+	}
+}
+
 func TestLegacyInstanceSecretsAreEncryptedDuringMigration(t *testing.T) {
 	dbPath := t.TempDir() + "/octobus.db"
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -46,10 +46,6 @@ func Open(path string) (*Store, error) {
 			return nil, err
 		}
 	}
-	secretKey, err := loadSecretKey(path)
-	if err != nil {
-		return nil, err
-	}
 	dbPath := path
 	if path != ":memory:" {
 		dbPath = "file:" + filepath.ToSlash(path)
@@ -68,7 +64,23 @@ func Open(path string) (*Store, error) {
 		_ = db.Close()
 		return nil, err
 	}
+	secretKey, err := loadSecretKey(path, func() (bool, error) {
+		var encrypted int
+		err := db.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM instances WHERE substr(secret_json, 1, ?) = ?)`, len(encryptedSecretPrefix), encryptedSecretPrefix).Scan(&encrypted)
+		if err != nil && strings.Contains(err.Error(), "no such table") {
+			return false, nil
+		}
+		return encrypted == 1, err
+	})
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	s := &Store{db: db, secretKey: secretKey}
+	if err := s.validateSecretKey(context.Background()); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	if err := s.Migrate(context.Background()); err != nil {
 		_ = db.Close()
 		return nil, err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,7 +19,8 @@ import (
 )
 
 type Store struct {
-	db *sql.DB
+	db        *sql.DB
+	secretKey []byte
 }
 
 type ServiceInUseError struct {
@@ -45,6 +46,10 @@ func Open(path string) (*Store, error) {
 			return nil, err
 		}
 	}
+	secretKey, err := loadSecretKey(path)
+	if err != nil {
+		return nil, err
+	}
 	dbPath := path
 	if path != ":memory:" {
 		dbPath = "file:" + filepath.ToSlash(path)
@@ -63,7 +68,7 @@ func Open(path string) (*Store, error) {
 		_ = db.Close()
 		return nil, err
 	}
-	s := &Store{db: db}
+	s := &Store{db: db, secretKey: secretKey}
 	if err := s.Migrate(context.Background()); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -107,6 +112,9 @@ func (s *Store) Migrate(ctx context.Context) error {
 		return err
 	}
 	if err := addColumnIfMissing(ctx, s.db, "services", "service_root", "TEXT NOT NULL DEFAULT '.'"); err != nil {
+		return err
+	}
+	if err := s.encryptLegacySecrets(ctx); err != nil {
 		return err
 	}
 	_, err := s.db.ExecContext(ctx, `UPDATE services SET runtime_mode = 'long-running' WHERE runtime_mode = ''`)
@@ -301,11 +309,15 @@ func (s *Store) UpsertInstance(ctx context.Context, inst domain.Instance) error 
 	if inst.SecretSHA256 == "" {
 		inst.SecretSHA256 = domain.HashBytes(inst.SecretJSON)
 	}
+	encryptedSecret, err := encryptSecret(s.secretKey, inst.SecretJSON)
+	if err != nil {
+		return err
+	}
 	var pid any
 	if inst.PID != nil {
 		pid = *inst.PID
 	}
-	_, err := s.db.ExecContext(ctx, `
+	_, err = s.db.ExecContext(ctx, `
 INSERT INTO instances (id, service_id, name, enabled, status, pid, listen_addr, node_entry, config_json, config_sha256, secret_json, secret_sha256, created_at, updated_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
@@ -320,16 +332,28 @@ ON CONFLICT(id) DO UPDATE SET
   config_sha256=excluded.config_sha256,
   secret_json=excluded.secret_json,
   secret_sha256=excluded.secret_sha256,
-  updated_at=excluded.updated_at`, inst.ID, inst.ServiceID, inst.Name, boolInt(inst.Enabled), string(inst.Status), pid, inst.ListenAddr, inst.NodeEntry, string(inst.ConfigJSON), inst.ConfigSHA256, string(inst.SecretJSON), inst.SecretSHA256, formatTime(inst.CreatedAt), formatTime(inst.UpdatedAt))
+  updated_at=excluded.updated_at`, inst.ID, inst.ServiceID, inst.Name, boolInt(inst.Enabled), string(inst.Status), pid, inst.ListenAddr, inst.NodeEntry, string(inst.ConfigJSON), inst.ConfigSHA256, encryptedSecret, inst.SecretSHA256, formatTime(inst.CreatedAt), formatTime(inst.UpdatedAt))
 	return err
 }
 
 func (s *Store) GetInstance(ctx context.Context, id string) (domain.Instance, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT id, service_id, name, enabled, status, pid, listen_addr, node_entry, config_json, config_sha256, secret_json, secret_sha256, created_at, updated_at FROM instances WHERE id = ?`, id)
-	return scanInstance(row)
+	return s.scanInstance(row)
 }
 
 func scanInstance(scanner interface {
+	Scan(dest ...any) error
+}) (domain.Instance, error) {
+	return scanInstanceWithKey(nil, scanner)
+}
+
+func (s *Store) scanInstance(scanner interface {
+	Scan(dest ...any) error
+}) (domain.Instance, error) {
+	return scanInstanceWithKey(s.secretKey, scanner)
+}
+
+func scanInstanceWithKey(secretKey []byte, scanner interface {
 	Scan(dest ...any) error
 }) (domain.Instance, error) {
 	var inst domain.Instance
@@ -346,7 +370,11 @@ func scanInstance(scanner interface {
 		inst.PID = &p
 	}
 	inst.ConfigJSON = json.RawMessage(config)
-	inst.SecretJSON = json.RawMessage(secret)
+	decryptedSecret, err := decryptSecret(secretKey, secret)
+	if err != nil {
+		return domain.Instance{}, err
+	}
+	inst.SecretJSON = json.RawMessage(decryptedSecret)
 	inst.CreatedAt = parseTime(created)
 	inst.UpdatedAt = parseTime(updated)
 	return inst, nil
@@ -360,7 +388,7 @@ func (s *Store) ListInstances(ctx context.Context) ([]domain.Instance, error) {
 	defer rows.Close()
 	var out []domain.Instance
 	for rows.Next() {
-		inst, err := scanInstance(rows)
+		inst, err := s.scanInstance(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -377,7 +405,7 @@ func (s *Store) ListEnabledInstancesByService(ctx context.Context, serviceID str
 	defer rows.Close()
 	var out []domain.Instance
 	for rows.Next() {
-		inst, err := scanInstance(rows)
+		inst, err := s.scanInstance(rows)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## 问题
实例 Secret 直接写入 SQLite 的 `secret_json` 字段，仅依赖数据库文件权限保护。

## 影响
数据库备份、WAL、快照、磁盘镜像或容器挂载目录泄露时，API Key、密码和其他凭证可以被直接恢复。

## 修复内容
- 使用 AES-256-GCM 加密实例 Secret，密文存储在原有数据库字段中。
- 默认在数据库旁生成权限为 `0600` 的密钥文件；生产环境可通过 `OCTOBUS_SECRET_ENCRYPTION_KEY` 提供 base64 编码的 32 字节密钥。
- Store 读取时解密，业务层保持原有 `SecretJSON` 接口不变。
- 启动迁移会自动加密历史明文 Secret。
- 使用随机 nonce，并验证认证标签，防止篡改后的密文被接受。
- 增加跨重启读取和历史明文迁移测试。

## 验证
- `go test ./internal/store ./internal/supervisor` 通过。
