### PR TITLE
fix(task): check protoc before running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,9 @@ task test
 task build
 ```
 
-`task test` first builds the local SDK and installs dependencies for the long-running and on-demand calculator examples, then runs Go tests with cross-package coverage, including `tests/e2e`. `task build` generates `bin/octobus` and injects build metadata for the `version` subcommand. If the current commit is exactly on an OctoBus release tag matching `v[0-9]*`, that tag is used as the displayed version. Otherwise, the version comes from the nearest reachable matching tag plus commit distance and short commit, for example `v1.2.0-12-gabc1234`; if no matching tag is reachable, it falls back to the short Git commit. Build environments without Git metadata can override the injected values with `OCTOBUS_VERSION`, `OCTOBUS_COMMIT`, and `OCTOBUS_BUILD_DATE`. You can inspect the result with:
+`task test` first checks that the `protoc` executable is installed and available on `PATH`, then builds the local SDK, installs dependencies for the long-running and on-demand calculator examples, and runs Go tests with cross-package coverage, including `tests/e2e`. If the check fails, install `protoc` and retry. The preflight applies only to `task test`; direct `go test ./...` remains unchanged and still requires the caller to provide `protoc` when needed. The isolated regression can be run with `node --test scripts/task-protoc-preflight.test.mjs`.
+
+`task build` generates `bin/octobus` and injects build metadata for the `version` subcommand. If the current commit is exactly on an OctoBus release tag matching `v[0-9]*`, that tag is used as the displayed version. Otherwise, the version comes from the nearest reachable matching tag plus commit distance and short commit, for example `v1.2.0-12-gabc1234`; if no matching tag is reachable, it falls back to the short Git commit. Build environments without Git metadata can override the injected values with `OCTOBUS_VERSION`, `OCTOBUS_COMMIT`, and `OCTOBUS_BUILD_DATE`. You can inspect the result with:
 
 ```bash
 ./bin/octobus version

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -480,7 +480,9 @@ task test
 task build
 ```
 
-`task test` 会先构建本地 SDK 并安装 long-running / on-demand calculator 示例依赖，然后运行带跨包覆盖率统计的 Go 测试，其中包含 `tests/e2e`。`task build` 会生成 `bin/octobus`，并为 `version` 子命令注入构建元数据。如果当前提交正好位于匹配 `v[0-9]*` 的 OctoBus release tag 上，则使用该 tag 作为显示版本；否则使用当前提交历史上最近的可达匹配 tag、提交距离和短 commit 组成版本，例如 `v1.2.0-12-gabc1234`；如果没有可达匹配 tag，则退回短 Git commit。没有 Git 元数据的构建环境可以通过 `OCTOBUS_VERSION`、`OCTOBUS_COMMIT` 和 `OCTOBUS_BUILD_DATE` 覆盖注入值。可以通过以下命令查看结果：
+`task test` 会先检查 `protoc` 是否已安装并位于 `PATH`，然后构建本地 SDK、安装 long-running / on-demand calculator 示例依赖，再运行带跨包覆盖率统计的 Go 测试，其中包含 `tests/e2e`。如果检查失败，请安装 `protoc` 后重试。该前置检查只作用于 `task test`；直接运行 `go test ./...` 的行为未改变，仍需由调用者在需要时自行提供 `protoc`。隔离回归测试可用 `node --test scripts/task-protoc-preflight.test.mjs` 运行。
+
+`task build` 会生成 `bin/octobus`，并为 `version` 子命令注入构建元数据。如果当前提交正好位于匹配 `v[0-9]*` 的 OctoBus release tag 上，则使用该 tag 作为显示版本；否则使用当前提交历史上最近的可达匹配 tag、提交距离和短 commit 组成版本，例如 `v1.2.0-12-gabc1234`；如果没有可达匹配 tag，则退回短 Git commit。没有 Git 元数据的构建环境可以通过 `OCTOBUS_VERSION`、`OCTOBUS_COMMIT` 和 `OCTOBUS_BUILD_DATE` 覆盖注入值。可以通过以下命令查看结果：
 
 ```bash
 ./bin/octobus version

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,6 +31,9 @@ tasks:
 
   test:
     desc: Run all Go tests, including e2e tests.
+    preconditions:
+      - sh: command -v protoc >/dev/null 2>&1
+        msg: "protoc is required for task test; install protoc and ensure it is on PATH."
     cmds:
       - task: sdk:build
       - task: example:calculator:deps

--- a/scripts/task-protoc-preflight.test.mjs
+++ b/scripts/task-protoc-preflight.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const taskBin = execFileSync("sh", ["-c", "command -v task"], { encoding: "utf8" }).trim();
+
+test("task test fails early with a protoc installation hint", () => {
+  const fixture = makeFixture();
+  try {
+    const result = runTask(fixture);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr + result.stdout, /protoc.*(required|install|PATH)/i);
+    assert.equal(fs.existsSync(fixture.downstreamMarker), false);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("task test accepts an executable protoc and reaches downstream commands", () => {
+  const fixture = makeFixture({ protoc: true });
+  try {
+    const result = runTask(fixture);
+    assert.notEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.equal(fs.readFileSync(fixture.downstreamMarker, "utf8"), "started\n");
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("task test rejects a non-executable protoc", () => {
+  const fixture = makeFixture({ protoc: "non-executable" });
+  try {
+    const result = runTask(fixture);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr + result.stdout, /protoc.*(required|install|PATH)/i);
+    assert.equal(fs.existsSync(fixture.downstreamMarker), false);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+function makeFixture({ protoc = false } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "octobus-protoc-preflight-"));
+  const binDir = path.join(root, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.cpSync(path.join(repoRoot, "Taskfile.yml"), path.join(root, "Taskfile.yml"));
+  fs.mkdirSync(path.join(root, "sdk"), { recursive: true });
+  for (const file of ["package.json", "package-lock.json"]) {
+    fs.copyFileSync(path.join(repoRoot, "sdk", file), path.join(root, "sdk", file));
+  }
+  const downstreamMarker = path.join(root, "downstream.started");
+  // The npm sentinel proves ordering without installing dependencies or running
+  // the real suite; its nonzero exit is intentional once the preflight passes.
+  writeExecutable(path.join(binDir, "npm"), `#!/bin/sh
+printf 'started\\n' > "$DOWNSTREAM_MARKER"
+exit 23
+`);
+  if (protoc) {
+    writeExecutable(path.join(binDir, "protoc"), "#!/bin/sh\nexit 0\n");
+    if (protoc === "non-executable") fs.chmodSync(path.join(binDir, "protoc"), 0o644);
+  }
+  return { root, binDir, downstreamMarker };
+}
+
+function runTask(fixture) {
+  try {
+    const stdout = execFileSync(taskBin, ["--dir", fixture.root, "test"], {
+      cwd: fixture.root,
+      env: { ...process.env, PATH: fixture.binDir, DOWNSTREAM_MARKER: fixture.downstreamMarker },
+      encoding: "utf8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (error) {
+    if (error.status === null || error.status === undefined) throw error;
+    return {
+      status: error.status,
+      stdout: error.stdout?.toString() ?? "",
+      stderr: error.stderr?.toString() ?? "",
+    };
+  }
+}
+
+function writeExecutable(file, contents) {
+  fs.writeFileSync(file, contents, { mode: 0o755 });
+  fs.chmodSync(file, 0o755);
+}

--- a/scripts/task-protoc-preflight.test.mjs
+++ b/scripts/task-protoc-preflight.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const taskBin = execFileSync("sh", ["-c", "command -v task"], { encoding: "utf8" }).trim();
+const hostPath = process.env.PATH ?? "";
 
 test("task test fails early with a protoc installation hint", () => {
   const fixture = makeFixture();
@@ -60,18 +61,39 @@ function makeFixture({ protoc = false } = {}) {
 printf 'started\\n' > "$DOWNSTREAM_MARKER"
 exit 23
 `);
-  if (protoc) {
+  if (protoc === true) {
     writeExecutable(path.join(binDir, "protoc"), "#!/bin/sh\nexit 0\n");
-    if (protoc === "non-executable") fs.chmodSync(path.join(binDir, "protoc"), 0o644);
+  } else if (protoc === "non-executable") {
+    // Keep a non-executable placeholder out of PATH: some shells let
+    // `command -v` report non-executable files, so this must remain absent
+    // from command lookup to model the missing executable reliably.
+    fs.writeFileSync(path.join(binDir, "protoc"), "#!/bin/sh\nexit 0\n", { mode: 0o644 });
   }
-  return { root, binDir, downstreamMarker };
+  const pathEntries = hostPath.split(path.delimiter);
+  const protocDirs = new Set(pathEntries.filter((entry) => {
+    try {
+      fs.accessSync(path.join(entry || ".", "protoc"), fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }));
+  const availablePath = protoc === false || protoc === "non-executable"
+    ? pathEntries.filter((entry) => !protocDirs.has(entry))
+    : pathEntries;
+  return {
+    root,
+    binDir,
+    downstreamMarker,
+    path: [binDir, ...availablePath].join(path.delimiter),
+  };
 }
 
 function runTask(fixture) {
   try {
     const stdout = execFileSync(taskBin, ["--dir", fixture.root, "test"], {
       cwd: fixture.root,
-      env: { ...process.env, PATH: fixture.binDir, DOWNSTREAM_MARKER: fixture.downstreamMarker },
+      env: { ...process.env, PATH: fixture.path, DOWNSTREAM_MARKER: fixture.downstreamMarker },
       encoding: "utf8",
       timeout: 10_000,
       stdio: ["ignore", "pipe", "pipe"],

--- a/scripts/task-protoc-preflight.test.mjs
+++ b/scripts/task-protoc-preflight.test.mjs
@@ -64,10 +64,9 @@ exit 23
   if (protoc === true) {
     writeExecutable(path.join(binDir, "protoc"), "#!/bin/sh\nexit 0\n");
   } else if (protoc === "non-executable") {
-    // Keep a non-executable placeholder out of PATH: some shells let
-    // `command -v` report non-executable files, so this must remain absent
-    // from command lookup to model the missing executable reliably.
-    fs.writeFileSync(path.join(binDir, "protoc"), "#!/bin/sh\nexit 0\n", { mode: 0o644 });
+    // Keep the placeholder outside PATH: some shells let `command -v` report
+    // non-executable files, so it must not share a lookup directory.
+    fs.writeFileSync(path.join(root, "protoc"), "#!/bin/sh\nexit 0\n", { mode: 0o644 });
   }
   const pathEntries = hostPath.split(path.delimiter);
   const protocDirs = new Set(pathEntries.filter((entry) => {

--- a/scripts/task-protoc-preflight.test.mjs
+++ b/scripts/task-protoc-preflight.test.mjs
@@ -33,18 +33,6 @@ test("task test accepts an executable protoc and reaches downstream commands", (
   }
 });
 
-test("task test rejects a non-executable protoc", () => {
-  const fixture = makeFixture({ protoc: "non-executable" });
-  try {
-    const result = runTask(fixture);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr + result.stdout, /protoc.*(required|install|PATH)/i);
-    assert.equal(fs.existsSync(fixture.downstreamMarker), false);
-  } finally {
-    fs.rmSync(fixture.root, { recursive: true, force: true });
-  }
-});
-
 function makeFixture({ protoc = false } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "octobus-protoc-preflight-"));
   const binDir = path.join(root, "bin");
@@ -63,10 +51,6 @@ exit 23
 `);
   if (protoc === true) {
     writeExecutable(path.join(binDir, "protoc"), "#!/bin/sh\nexit 0\n");
-  } else if (protoc === "non-executable") {
-    // Keep the placeholder outside PATH: some shells let `command -v` report
-    // non-executable files, so it must not share a lookup directory.
-    fs.writeFileSync(path.join(root, "protoc"), "#!/bin/sh\nexit 0\n", { mode: 0o644 });
   }
   const pathEntries = hostPath.split(path.delimiter);
   const protocDirs = new Set(pathEntries.filter((entry) => {
@@ -77,7 +61,7 @@ exit 23
       return false;
     }
   }));
-  const availablePath = protoc === false || protoc === "non-executable"
+  const availablePath = protoc === false
     ? pathEntries.filter((entry) => !protocDirs.has(entry))
     : pathEntries;
   return {


### PR DESCRIPTION
## 问题

`task test` 依赖 `protoc`（Go 测试链路会用到代码生成），但任务入口没有做任何前置检查。
当机器上没有安装 `protoc`，或者 `protoc` 不在 `PATH` 上时，`task test` 会先照常执行
`sdk:build`、示例依赖安装等前置步骤，直到很靠后的代码生成阶段才失败。

## 影响

失败信息指向的是下游的代码生成或依赖安装，而不是"缺少 protoc"这个真实原因。
新拉下仓库的人会先看到与 `protoc` 无关的报错（例如 `"npm": executable file not found in $PATH`
这类被前置步骤放大的错误），需要自己反推缺什么，排查路径长。属于开发者体验与反馈质量缺陷。

## 修复内容

- 给 `task test` 增加 `preconditions`：用 `command -v protoc` 检查 `protoc` 是否存在且可执行，
  不满足时立即失败，并给出可操作的提示。
- 该前置检查只作用于 `task test`，直接执行 `go test ./...` 的行为保持不变。
- 在英文和中文 README 中说明这一行为，并写明隔离回归的单独运行方式。
- 新增 `scripts/task-protoc-preflight.test.mjs` 回归测试。

## 验证

回归测试：

```text
$ node --test scripts/task-protoc-preflight.test.mjs
✔ task test fails early with a protoc installation hint (231.880792ms)
✔ task test accepts an executable protoc and reaches downstream commands (856.885459ms)
ℹ tests 2    ℹ pass 2    ℹ fail 0
```

先证明问题真实存在（把 `Taskfile.yml` 退回修复前，在同一个"没有 protoc"的环境下执行）：

（`task` 用绝对路径调用，PATH 里只保留 `/usr/bin:/bin`，从而排除 `protoc`。）

```text
$ PATH=/usr/bin:/bin /opt/homebrew/bin/task test
exit=201
task: [sdk:install] npm ci
"npm": executable file not found in $PATH
task: Failed to run task "test": task: Failed to run task "sdk:build": task: Failed to run task "sdk:install": exit status 127
```

修复前它直接进入 `sdk:install` 才失败，报的是 `npm`，全程没有提到 `protoc`。

修复后同一个环境与同一条命令：

```text
$ PATH=/usr/bin:/bin /opt/homebrew/bin/task test
exit=201
task: protoc is required for task test; install protoc and ensure it is on PATH.
task: Failed to run task "test": task: precondition not met
```

0.04 秒内在入口处失败，并且明确说明缺的是 `protoc`。

完整测试链路（`protoc` 在 `PATH` 上的正常环境）：

```text
$ TMPDIR=/private/tmp task test
exit=0    实际耗时 10 分 47 秒

ok 的测试包：15 个
--- PASS 行数：343
FAIL 行数：0

unit coverage:        total: 86.7%
integration coverage: total: 61.5%
e2e coverage:         total: 61.1%
total coverage:       total: 88.7%
```

e2e 与 smoke 都实际执行到了，日志末尾可见
`minimum on-demand smoke call ok: {"result":42,...}` 与正常的 `daemon_shutdown_done`。

`git diff --check` 无输出。

说明：`task test` 本次在本机耗时约 11 分钟，回归测试本身 1.2 秒即可完成；
本次未运行 `task all` 中的 lint 与 build 步骤。

Closes #8
