### PR TITLE
fix(wazuh): fall back from empty request credentials

### DIFF
--- a/services/wazuh__siem/src/wazuh-siem.js
+++ b/services/wazuh__siem/src/wazuh-siem.js
@@ -304,8 +304,8 @@ export function rpcdef(ctx) {
   const skipTlsVerify = Boolean(bindings.tlsInsecureSkipVerify || bindings.skipTlsVerify || bindings.skip_tls_verify || bindings.tls_insecure_skip_verify);
 
   const requestWithDefaults = (req = {}) => {
-    const username = firstDefined(req?.username, bindings.username);
-    const password = firstDefined(req?.password, bindings.password);
+    const username = req?.username || bindings.username;
+    const password = req?.password || bindings.password;
     const result = { ...req };
     if (username !== undefined && username !== null) result.username = username;
     if (password !== undefined && password !== null) result.password = password;

--- a/services/wazuh__siem/test/wazuh-siem.test.js
+++ b/services/wazuh__siem/test/wazuh-siem.test.js
@@ -1056,6 +1056,21 @@ test('request-level username/password takes priority for Manager JWT auth', asyn
   assert.equal(decoded, 'override-user:override-pass');
 });
 
+test('empty request credentials fall back to Manager secret', async () => {
+  const { _test } = await import('../src/wazuh-siem.js');
+  _test.clearJwtCache();
+
+  const calls = mockWithAuth('secret-cred-token');
+  const handler = await loadHandler(listAgentsPath, {
+    username: '',
+    password: '',
+  }, defaultManagerSecretCtx);
+  await handler();
+
+  const decoded = Buffer.from(calls.auth[0].init.headers['Authorization'].slice(6), 'base64').toString();
+  assert.equal(decoded, 'wazuh:wazuh');
+});
+
 test('timeoutMs reads from bindings (config) before falling back to limits', async () => {
   const { _test } = await import('../src/wazuh-siem.js');
   // mergedBindings merges config into bindings, so config.timeoutMs takes priority


### PR DESCRIPTION
## Summary

- fall back to instance secrets when proto3 request credentials decode as empty strings
- preserve explicit non-empty request credential overrides
- add a focused regression test for the empty-request path

Closes #506

## Integration and compliance

- Target: Wazuh Manager API 4.x (`POST /security/user/authenticate`, `GET /agents`)
- Interface source: Wazuh public REST API documentation
- Implementation: original change to the existing integration; no new SDK or dependency
- Credentials: users provide the Wazuh username and password through OctoBus instance secrets
- Rate limits / terms: no new requests or changed request frequency
- Risk: `ListAgents` is read-only; no high-risk device operation is added
- Test data: local mock responses only; no real credentials or customer data

## Validation

- `npm test -- --service-dir wazuh__siem` (48 passed)
- `npm run validate -- --service-dir wazuh__siem`
- `npm run pack:check`
- `task all` (lint, unit/integration/e2e tests, smoke tests, static build)
- mutation check: restoring the old fallback makes the new regression test fail

The optional per-service coverage command still reports the repository baseline branch-coverage shortfall (88.35% after this change versus 88.30% before); all 48 tests pass.
