### PR TITLE
Forward x-octobus-ext-* metadata on the MCP path

### DIFF
--- a/internal/protocol/gateway.go
+++ b/internal/protocol/gateway.go
@@ -705,7 +705,7 @@ func (g *Gateway) HandleConnectRPC(w http.ResponseWriter, r *http.Request) {
 		connect.NewErrorWriter().Write(recorder, r, connect.NewError(connect.CodeInternal, err))
 		return
 	}
-	ctx := metadata.NewIncomingContext(r.Context(), connectForwardMetadata(r.Header))
+	ctx := metadata.NewIncomingContext(r.Context(), forwardMetadataFromHeaders(r.Header))
 	ctx = context.WithValue(ctx, connectExposedMethodKey{}, item)
 	r = r.WithContext(ctx)
 	r.URL.Path = "/" + item.Method.FullName
@@ -749,6 +749,7 @@ func (g *Gateway) HandleMCP(w http.ResponseWriter, r *http.Request) {
 		writeJSON(recorder, http.StatusUnauthorized, mcpProtocolError(nil, err.Error()))
 		return
 	}
+	r = r.WithContext(metadata.NewIncomingContext(r.Context(), forwardMetadataFromHeaders(r.Header)))
 	r.Body = http.MaxBytesReader(recorder, r.Body, DefaultMaxRequestBytes)
 	var req struct {
 		JSONRPC string          `json:"jsonrpc"`
@@ -1896,11 +1897,11 @@ func isOctobusControlMetadata(key string) bool {
 	return strings.HasPrefix(normalized, "x-octobus-") && !strings.HasPrefix(normalized, "x-octobus-ext-")
 }
 
-func connectForwardMetadata(headers http.Header) metadata.MD {
+func forwardMetadataFromHeaders(headers http.Header) metadata.MD {
 	out := metadata.MD{}
 	for key, vals := range headers {
 		normalized := strings.ToLower(key)
-		if !isAllowedConnectForwardHeader(normalized) {
+		if !isForwardableHeader(normalized) {
 			continue
 		}
 		for _, val := range vals {
@@ -1910,7 +1911,7 @@ func connectForwardMetadata(headers http.Header) metadata.MD {
 	return out
 }
 
-func isAllowedConnectForwardHeader(key string) bool {
+func isForwardableHeader(key string) bool {
 	return key == "x-business-request-id" || strings.HasPrefix(key, "x-octobus-ext-")
 }
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -217,6 +217,19 @@ func TestFullUserFlowInvokesAllProtocolsAndPersistsData(t *testing.T) {
 		t.Fatalf("unexpected MCP text content: %+v", content)
 	}
 
+	var mdCall map[string]any
+	h.mcpWithHeaders(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"calculator__calculator-test__add","arguments":{"left":20,"right":22}}}`, map[string]string{
+		"x-octobus-ext-business-request-id": "req-mcp",
+		"x-octobus-ext-username":            "carol",
+		"x-octobus-capset":                  "wrong",
+		"x-octobus-instance":                "wrong",
+	}, &mdCall)
+	mdResult := mdCall["result"].(map[string]any)["structuredContent"].(map[string]any)
+	if mdResult["businessRequestId"] != "req-mcp" {
+		t.Fatalf("MCP businessRequestId=%v in %+v", mdResult["businessRequestId"], mdResult)
+	}
+	assertBackendMetadata(t, h, "calculator-test", "req-mcp", "carol")
+
 	logs := h.mustCLI("logs", "--capset", "dev", "--instance", "calculator-test", "--service", "calculator", "--limit", "0")
 	assertAccessLogContains(t, logs, map[string]any{
 		"protocol":    "connect",

--- a/tests/e2e/harness_test.go
+++ b/tests/e2e/harness_test.go
@@ -387,7 +387,20 @@ func (h *harness) publicConnectProto(path string, body []byte, want int) []byte 
 
 func (h *harness) mcp(body string, out any) []byte {
 	h.t.Helper()
-	resp, err := h.client.Post("http://"+h.publicAddr+"/capsets/dev/mcp", "application/json", strings.NewReader(body))
+	return h.mcpWithHeaders(body, nil, out)
+}
+
+func (h *harness) mcpWithHeaders(body string, headers map[string]string, out any) []byte {
+	h.t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "http://"+h.publicAddr+"/capsets/dev/mcp", strings.NewReader(body))
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	resp, err := h.client.Do(req)
 	if err != nil {
 		h.t.Fatal(err)
 	}

--- a/tests/e2e/on_demand_test.go
+++ b/tests/e2e/on_demand_test.go
@@ -93,11 +93,20 @@ func TestCalculatorOnDemandExampleInvokesAllProtocols(t *testing.T) {
 	assertBackendMetadata(t, h, "calculator-test", "od-calc-connect", "od-bob")
 
 	var mcpResp map[string]any
-	h.mcp(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"`+mcpAdd.ToolName+`","arguments":{"left":9,"right":3}}}`, &mcpResp)
+	h.mcpWithHeaders(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"`+mcpAdd.ToolName+`","arguments":{"left":9,"right":3}}}`, map[string]string{
+		"x-octobus-ext-business-request-id": "od-calc-mcp",
+		"x-octobus-ext-username":            "od-carol",
+		"x-octobus-capset":                  "wrong",
+		"x-octobus-instance":                "wrong",
+	}, &mcpResp)
 	structured := mcpResp["result"].(map[string]any)["structuredContent"].(map[string]any)
 	if math.Abs(structured["result"].(float64)-12) > 0.000001 || structured["serviceId"] != "calculator-on-demand" || structured["secretToken"] != "runtime-secret" {
 		t.Fatalf("unexpected MCP response: %+v", mcpResp)
 	}
+	if structured["businessRequestId"] != "od-calc-mcp" {
+		t.Fatalf("MCP businessRequestId=%v in %+v", structured["businessRequestId"], structured)
+	}
+	assertBackendMetadata(t, h, "calculator-test", "od-calc-mcp", "od-carol")
 
 	after := h.readDB(`SELECT pid, listen_addr FROM instances WHERE id = ?`, "calculator-test")
 	if after["pid"] != "" || after["listen_addr"] != "" {


### PR DESCRIPTION
## Problem

`HandleMCP` passes the raw HTTP request context to `invokeJSON`, so no gRPC metadata ever reaches the service package. `HandleConnectRPC` converts the allowed headers into incoming metadata via `connectForwardMetadata`, but MCP has no equivalent step.

As a result, `x-octobus-ext-*` and `x-business-request-id` sent to a capset's MCP endpoint are silently dropped. Both routes are affected, since both read from the request context:

- long-running: `invokeRaw` → `stripOctobusMetadata(ctx)` → `conn.Invoke`
- on-demand: `invokeOnDemand` → `stripOctobusMetadata(ctx)` serialized into `metadata.json` for the subprocess

## Fix

Attach the forwarded metadata to the request context right after authorization in `HandleMCP`, mirroring what Connect RPC already does.

`connectForwardMetadata` and `isAllowedConnectForwardHeader` are renamed to `forwardMetadataFromHeaders` and `isForwardableHeader`, since they are no longer Connect-specific. The allowlist itself is unchanged: only `x-business-request-id` and `x-octobus-ext-*` are forwarded, so routing metadata and `Authorization` still never reach the backend.

## Tests

The existing e2e `x-octobus-ext-*` assertions only covered gRPC and Connect, which is why this gap went unnoticed. Added MCP assertions to both `TestFullUserFlowInvokesAllProtocolsAndPersistsData` and `TestCalculatorOnDemandExampleInvokesAllProtocols`, reusing `assertBackendMetadata` so the check reads the metadata the service package actually received.

Both were verified in both directions:

| | long-running | on-demand |
|---|---|---|
| with the fix | pass | pass |
| without the fix | fail | fail (`MCP businessRequestId=<nil>`) |

`gofmt`, `go vet`, `go test ./internal/...` and `go test ./tests/e2e` all run. One pre-existing failure in `internal/cli` (`TestResolveImportSourceTransferModes/auto_local_archive`, a `/var` vs `/private/var` symlink assertion on macOS) reproduces on `main` and is unrelated.