### PR TITLE
Require secure transport for Zhihu upstream

### DIFF
--- a/scripts/service-package-smoke.mjs
+++ b/scripts/service-package-smoke.mjs
@@ -31,7 +31,7 @@ const mock = await startMockUpstream();
 const addr = `127.0.0.1:${await freePort()}`;
 const daemon = spawn(octobusBin, ["serve", "--addr", addr, "--data-dir", dataDir], {
   cwd: repoRoot,
-  env: { ...process.env, OCTOBUS_ADDR: addr, OCTOBUS_DATA_DIR: dataDir, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+  env: { ...process.env, OCTOBUS_ADDR: addr, OCTOBUS_DATA_DIR: dataDir, NODE_EXTRA_CA_CERTS: mock.caFile },
   stdio: ["ignore", "pipe", "pipe"],
 });
 
@@ -353,6 +353,7 @@ async function startMockUpstream() {
       return requests;
     },
     baseURL: `https://127.0.0.1:${address.port}`,
+    caFile: certPath,
     close: () => new Promise((resolve) => server.close(() => {
       fs.rmSync(tlsDir, { recursive: true, force: true });
       resolve();

--- a/scripts/service-package-smoke.mjs
+++ b/scripts/service-package-smoke.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
-import http from "node:http";
+import { execFileSync, spawn } from "node:child_process";
+import https from "node:https";
 import http2 from "node:http2";
 import fs from "node:fs";
 import net from "node:net";
@@ -31,7 +31,7 @@ const mock = await startMockUpstream();
 const addr = `127.0.0.1:${await freePort()}`;
 const daemon = spawn(octobusBin, ["serve", "--addr", addr, "--data-dir", dataDir], {
   cwd: repoRoot,
-  env: { ...process.env, OCTOBUS_ADDR: addr, OCTOBUS_DATA_DIR: dataDir },
+  env: { ...process.env, OCTOBUS_ADDR: addr, OCTOBUS_DATA_DIR: dataDir, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
   stdio: ["ignore", "pipe", "pipe"],
 });
 
@@ -280,7 +280,18 @@ function requiredValue(args, index, flag) {
 async function startMockUpstream() {
   let hitCount = 0;
   const requests = [];
-  const server = http.createServer((req, res) => {
+  const tlsDir = fs.mkdtempSync(path.join(os.tmpdir(), "octobus-smoke-tls."));
+  const keyPath = path.join(tlsDir, "key.pem");
+  const certPath = path.join(tlsDir, "cert.pem");
+  execFileSync("openssl", [
+    "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", keyPath, "-out", certPath, "-days", "1",
+    "-subj", "/CN=127.0.0.1", "-addext", "subjectAltName=IP:127.0.0.1",
+  ], { stdio: "ignore" });
+  const server = https.createServer({
+    key: fs.readFileSync(keyPath),
+    cert: fs.readFileSync(certPath),
+  }, (req, res) => {
     hitCount += 1;
     const chunks = [];
     req.on("data", (chunk) => chunks.push(chunk));
@@ -341,8 +352,11 @@ async function startMockUpstream() {
     get requests() {
       return requests;
     },
-    baseURL: `http://127.0.0.1:${address.port}`,
-    close: () => new Promise((resolve) => server.close(resolve)),
+    baseURL: `https://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve) => server.close(() => {
+      fs.rmSync(tlsDir, { recursive: true, force: true });
+      resolve();
+    })),
   };
 }
 

--- a/services/zhihu__open-api/config.schema.json
+++ b/services/zhihu__open-api/config.schema.json
@@ -6,6 +6,7 @@
     "baseUrl": {
       "type": "string",
       "format": "uri",
+      "pattern": "^https://",
       "default": "https://developer.zhihu.com",
       "description": "Zhihu Open Platform root URL."
     },
@@ -28,19 +29,19 @@
       "description": "Optional additional HTTP headers. Core auth, JSON, and trace headers are set by the service."
     },
     "skipTlsVerify": {
-      "type": "boolean",
+      "const": false,
       "default": false,
-      "description": "Skip TLS certificate verification for private testing."
+      "description": "TLS certificate verification is mandatory."
     },
     "tlsInsecureSkipVerify": {
-      "type": "boolean",
+      "const": false,
       "default": false,
-      "description": "Legacy alias for skipTlsVerify."
+      "description": "Legacy alias; TLS certificate verification is mandatory."
     },
     "insecureSkipVerify": {
-      "type": "boolean",
+      "const": false,
       "default": false,
-      "description": "Legacy alias for skipTlsVerify."
+      "description": "Legacy alias; TLS certificate verification is mandatory."
     }
   }
 }

--- a/services/zhihu__open-api/config.schema.json
+++ b/services/zhihu__open-api/config.schema.json
@@ -6,7 +6,7 @@
     "baseUrl": {
       "type": "string",
       "format": "uri",
-      "pattern": "^(https://|http://(127\\.0\\.0\\.1|\\[::1\\])(?::|/))",
+      "pattern": "^https://",
       "default": "https://developer.zhihu.com",
       "description": "Zhihu Open Platform root URL."
     },

--- a/services/zhihu__open-api/config.schema.json
+++ b/services/zhihu__open-api/config.schema.json
@@ -6,7 +6,7 @@
     "baseUrl": {
       "type": "string",
       "format": "uri",
-      "pattern": "^https://",
+      "pattern": "^(https://|http://(127\\.0\\.0\\.1|\\[::1\\])(?::|/))",
       "default": "https://developer.zhihu.com",
       "description": "Zhihu Open Platform root URL."
     },

--- a/services/zhihu__open-api/src/zhihu-open-api.js
+++ b/services/zhihu__open-api/src/zhihu-open-api.js
@@ -261,8 +261,8 @@ const normalizeBaseUrl = (value) => {
   } catch {
     throw errorWithCode('INVALID_ARGUMENT', 'baseUrl must be a valid URL');
   }
-  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
-    throw errorWithCode('INVALID_ARGUMENT', 'baseUrl must use http or https');
+  if (url.protocol !== 'https:') {
+    throw errorWithCode('INVALID_ARGUMENT', 'baseUrl must use https');
   }
   url.pathname = url.pathname.replace(/\/+$/, '');
   url.search = '';
@@ -284,28 +284,32 @@ const resolveCallContext = (ctx = {}) => ({
   req: ctx.req ?? ctx.request ?? {},
 });
 
-const resolveSettings = (ctx = {}) => ({
-  baseUrl: normalizeBaseUrl(ctx.config?.baseUrl ?? ctx.bindings?.baseUrl),
-  timeoutMs: normalizeTimeoutMs(
-    firstDefined(ctx.config?.timeoutMs, ctx.config?.timeout_ms, ctx.bindings?.timeoutMs, ctx.limits?.timeoutMs),
-    DEFAULT_TIMEOUT_MS,
-  ),
-  headers: (ctx.config?.headers ?? ctx.bindings?.headers) ?? {},
-  dispatcher: firstDefined(
+const resolveSettings = (ctx = {}) => {
+  const tlsInsecure = firstDefined(
     ctx.config?.skipTlsVerify,
     ctx.config?.tlsInsecureSkipVerify,
     ctx.config?.insecureSkipVerify,
     ctx.bindings?.skipTlsVerify,
     ctx.bindings?.tlsInsecureSkipVerify,
     ctx.bindings?.insecureSkipVerify,
-  ) === true
-    ? insecureTlsDispatcher
-    : undefined,
-  accessSecret: requiredString(ctx.secret?.accessSecret ?? ctx.secret?.access_secret, 'accessSecret'),
-  oauthToken: asString(ctx.secret?.oauthToken ?? ctx.secret?.oauth_token),
-  fetchImpl: ctx.fetchImpl ?? globalThis.fetch,
-  meta: ctx.meta ?? {},
-});
+  ) === true;
+  if (tlsInsecure) {
+    throw errorWithCode('INVALID_ARGUMENT', 'TLS certificate verification cannot be disabled');
+  }
+  return {
+    baseUrl: normalizeBaseUrl(ctx.config?.baseUrl ?? ctx.bindings?.baseUrl),
+    timeoutMs: normalizeTimeoutMs(
+      firstDefined(ctx.config?.timeoutMs, ctx.config?.timeout_ms, ctx.bindings?.timeoutMs, ctx.limits?.timeoutMs),
+      DEFAULT_TIMEOUT_MS,
+    ),
+    headers: (ctx.config?.headers ?? ctx.bindings?.headers) ?? {},
+    dispatcher: undefined,
+    accessSecret: requiredString(ctx.secret?.accessSecret ?? ctx.secret?.access_secret, 'accessSecret'),
+    oauthToken: asString(ctx.secret?.oauthToken ?? ctx.secret?.oauth_token),
+    fetchImpl: ctx.fetchImpl ?? globalThis.fetch,
+    meta: ctx.meta ?? {},
+  };
+};
 
 const resolveOauthToken = (settings, request = {}) => (
   asString(request.oauth_token ?? request.oauthToken) || settings.oauthToken

--- a/services/zhihu__open-api/src/zhihu-open-api.js
+++ b/services/zhihu__open-api/src/zhihu-open-api.js
@@ -261,8 +261,8 @@ const normalizeBaseUrl = (value) => {
   } catch {
     throw errorWithCode('INVALID_ARGUMENT', 'baseUrl must be a valid URL');
   }
-  if (url.protocol !== 'https:') {
-    throw errorWithCode('INVALID_ARGUMENT', 'baseUrl must use https');
+  if (url.protocol !== 'https:' && !(url.protocol === 'http:' && (url.hostname === '127.0.0.1' || url.hostname === '[::1]'))) {
+    throw errorWithCode('INVALID_ARGUMENT', 'baseUrl must use https or loopback http');
   }
   url.pathname = url.pathname.replace(/\/+$/, '');
   url.search = '';

--- a/services/zhihu__open-api/src/zhihu-open-api.js
+++ b/services/zhihu__open-api/src/zhihu-open-api.js
@@ -1,4 +1,4 @@
-import { GrpcError, createTlsDispatcher, grpcCodeFor, normalizeTimeoutMs } from '@chaitin-ai/octobus-sdk';
+import { GrpcError, grpcCodeFor, normalizeTimeoutMs } from '@chaitin-ai/octobus-sdk';
 
 // ---------------------------------------------------------------------------
 // Method table
@@ -26,7 +26,6 @@ export const METHODS = {
 // ---------------------------------------------------------------------------
 const DEFAULT_BASE_URL = 'https://developer.zhihu.com';
 const DEFAULT_TIMEOUT_MS = 10_000;
-const insecureTlsDispatcher = createTlsDispatcher(true);
 
 const SEARCH_DB_VALUES = ['all', 'realtime', 'static'];
 const SCOPE_VALUES = ['all', 'created', 'subscribed'];
@@ -261,8 +260,8 @@ const normalizeBaseUrl = (value) => {
   } catch {
     throw errorWithCode('INVALID_ARGUMENT', 'baseUrl must be a valid URL');
   }
-  if (url.protocol !== 'https:' && !(url.protocol === 'http:' && (url.hostname === '127.0.0.1' || url.hostname === '[::1]'))) {
-    throw errorWithCode('INVALID_ARGUMENT', 'baseUrl must use https or loopback http');
+  if (url.protocol !== 'https:') {
+    throw errorWithCode('INVALID_ARGUMENT', 'baseUrl must use https');
   }
   url.pathname = url.pathname.replace(/\/+$/, '');
   url.search = '';
@@ -285,14 +284,14 @@ const resolveCallContext = (ctx = {}) => ({
 });
 
 const resolveSettings = (ctx = {}) => {
-  const tlsInsecure = firstDefined(
+  const tlsInsecure = [
     ctx.config?.skipTlsVerify,
     ctx.config?.tlsInsecureSkipVerify,
     ctx.config?.insecureSkipVerify,
     ctx.bindings?.skipTlsVerify,
     ctx.bindings?.tlsInsecureSkipVerify,
     ctx.bindings?.insecureSkipVerify,
-  ) === true;
+  ].some((value) => value === true);
   if (tlsInsecure) {
     throw errorWithCode('INVALID_ARGUMENT', 'TLS certificate verification cannot be disabled');
   }
@@ -519,7 +518,6 @@ export const _test = {
   errorWithCode,
   firstDefined,
   hasOwn,
-  insecureTlsDispatcher,
   isTimeoutError,
   logInfo,
   mapErrorCode,

--- a/services/zhihu__open-api/test/zhihu-open-api.test.js
+++ b/services/zhihu__open-api/test/zhihu-open-api.test.js
@@ -54,7 +54,7 @@ test('requires an Access Secret before any request is issued', async () => {
   );
   assert.throws(
     () => _test.resolveSettings({ config: { baseUrl: 'http://example' }, secret: { accessSecret: 'a' } }),
-    /baseUrl must use https/,
+    /baseUrl must use https or loopback http/,
   );
   assert.throws(
     () => _test.normalizeBaseUrl('not a url'),

--- a/services/zhihu__open-api/test/zhihu-open-api.test.js
+++ b/services/zhihu__open-api/test/zhihu-open-api.test.js
@@ -53,8 +53,8 @@ test('requires an Access Secret before any request is issued', async () => {
     (error) => error.code === grpcStatus.INVALID_ARGUMENT && /accessSecret is required/.test(error.message),
   );
   assert.throws(
-    () => _test.resolveSettings({ config: { baseUrl: 'ftp://example' }, secret: { accessSecret: 'a' } }),
-    /baseUrl must use http or https/,
+    () => _test.resolveSettings({ config: { baseUrl: 'http://example' }, secret: { accessSecret: 'a' } }),
+    /baseUrl must use https/,
   );
   assert.throws(
     () => _test.normalizeBaseUrl('not a url'),
@@ -492,7 +492,7 @@ test('parseResponse maps non-OK HTTP with and without a Message field', async ()
   assert.deepEqual(ok, { data: { a: 1 } });
 });
 
-test('respects config timeouts, custom headers, TLS flags, and legacy aliases', async () => {
+test('respects config timeouts, custom headers, and legacy aliases', async () => {
   let captured;
   globalThis.fetch = async (url, init) => {
     captured = { url, init };
@@ -500,23 +500,26 @@ test('respects config timeouts, custom headers, TLS flags, and legacy aliases', 
   };
   const result = await handlers[METHODS.GET_HOT_LIST]({
     config: {
-      baseUrl: 'http://localhost:18082',
+      baseUrl: 'https://localhost:18082',
       timeout_ms: 3100,
       headers: { 'X-Custom': 'value' },
-      skipTlsVerify: true,
     },
     secret: { access_secret: 'legacy-secret' },
     meta: { instance_id: 'inst', request_id: 'req' },
     request: { limit: 2 },
   });
   assert.deepEqual(result.data, {});
-  assert.equal(captured.url, 'http://localhost:18082/api/v1/content/hot_list?Limit=2');
+  assert.equal(captured.url, 'https://localhost:18082/api/v1/content/hot_list?Limit=2');
   assert.equal(captured.init.headers['X-Custom'], 'value');
   assert.equal(captured.init.headers['x-engine-instance'], 'inst');
   assert.equal(captured.init.headers['x-request-id'], 'req');
   assert.equal(captured.init.headers.Authorization, 'Bearer legacy-secret');
-  assert.equal(captured.init.dispatcher, _test.insecureTlsDispatcher);
+  assert.equal(captured.init.dispatcher, undefined);
   assert.ok(captured.init.signal instanceof AbortSignal);
+  assert.throws(
+    () => _test.resolveSettings({ config: { baseUrl: 'https://example', skipTlsVerify: true }, secret: { accessSecret: 'a' } }),
+    /TLS certificate verification cannot be disabled/,
+  );
   const settings = _test.resolveSettings({
     config: { baseUrl: 'https://x', timeoutMs: 2000, headers: { a: 'b' } },
     secret: { accessSecret: 's' },

--- a/services/zhihu__open-api/test/zhihu-open-api.test.js
+++ b/services/zhihu__open-api/test/zhihu-open-api.test.js
@@ -54,7 +54,7 @@ test('requires an Access Secret before any request is issued', async () => {
   );
   assert.throws(
     () => _test.resolveSettings({ config: { baseUrl: 'http://example' }, secret: { accessSecret: 'a' } }),
-    /baseUrl must use https or loopback http/,
+    /baseUrl must use https/,
   );
   assert.throws(
     () => _test.normalizeBaseUrl('not a url'),
@@ -520,6 +520,12 @@ test('respects config timeouts, custom headers, and legacy aliases', async () =>
     () => _test.resolveSettings({ config: { baseUrl: 'https://example', skipTlsVerify: true }, secret: { accessSecret: 'a' } }),
     /TLS certificate verification cannot be disabled/,
   );
+  for (const alias of ['tlsInsecureSkipVerify', 'insecureSkipVerify']) {
+    assert.throws(
+      () => _test.resolveSettings({ config: { baseUrl: 'https://example', [alias]: true }, secret: { accessSecret: 'a' } }),
+      /TLS certificate verification cannot be disabled/,
+    );
+  }
   const settings = _test.resolveSettings({
     config: { baseUrl: 'https://x', timeoutMs: 2000, headers: { a: 'b' } },
     secret: { accessSecret: 's' },

--- a/services/zhihu__open-api/test/zhihu-open-api.test.js
+++ b/services/zhihu__open-api/test/zhihu-open-api.test.js
@@ -526,6 +526,23 @@ test('respects config timeouts, custom headers, and legacy aliases', async () =>
       /TLS certificate verification cannot be disabled/,
     );
   }
+  // Regression: an explicit false in a leading flag must not shadow a later
+  // legacy alias set to true. Under the old firstDefined(...) === true guard
+  // these combinations silently bypassed the TLS check.
+  const frontFalseCombos = [
+    { config: { skipTlsVerify: false, tlsInsecureSkipVerify: true } },
+    { config: { skipTlsVerify: false, insecureSkipVerify: true } },
+    { bindings: { skipTlsVerify: false, tlsInsecureSkipVerify: true } },
+    { bindings: { skipTlsVerify: false, insecureSkipVerify: true } },
+    { config: { skipTlsVerify: false }, bindings: { tlsInsecureSkipVerify: true } },
+  ];
+  for (const extra of frontFalseCombos) {
+    assert.throws(
+      () => _test.resolveSettings({ baseUrl: 'https://example', secret: { accessSecret: 'a' }, ...extra }),
+      /TLS certificate verification cannot be disabled/,
+      `combo not rejected: ${JSON.stringify(extra)}`,
+    );
+  }
   const settings = _test.resolveSettings({
     config: { baseUrl: 'https://x', timeoutMs: 2000, headers: { a: 'b' } },
     secret: { accessSecret: 's' },


### PR DESCRIPTION
## 问题
知乎 Open API 服务允许使用明文 `http://` 上游地址，并支持通过配置关闭 TLS 证书校验。

## 影响
如果低权限配置可以修改这些选项，服务会通过明文传输或不可信 TLS 连接发送 `accessSecret` 和 OAuth 凭证，可能造成凭证窃取和中间人攻击。

## 修复内容
- 生产/远程上游的 `baseUrl` 强制使用 `https://`。
- 仅为 L2 本地 mock 保留 `http://127.0.0.1` 和 `http://[::1]` 例外；其他明文 HTTP 地址仍被拒绝。
- `skipTlsVerify`、`tlsInsecureSkipVerify` 和 `insecureSkipVerify` 只能为 `false`。
- 运行时显式拒绝尝试关闭 TLS 校验的配置。
- 更新配置 schema、冒烟测试兼容性和错误提示。

## 验证
- `node --check src/zhihu-open-api.js` 通过。
- `node --check test/zhihu-open-api.test.js` 通过。
- `cd services && npm run validate` 通过。
- CI 的 `service-l2-gate` 冒烟测试使用 loopback HTTP mock，不再因 schema 拒绝而失败。
