### PR TITLE
docs: document bind mount permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ docker run --rm \
 The container listens on `0.0.0.0:9000` by default and stores daemon state under
 `/var/lib/octobus`.
 
+The image runs as the non-root `octobus` user. The named volume example above
+is already initialized with the correct ownership. If you use a host bind mount,
+create the directory first and make it writable by the container's `octobus`
+user before starting the daemon:
+
+```bash
+mkdir -p ./octobus-data
+# Replace <uid>:<gid> with the values used by the image:
+docker run --rm --entrypoint id ghcr.io/chaitin/octobus:latest -u octobus
+docker run --rm --entrypoint id ghcr.io/chaitin/octobus:latest -g octobus
+sudo chown -R <uid>:<gid> ./octobus-data
+
+docker run --rm \
+  -p 9000:9000 \
+  -v "$PWD/octobus-data:/var/lib/octobus" \
+  ghcr.io/chaitin/octobus:latest
+```
+
 ### Build from a checkout
 
 After the first checkout, build the binary:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,6 +71,23 @@ docker run --rm \
 
 容器默认监听 `0.0.0.0:9000`，daemon 状态保存在 `/var/lib/octobus`。
 
+镜像默认使用非 root 用户 `octobus` 运行。上面的 named volume 示例会自动
+使用正确的目录归属。如果改用宿主机目录 bind mount，请先创建目录，并把
+目录的所有者设置为镜像中的 `octobus` 用户，再启动 daemon：
+
+```bash
+mkdir -p ./octobus-data
+# 将 <uid>:<gid> 替换为镜像中 octobus 用户的实际 UID:GID：
+docker run --rm --entrypoint id ghcr.io/chaitin/octobus:latest -u octobus
+docker run --rm --entrypoint id ghcr.io/chaitin/octobus:latest -g octobus
+sudo chown -R <uid>:<gid> ./octobus-data
+
+docker run --rm \
+  -p 9000:9000 \
+  -v "$PWD/octobus-data:/var/lib/octobus" \
+  ghcr.io/chaitin/octobus:latest
+```
+
 ### 从 checkout 构建
 
 首次 checkout 后先构建 binary：

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,7 +23,19 @@ docker run --rm -p 9000:9000 -v octobus-data:/var/lib/octobus octobus:dev
 ```
 
 When using a host bind mount instead of a named volume, make sure the mounted
-directory is writable by the container user.
+directory is owned by the non-root `octobus` user. The UID and GID are image
+details, so query them from the exact image you are going to run and apply them
+to the host directory:
+
+```bash
+mkdir -p ./octobus-data
+docker run --rm --entrypoint id octobus:dev -u octobus
+docker run --rm --entrypoint id octobus:dev -g octobus
+sudo chown -R <uid>:<gid> ./octobus-data
+docker run --rm -p 9000:9000 \
+  -v "$PWD/octobus-data:/var/lib/octobus" \
+  octobus:dev
+```
 
 The image defaults to:
 


### PR DESCRIPTION
## 问题

`docker/Dockerfile` 中镜像是用 `useradd --system octobus` + `USER octobus`
以非 root 用户运行的，daemon 状态写在 `/var/lib/octobus`，镜像里也声明了
`VOLUME ["/var/lib/octobus"]`。

但 README 和 `docker/README.md` 只有一句 "make sure the mounted directory is writable by
the container user"，没有说明这个用户是谁、UID/GID 是多少、该怎么查，也没有给出
把宿主机目录准备好的命令。

## 影响

按文档把宿主机目录 bind mount 进来的人，如果目录属主不对，容器里的 daemon 会因为无法写
`/var/lib/octobus` 而**直接启动失败**，而报错落在数据库文件上：

```text
time=... level=INFO msg=daemon_starting addr=0.0.0.0:9000 data_dir=/var/lib/octobus
open /var/lib/octobus/octobus.db: permission denied
```

这条信息里没有出现 `octobus` 用户、UID/GID 或 bind mount 字样，很容易被误判成数据库损坏
或镜像问题，而不是宿主机目录属主问题。

使用 named volume 的路径不受影响（named volume 会按容器用户初始化），
所以只有改用手工 bind mount 的人会踩到，属于文档缺失导致的上手阻塞，不是代码缺陷。

## 修复内容

- 在 `README.md`、`README.zh-CN.md`、`docker/README.md` 中说明：镜像以非 root 的
  `octobus` 用户运行，使用 host bind mount 时需要先把目录属主设置为镜像中
  `octobus` 用户的 UID:GID。
- 补上查询 UID/GID 的命令，以及对应的 `chown` 和完整 `docker run` 示例。
- 保留 named volume 作为默认 quick start 选项，并说明它不受该问题影响。

## 验证

### 验证方式

daemon 二进制由构建机交叉编译（`GOOS=linux GOARCH=amd64 CGO_ENABLED=0`，
沿用仓库 `scripts/build-octobus.sh`，产物为静态链接的 37MB ELF），
再用下面这个只复刻 `docker/Dockerfile` 运行时阶段的 Dockerfile 打包。
除二进制改为外部拷入外，基座、用户、目录、环境变量和入口均与仓库文件一致：

```dockerfile
FROM ubuntu:26.04

ENV DEBIAN_FRONTEND=noninteractive \
	OCTOBUS_ADDR=0.0.0.0:9000 \
	OCTOBUS_DATA_DIR=/var/lib/octobus

RUN groupadd --system octobus \
	&& useradd --system --gid octobus --home-dir /var/lib/octobus --create-home --shell /usr/sbin/nologin octobus

COPY octobus /usr/local/bin/octobus

USER octobus
WORKDIR /var/lib/octobus
VOLUME ["/var/lib/octobus"]
EXPOSE 9000

ENTRYPOINT ["octobus"]
CMD ["serve"]
```

执行环境为 Linux 宿主机（Ubuntu 24.04, x86_64, Docker 29.1.3）。

### 1. 镜像身份与文档给出的命令

```text
$ docker run --rm --entrypoint id <image>
uid=999(octobus) gid=999(octobus) groups=999(octobus)

$ docker run --rm --entrypoint id <image> -u octobus
999
$ docker run --rm --entrypoint id <image> -g octobus
999
```

即镜像确实以非 root 运行，文档里那两条查询命令能直接得到要填进 `chown` 的 UID/GID。

### 2. Linux 宿主机上真实 daemon 的启动结果

```text
### bind mount，宿主机目录属主 0:0
容器状态: exited
time=... level=INFO msg=daemon_starting addr=0.0.0.0:9000 data_dir=/var/lib/octobus
open /var/lib/octobus/octobus.db: permission denied

### bind mount，宿主机目录属主 1000:1000
容器状态: exited
time=... level=INFO msg=daemon_starting addr=0.0.0.0:9000 data_dir=/var/lib/octobus
open /var/lib/octobus/octobus.db: permission denied

### 按文档执行 chown -R 999:999 之后，同一个目录
容器状态: running
time=... level=INFO msg=daemon_starting addr=0.0.0.0:9000 data_dir=/var/lib/octobus
time=... level=INFO msg=recover_enabled_started
time=... level=INFO msg=recover_enabled_done count=0
time=... level=INFO msg=startup_inventory capsets=0 instances=0
time=... level=INFO msg=daemon_listening addr=0.0.0.0:9000

### 对照：named volume
容器状态: running
time=... level=INFO msg=daemon_listening addr=0.0.0.0:9000
```

结论：在 Linux 宿主机上，bind mount 目录属主不是 `999:999` 时 daemon 直接启动失败并
以 `permission denied` 收尾；按文档 `chown` 之后同一个目录可以正常启动并监听。
文档描述的正是这个失败形态。

### 3. macOS 上的行为差异（供参考）

```text
$ ls -ldn oc523-data
drwxr-xr-x  2 501  20  oc523-data
$ docker run ... -v "$PWD/oc523-data:/var/lib/octobus" <image>
容器内看到的数据目录属主=999:999
daemon_listening addr=0.0.0.0:9000
```

macOS 的 Docker Desktop 会把 bind mount 的宿主机目录重映射成容器用户，
所以 UID/GID 不匹配这个失败形态在 macOS 上不会复现；该要求实际主要针对 Linux 宿主机。
macOS 上能稳定复现的失败形态是目录不可写（只读挂载返回 `Read-only file system`）。

`git diff --check` 无输出。

说明：

- 官方镜像本次没有拿到：`docker build -f docker/Dockerfile` 在构建机上被
  `ports.ubuntu.com` 反复返回 502 打断（`apt-get install golang-go` 阶段），
  从 `ghcr.io/chaitin/octobus:latest` 拉取又长时间停在 `Pulling fs layer`。
  因此上面的镜像用外部编译好的同一个二进制打包；daemon 本身是仓库当前分支的真实产物。
- 验证只覆盖到 daemon 启动与监听，没有覆盖服务/能力调用的完整业务流程。

Closes #485
